### PR TITLE
Add scaled l2 norm computation

### DIFF
--- a/batched/KokkosBatched_Util.hpp
+++ b/batched/KokkosBatched_Util.hpp
@@ -247,6 +247,24 @@ struct Norm {
   struct ScaledL2 {};
 };
 
+template <class T>
+struct is_norm : std::false_type {};
+
+template <>
+struct is_norm<Norm::L1> : std::true_type {};
+
+template <>
+struct is_norm<Norm::L2> : std::true_type {};
+
+template <>
+struct is_norm<Norm::LInf> : std::true_type {};
+
+template <>
+struct is_norm<Norm::ScaledL2> : std::true_type {};
+
+template <class T>
+constexpr bool is_norm_v = is_norm<T>::value;
+
 /// BatchLayout class used to specify where the batch dimension is
 /// allocated in the input views for host-level Batched BLAS/LAPACK routines.
 struct BatchLayout {

--- a/batched/KokkosBatched_Util.hpp
+++ b/batched/KokkosBatched_Util.hpp
@@ -244,6 +244,7 @@ struct Norm {
   struct L1 {};
   struct L2 {};
   struct LInf {};
+  struct ScaledL2 {};
 };
 
 /// BatchLayout class used to specify where the batch dimension is

--- a/batched/dense/impl/KokkosBatched_Nrm_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Nrm_Impl.hpp
@@ -66,7 +66,6 @@ template <typename XViewType, typename NormViewType>
 KOKKOS_INLINE_FUNCTION int TeamVectorNrm<MemberType, NrmType>::invoke(const MemberType &member, const XViewType &x,
                                                                       const NormViewType &norm) {
   Impl::checkNrmInput(x, norm);
-
   const int n = x.extent_int(0);
   if (n == 0) {
     norm() = KokkosKernels::ArithTraits<typename NormViewType::non_const_value_type>::zero();

--- a/batched/dense/impl/KokkosBatched_Nrm_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Nrm_Internal.hpp
@@ -28,6 +28,96 @@ KOKKOS_INLINE_FUNCTION NrmValueType square(const ValueType &x) {
   }
 }
 
+template <typename NrmValueType, typename ExecutionSpace>
+struct NormAccumulator {
+ public:
+  using value_type = Kokkos::pair<NrmValueType, NrmValueType>;
+  using reducer    = NormAccumulator<NrmValueType, ExecutionSpace>;
+
+ private:
+  value_type &m_accum;  // (scale, sumsq)
+
+ public:
+  KOKKOS_INLINE_FUNCTION NormAccumulator(value_type &val) : m_accum(val) {}
+  KOKKOS_INLINE_FUNCTION
+  void join(value_type &dest, const value_type &src) const {
+    if (src.first == KokkosKernels::ArithTraits<NrmValueType>::zero()) {
+      return;
+    }
+    if (dest.first == KokkosKernels::ArithTraits<NrmValueType>::zero()) {
+      dest = src;
+      return;
+    }
+
+    if (dest.first >= src.first) {
+      auto r = src.first / dest.first;
+      dest.second += src.second * square<NrmValueType>(r);
+    } else {
+      auto r      = dest.first / src.first;
+      dest.second = src.second + dest.second * square<NrmValueType>(r);
+      dest.first  = src.first;
+    }
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  void init(value_type &val) const {
+    val.first  = KokkosKernels::ArithTraits<NrmValueType>::zero();
+    val.second = KokkosKernels::ArithTraits<NrmValueType>::one();
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  value_type &reference() const { return m_accum; }
+};
+
+/// \brief Helper function to compute scaled square for ScaledL2 norm. It updates the scale and sumsq values based on
+/// the input x.
+/// Reference:
+/// dnrm2: https://www.netlib.org/lapack/lapack-3.1.1/html/dnrm2.f.html,
+/// dznrm2: https://www.netlib.org/lapack/lapack-3.1.1/html/dznrm2.f.html
+/// \tparam NrmValueType: Value type for the norm (e.g., double)
+/// \tparam ValueType: Value type for the input (e.g., std::complex<double>)
+/// \param[in] x Input value for which the scaled square is computed
+/// \param[in,out] scale Current scale value, which is updated if the absolute value of x
+/// is greater than the current scale
+/// \param[in,out] sumsq Current sum of squares, which is updated if the absolute
+/// value of x is greater than the current scale
+template <typename NrmValueType, typename ValueType>
+KOKKOS_INLINE_FUNCTION void scaled_square(const ValueType &x, NrmValueType &scale, NrmValueType &sumsq) {
+  if constexpr (KokkosKernels::ArithTraits<ValueType>::is_complex) {
+    using mag_type = typename KokkosKernels::ArithTraits<ValueType>::mag_type;
+    auto x_real    = KokkosKernels::ArithTraits<ValueType>::real(x);
+    if (x_real != KokkosKernels::ArithTraits<mag_type>::zero()) {
+      const NrmValueType abs_val = KokkosKernels::ArithTraits<mag_type>::abs(x_real);
+      if (scale < abs_val) {
+        sumsq = KokkosKernels::ArithTraits<mag_type>::one() + sumsq * square<NrmValueType>(scale / abs_val);
+        scale = abs_val;
+      } else {
+        sumsq += square<NrmValueType>(abs_val / scale);
+      }
+    }
+    auto x_imag = KokkosKernels::ArithTraits<ValueType>::imag(x);
+    if (x_imag != KokkosKernels::ArithTraits<mag_type>::zero()) {
+      const NrmValueType abs_val = KokkosKernels::ArithTraits<mag_type>::abs(x_imag);
+      if (scale < abs_val) {
+        sumsq = KokkosKernels::ArithTraits<mag_type>::one() + sumsq * square<NrmValueType>(scale / abs_val);
+        scale = abs_val;
+      } else {
+        sumsq += square<NrmValueType>(abs_val / scale);
+      }
+    }
+  } else {
+    if (x != KokkosKernels::ArithTraits<ValueType>::zero()) {
+      const NrmValueType abs_val = KokkosKernels::ArithTraits<ValueType>::abs(x);
+      if (scale < abs_val) {
+        sumsq = KokkosKernels::ArithTraits<NrmValueType>::one() + sumsq * square<NrmValueType>(scale / abs_val);
+        scale = abs_val;
+      } else {
+        sumsq += square<NrmValueType>(abs_val / scale);
+      }
+    }
+  }
+}
+
 ///
 /// Serial Internal Impl
 /// ====================
@@ -57,6 +147,17 @@ KOKKOS_INLINE_FUNCTION void SerialNrmInternal<NrmType>::invoke(const int n, cons
     for (int i = 0; i < n; ++i) {
       const NrmValueType abs_val = KokkosKernels::ArithTraits<ValueType>::abs(x[i * xs0]);
       if (abs_val > nrm) nrm = abs_val;
+    }
+  } else if constexpr (std::is_same_v<NrmType, Norm::ScaledL2>) {
+    if (n == 1) {
+      nrm = KokkosKernels::ArithTraits<ValueType>::abs(x[0]);
+    } else {
+      NrmValueType scale = KokkosKernels::ArithTraits<NrmValueType>::zero();
+      NrmValueType sumsq = KokkosKernels::ArithTraits<NrmValueType>::one();
+      for (int i = 0; i < n; ++i) {
+        scaled_square(x[i * xs0], scale, sumsq);
+      }
+      nrm = scale * KokkosKernels::ArithTraits<NrmValueType>::sqrt(sumsq);
     }
   }
 
@@ -99,6 +200,23 @@ KOKKOS_INLINE_FUNCTION void TeamNrmInternal<MemberType, NrmType>::invoke(const M
           if (abs_val > thread_nrm) thread_nrm = abs_val;
         },
         max_nrm);
+  } else if constexpr (std::is_same_v<NrmType, Norm::ScaledL2>) {
+    if (n == 1) {
+      nrm = KokkosKernels::ArithTraits<ValueType>::abs(x[0]);
+    } else {
+      Kokkos::pair<NrmValueType, NrmValueType> init_val{KokkosKernels::ArithTraits<NrmValueType>::zero(),
+                                                        KokkosKernels::ArithTraits<NrmValueType>::one()};
+      NormAccumulator<NrmValueType, typename MemberType::execution_space> accumulator(init_val);
+      Kokkos::parallel_reduce(
+          Kokkos::TeamThreadRange(member, n),
+          [&](const int i,
+              typename NormAccumulator<NrmValueType, typename MemberType::execution_space>::value_type &thread_accum) {
+            scaled_square(x[i * xs0], thread_accum.first, thread_accum.second);
+          },
+          accumulator);
+      const auto [scale, sumsq] = accumulator.reference();
+      nrm                       = scale * KokkosKernels::ArithTraits<NrmValueType>::sqrt(sumsq);
+    }
   }
 
   *norm = nrm;
@@ -140,6 +258,23 @@ KOKKOS_INLINE_FUNCTION void TeamVectorNrmInternal<MemberType, NrmType>::invoke(c
           if (abs_val > thread_nrm) thread_nrm = abs_val;
         },
         max_nrm);
+  } else if constexpr (std::is_same_v<NrmType, Norm::ScaledL2>) {
+    if (n == 1) {
+      nrm = KokkosKernels::ArithTraits<ValueType>::abs(x[0]);
+    } else {
+      Kokkos::pair<NrmValueType, NrmValueType> init_val{KokkosKernels::ArithTraits<NrmValueType>::zero(),
+                                                        KokkosKernels::ArithTraits<NrmValueType>::one()};
+      NormAccumulator<NrmValueType, typename MemberType::execution_space> accumulator(init_val);
+      Kokkos::parallel_reduce(
+          Kokkos::TeamVectorRange(member, n),
+          [&](const int i,
+              typename NormAccumulator<NrmValueType, typename MemberType::execution_space>::value_type &thread_accum) {
+            scaled_square(x[i * xs0], thread_accum.first, thread_accum.second);
+          },
+          accumulator);
+      const auto [scale, sumsq] = accumulator.reference();
+      nrm                       = scale * KokkosKernels::ArithTraits<NrmValueType>::sqrt(sumsq);
+    }
   }
   *norm = nrm;
 }

--- a/batched/dense/impl/KokkosBatched_Nrm_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Nrm_Internal.hpp
@@ -75,7 +75,7 @@ struct NormAccumulator {
 /// dnrm2: https://www.netlib.org/lapack/lapack-3.1.1/html/dnrm2.f.html,
 /// dznrm2: https://www.netlib.org/lapack/lapack-3.1.1/html/dznrm2.f.html
 /// \tparam NrmValueType: Value type for the norm (e.g., double)
-/// \tparam ValueType: Value type for the input (e.g., std::complex<double>)
+/// \tparam ValueType: Value type for the input (e.g., Kokkos::complex<double>)
 /// \param[in] x Input value for which the scaled square is computed
 /// \param[in,out] scale Current scale value, which is updated if the absolute value of x
 /// is greater than the current scale

--- a/batched/dense/src/KokkosBatched_Nrm.hpp
+++ b/batched/dense/src/KokkosBatched_Nrm.hpp
@@ -15,8 +15,7 @@ namespace KokkosBatched {
 /// \tparam NrmType: one of Norm::L1, Norm::L2, Norm::LInf, Norm::ScaledL2
 template <typename NrmType>
 struct SerialNrm {
-  static_assert(std::is_same_v<NrmType, Norm::L1> || std::is_same_v<NrmType, Norm::L2> ||
-                    std::is_same_v<NrmType, Norm::LInf> || std::is_same_v<NrmType, Norm::ScaledL2>,
+  static_assert(is_norm_v<NrmType>,
                 "KokkosBatched::SerialNrm: NrmType must be one of Norm::L1, Norm::L2, Norm::LInf, Norm::ScaledL2");
   /// \tparam XViewType: Type for input X, needs to be a 1D view
   /// \tparam NormViewType: Type for output norm, needs to be a 0D view
@@ -36,8 +35,7 @@ struct SerialNrm {
 /// \tparam NrmType: one of Norm::L1, Norm::L2, Norm::LInf
 template <typename MemberType, typename NrmType>
 struct TeamNrm {
-  static_assert(std::is_same_v<NrmType, Norm::L1> || std::is_same_v<NrmType, Norm::L2> ||
-                    std::is_same_v<NrmType, Norm::LInf> || std::is_same_v<NrmType, Norm::ScaledL2>,
+  static_assert(is_norm_v<NrmType>,
                 "KokkosBatched::TeamNrm: NrmType must be one of Norm::L1, Norm::L2, Norm::LInf, Norm::ScaledL2");
   /// \tparam XViewType: Type for input X, needs to be a 1D view
   /// \tparam NormViewType: Type for output norm, needs to be a 0D view
@@ -58,8 +56,7 @@ struct TeamNrm {
 /// \tparam NrmType: one of Norm::L1, Norm::L2, Norm::LInf, Norm::ScaledL2
 template <typename MemberType, typename NrmType>
 struct TeamVectorNrm {
-  static_assert(std::is_same_v<NrmType, Norm::L1> || std::is_same_v<NrmType, Norm::L2> ||
-                    std::is_same_v<NrmType, Norm::LInf> || std::is_same_v<NrmType, Norm::ScaledL2>,
+  static_assert(is_norm_v<NrmType>,
                 "KokkosBatched::TeamVectorNrm: NrmType must be one of Norm::L1, Norm::L2, Norm::LInf, Norm::ScaledL2");
   /// \tparam XViewType: Type for input X, needs to be a 1D view
   /// \tparam NormViewType: Type for output norm, needs to be a 0D view

--- a/batched/dense/src/KokkosBatched_Nrm.hpp
+++ b/batched/dense/src/KokkosBatched_Nrm.hpp
@@ -10,13 +10,14 @@ namespace KokkosBatched {
 /// If NrmType == Norm::L1, compute L1 norm of each vector in the batch
 /// If NrmType == Norm::L2, compute L2 norm of each vector in the batch
 /// If NrmType == Norm::LInf, compute Linf norm of each vector in the batch
+/// If NrmType == Norm::ScaledL2, compute ScaledL2 norm of each vector in the batch
 /// No nested parallel_for is used inside of the function.
-/// \tparam NrmType: one of Norm::L1, Norm::L2, Norm::LInf
+/// \tparam NrmType: one of Norm::L1, Norm::L2, Norm::LInf, Norm::ScaledL2
 template <typename NrmType>
 struct SerialNrm {
   static_assert(std::is_same_v<NrmType, Norm::L1> || std::is_same_v<NrmType, Norm::L2> ||
-                    std::is_same_v<NrmType, Norm::LInf>,
-                "KokkosBatched::SerialNrm: NrmType must be one of Norm::L1, Norm::L2, Norm::LInf");
+                    std::is_same_v<NrmType, Norm::LInf> || std::is_same_v<NrmType, Norm::ScaledL2>,
+                "KokkosBatched::SerialNrm: NrmType must be one of Norm::L1, Norm::L2, Norm::LInf, Norm::ScaledL2");
   /// \tparam XViewType: Type for input X, needs to be a 1D view
   /// \tparam NormViewType: Type for output norm, needs to be a 0D view
   ///
@@ -36,8 +37,8 @@ struct SerialNrm {
 template <typename MemberType, typename NrmType>
 struct TeamNrm {
   static_assert(std::is_same_v<NrmType, Norm::L1> || std::is_same_v<NrmType, Norm::L2> ||
-                    std::is_same_v<NrmType, Norm::LInf>,
-                "KokkosBatched::TeamNrm: NrmType must be one of Norm::L1, Norm::L2, Norm::LInf");
+                    std::is_same_v<NrmType, Norm::LInf> || std::is_same_v<NrmType, Norm::ScaledL2>,
+                "KokkosBatched::TeamNrm: NrmType must be one of Norm::L1, Norm::L2, Norm::LInf, Norm::ScaledL2");
   /// \tparam XViewType: Type for input X, needs to be a 1D view
   /// \tparam NormViewType: Type for output norm, needs to be a 0D view
   ///
@@ -54,12 +55,12 @@ struct TeamNrm {
 /// If NrmType == Norm::LInf, compute Linf norm of each vector in the batch
 /// A nested parallel_for with TeamVectorRange is used.
 /// \tparam MemberType: Kokkos TeamPolicy member type
-/// \tparam NrmType: one of Norm::L1, Norm::L2, Norm::LInf
+/// \tparam NrmType: one of Norm::L1, Norm::L2, Norm::LInf, Norm::ScaledL2
 template <typename MemberType, typename NrmType>
 struct TeamVectorNrm {
   static_assert(std::is_same_v<NrmType, Norm::L1> || std::is_same_v<NrmType, Norm::L2> ||
-                    std::is_same_v<NrmType, Norm::LInf>,
-                "KokkosBatched::TeamVectorNrm: NrmType must be one of Norm::L1, Norm::L2, Norm::LInf");
+                    std::is_same_v<NrmType, Norm::LInf> || std::is_same_v<NrmType, Norm::ScaledL2>,
+                "KokkosBatched::TeamVectorNrm: NrmType must be one of Norm::L1, Norm::L2, Norm::LInf, Norm::ScaledL2");
   /// \tparam XViewType: Type for input X, needs to be a 1D view
   /// \tparam NormViewType: Type for output norm, needs to be a 0D view
   ///

--- a/batched/dense/unit_test/Test_Batched_Nrm.hpp
+++ b/batched/dense/unit_test/Test_Batched_Nrm.hpp
@@ -94,20 +94,22 @@ void impl_test_batched_nrm_analytical(const std::size_t Nb) {
       h_x(ib, 2) = ScalarType(5, 6);
 
       // L1 norm: 21, L2 norm: sqrt(91), Linf norm: sqrt(61)
-      h_norm_ref(ib) = std::is_same_v<ArgNorm, Norm::L1>     ? RealType(21)
-                       : std::is_same_v<ArgNorm, Norm::L2>   ? Kokkos::sqrt(RealType(91))
-                       : std::is_same_v<ArgNorm, Norm::LInf> ? Kokkos::sqrt(RealType(61))
-                                                             : RealType(-1);
+      h_norm_ref(ib) = std::is_same_v<ArgNorm, Norm::L1>         ? RealType(21)
+                       : std::is_same_v<ArgNorm, Norm::L2>       ? Kokkos::sqrt(RealType(91))
+                       : std::is_same_v<ArgNorm, Norm::LInf>     ? Kokkos::sqrt(RealType(61))
+                       : std::is_same_v<ArgNorm, Norm::ScaledL2> ? Kokkos::sqrt(RealType(91))
+                                                                 : RealType(-1);
     } else {
       h_x(ib, 0) = ScalarType(1);
       h_x(ib, 1) = ScalarType(3);
       h_x(ib, 2) = ScalarType(5);
 
       // L1 norm: 9, L2 norm: sqrt(35), Linf norm: 5
-      h_norm_ref(ib) = std::is_same_v<ArgNorm, Norm::L1>     ? RealType(9)
-                       : std::is_same_v<ArgNorm, Norm::L2>   ? ats::sqrt(RealType(35))
-                       : std::is_same_v<ArgNorm, Norm::LInf> ? RealType(5)
-                                                             : RealType(-1);
+      h_norm_ref(ib) = std::is_same_v<ArgNorm, Norm::L1>         ? RealType(9)
+                       : std::is_same_v<ArgNorm, Norm::L2>       ? ats::sqrt(RealType(35))
+                       : std::is_same_v<ArgNorm, Norm::LInf>     ? RealType(5)
+                       : std::is_same_v<ArgNorm, Norm::ScaledL2> ? ats::sqrt(RealType(35))
+                                                                 : RealType(-1);
     }
   }
 
@@ -133,12 +135,94 @@ void impl_test_batched_nrm_analytical(const std::size_t Nb) {
   }
 }
 
+/// \brief Implementation details of batched nrm overflow test
+/// 3.4e38 and 1e308 are the largest representable finite values for fp32 and fp64 respectively.
+/// For fp32, where x^2 is expected to overflow
+/// x = [1e20, 1e20, 1e20]
+/// z = [1e200 + 1e200j, 1e200 + 1e200j, 1e200 + 1e200j]
+/// L2 norm: x: sqrt(3) * 1e200, z: sqrt(6) * 1e200
+///
+/// For fp64, where x^2 is expected to overflow
+/// x = [1e200, 1e200, 1e200]
+/// z = [1e200 + 1e200j, 1e200 + 1e200j, 1e200 + 1e200j]
+/// L2 norm: x: sqrt(3) * 1e200, z: sqrt(6) * 1e200
+///
+/// \tparam DeviceType Kokkos device type
+/// \tparam ScalarType Kokkos scalar type
+/// \tparam LayoutType Kokkos layout type for the views
+/// \tparam ArgMode: one of Mode::Serial, Mode::Team, Mode::TeamVector
+///
+/// \param[in] Nb Batch size of vectors
+template <typename DeviceType, typename ScalarType, typename LayoutType, typename ArgMode>
+void impl_test_batched_nrm_overflow(const std::size_t Nb) {
+  using ats               = typename KokkosKernels::ArithTraits<ScalarType>;
+  using RealType          = typename ats::mag_type;
+  using NormViewType      = Kokkos::View<RealType *, LayoutType, DeviceType>;
+  using View2DType        = Kokkos::View<ScalarType **, LayoutType, DeviceType>;
+  using StridedView2DType = Kokkos::View<ScalarType **, Kokkos::LayoutStride, DeviceType>;
+
+  const std::size_t N = 3;
+  View2DType x("x", Nb, N);
+  NormViewType norm("norm", Nb), norm_s("norm_s", Nb), norm_ref("norm_ref", Nb);
+
+  const std::size_t incx = 2;
+  // Testing incx argument with strided views
+  Kokkos::LayoutStride layout{Nb, incx, N, Nb * incx};
+  StridedView2DType x_s("x_s", layout);
+
+  auto h_x        = Kokkos::create_mirror_view(x);
+  auto h_norm_ref = Kokkos::create_mirror_view(norm_ref);
+
+  constexpr bool is_complex = KokkosKernels::ArithTraits<ScalarType>::is_complex;
+  const RealType large_val  = std::is_same_v<RealType, float> ? RealType(1e20) : RealType(1e200);
+
+  for (std::size_t ib = 0; ib < Nb; ib++) {
+    if constexpr (is_complex) {
+      h_x(ib, 0) = ScalarType(large_val, large_val);
+      h_x(ib, 1) = ScalarType(large_val, large_val);
+      h_x(ib, 2) = ScalarType(large_val, large_val);
+
+      // L2 norm: sqrt(6) * large_val
+      h_norm_ref(ib) = Kokkos::sqrt(RealType(6)) * large_val;
+    } else {
+      h_x(ib, 0) = ScalarType(large_val);
+      h_x(ib, 1) = ScalarType(large_val);
+      h_x(ib, 2) = ScalarType(large_val);
+
+      // L2 norm: sqrt(3) * large_val
+      h_norm_ref(ib) = Kokkos::sqrt(RealType(3)) * large_val;
+    }
+  }
+
+  Kokkos::deep_copy(x, h_x);
+
+  // Deep copy to strided views
+  Kokkos::deep_copy(x_s, x);
+
+  using ArgNorm = KokkosBatched::Norm::ScaledL2;
+  auto info     = Functor_BatchedNrm<DeviceType, View2DType, NormViewType, ArgNorm, ArgMode>(x, norm).run();
+  EXPECT_EQ(info, 0);
+
+  // With strided views
+  info = Functor_BatchedNrm<DeviceType, StridedView2DType, NormViewType, ArgNorm, ArgMode>(x_s, norm_s).run();
+  EXPECT_EQ(info, 0);
+
+  RealType eps  = 1.0e1 * ats::epsilon();
+  auto h_norm   = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, norm);
+  auto h_norm_s = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, norm_s);
+
+  for (std::size_t ib = 0; ib < Nb; ib++) {
+    KK_EXPECT_NEAR(h_norm(ib), h_norm_ref(ib), eps);
+    KK_EXPECT_NEAR(h_norm_s(ib), h_norm_ref(ib), eps);
+  }
+}
+
 /// \brief Implementation details of batched nrm test
 ///
 /// \tparam DeviceType Kokkos device type
 /// \tparam ScalarType Kokkos scalar type
 /// \tparam LayoutType Kokkos layout type for the views
-/// \tparam ArgNorm: one of L1, L2, Linf
+/// \tparam ArgNorm: one of L1, L2, Linf, ScaledL2
 /// \tparam ArgMode: one of Mode::Serial, Mode::Team, Mode::TeamVector
 ///
 /// \param[in] Nb Batch size of vectors
@@ -195,7 +279,7 @@ void impl_test_batched_nrm(const std::size_t Nb, const std::size_t N) {
       for (std::size_t i = 0; i < N; i++) {
         norm_tmp += asum(h_x(ib, i));
       }
-    } else if constexpr (std::is_same_v<ArgNorm, Norm::L2>) {
+    } else if constexpr (std::is_same_v<ArgNorm, Norm::L2> || std::is_same_v<ArgNorm, Norm::ScaledL2>) {
       for (std::size_t i = 0; i < N; i++) {
         const auto abs_val = ats::abs(h_x(ib, i));
         norm_tmp += abs_val * abs_val;
@@ -235,6 +319,11 @@ int test_batched_nrm() {
       Test::Nrm::impl_test_batched_nrm<DeviceType, ScalarType, LayoutType, ArgNorm, ArgMode>(1, i);
       Test::Nrm::impl_test_batched_nrm<DeviceType, ScalarType, LayoutType, ArgNorm, ArgMode>(2, i);
     }
+
+    if constexpr (std::is_same_v<ArgNorm, KokkosBatched::Norm::ScaledL2>) {
+      // Additional test for large values to check for overflow handling in ScaledL2 norm
+      Test::Nrm::impl_test_batched_nrm_overflow<DeviceType, ScalarType, LayoutType, ArgMode>(3);
+    }
   }
 #endif
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT)
@@ -245,6 +334,11 @@ int test_batched_nrm() {
     for (int i = 0; i < 5; i++) {
       Test::Nrm::impl_test_batched_nrm<DeviceType, ScalarType, LayoutType, ArgNorm, ArgMode>(1, i);
       Test::Nrm::impl_test_batched_nrm<DeviceType, ScalarType, LayoutType, ArgNorm, ArgMode>(2, i);
+    }
+
+    if constexpr (std::is_same_v<ArgNorm, KokkosBatched::Norm::ScaledL2>) {
+      // Additional test for large values to check for overflow handling in ScaledL2 norm
+      Test::Nrm::impl_test_batched_nrm_overflow<DeviceType, ScalarType, LayoutType, ArgMode>(3);
     }
   }
 #endif
@@ -265,6 +359,10 @@ TEST_F(TestCategory, test_batched_serial_nrm_linf_float) {
   test_batched_nrm<TestDevice, float, KokkosBatched::Norm::LInf, KokkosBatched::Mode::Serial>();
 }
 
+TEST_F(TestCategory, test_batched_serial_nrm_scaled_l2_float) {
+  test_batched_nrm<TestDevice, float, KokkosBatched::Norm::ScaledL2, KokkosBatched::Mode::Serial>();
+}
+
 // Team
 TEST_F(TestCategory, test_batched_team_nrm_l1_float) {
   test_batched_nrm<TestDevice, float, KokkosBatched::Norm::L1, KokkosBatched::Mode::Team>();
@@ -274,6 +372,9 @@ TEST_F(TestCategory, test_batched_team_nrm_l2_float) {
 }
 TEST_F(TestCategory, test_batched_team_nrm_linf_float) {
   test_batched_nrm<TestDevice, float, KokkosBatched::Norm::LInf, KokkosBatched::Mode::Team>();
+}
+TEST_F(TestCategory, test_batched_team_nrm_scaled_l2_float) {
+  test_batched_nrm<TestDevice, float, KokkosBatched::Norm::ScaledL2, KokkosBatched::Mode::Team>();
 }
 
 // TeamVector
@@ -285,6 +386,9 @@ TEST_F(TestCategory, test_batched_teamvector_nrm_l2_float) {
 }
 TEST_F(TestCategory, test_batched_teamvector_nrm_linf_float) {
   test_batched_nrm<TestDevice, float, KokkosBatched::Norm::LInf, KokkosBatched::Mode::TeamVector>();
+}
+TEST_F(TestCategory, test_batched_teamvector_nrm_scaled_l2_float) {
+  test_batched_nrm<TestDevice, float, KokkosBatched::Norm::ScaledL2, KokkosBatched::Mode::TeamVector>();
 }
 #endif
 
@@ -299,6 +403,9 @@ TEST_F(TestCategory, test_batched_serial_nrm_l2_double) {
 TEST_F(TestCategory, test_batched_serial_nrm_linf_double) {
   test_batched_nrm<TestDevice, double, KokkosBatched::Norm::LInf, KokkosBatched::Mode::Serial>();
 }
+TEST_F(TestCategory, test_batched_serial_nrm_scaled_l2_double) {
+  test_batched_nrm<TestDevice, double, KokkosBatched::Norm::ScaledL2, KokkosBatched::Mode::Serial>();
+}
 
 // Team
 TEST_F(TestCategory, test_batched_team_nrm_l1_double) {
@@ -310,6 +417,9 @@ TEST_F(TestCategory, test_batched_team_nrm_l2_double) {
 TEST_F(TestCategory, test_batched_team_nrm_linf_double) {
   test_batched_nrm<TestDevice, double, KokkosBatched::Norm::LInf, KokkosBatched::Mode::Team>();
 }
+TEST_F(TestCategory, test_batched_team_nrm_scaled_l2_double) {
+  test_batched_nrm<TestDevice, double, KokkosBatched::Norm::ScaledL2, KokkosBatched::Mode::Team>();
+}
 
 // TeamVector
 TEST_F(TestCategory, test_batched_teamvector_nrm_l1_double) {
@@ -320,6 +430,9 @@ TEST_F(TestCategory, test_batched_teamvector_nrm_l2_double) {
 }
 TEST_F(TestCategory, test_batched_teamvector_nrm_linf_double) {
   test_batched_nrm<TestDevice, double, KokkosBatched::Norm::LInf, KokkosBatched::Mode::TeamVector>();
+}
+TEST_F(TestCategory, test_batched_teamvector_nrm_scaled_l2_double) {
+  test_batched_nrm<TestDevice, double, KokkosBatched::Norm::ScaledL2, KokkosBatched::Mode::TeamVector>();
 }
 #endif
 
@@ -334,6 +447,9 @@ TEST_F(TestCategory, test_batched_serial_nrm_l2_fcomplex) {
 TEST_F(TestCategory, test_batched_serial_nrm_linf_fcomplex) {
   test_batched_nrm<TestDevice, Kokkos::complex<float>, KokkosBatched::Norm::LInf, KokkosBatched::Mode::Serial>();
 }
+TEST_F(TestCategory, test_batched_serial_nrm_scaled_l2_fcomplex) {
+  test_batched_nrm<TestDevice, Kokkos::complex<float>, KokkosBatched::Norm::ScaledL2, KokkosBatched::Mode::Serial>();
+}
 
 // Team
 TEST_F(TestCategory, test_batched_team_nrm_l1_fcomplex) {
@@ -345,6 +461,9 @@ TEST_F(TestCategory, test_batched_team_nrm_l2_fcomplex) {
 TEST_F(TestCategory, test_batched_team_nrm_linf_fcomplex) {
   test_batched_nrm<TestDevice, Kokkos::complex<float>, KokkosBatched::Norm::LInf, KokkosBatched::Mode::Team>();
 }
+TEST_F(TestCategory, test_batched_team_nrm_scaled_l2_fcomplex) {
+  test_batched_nrm<TestDevice, Kokkos::complex<float>, KokkosBatched::Norm::ScaledL2, KokkosBatched::Mode::Team>();
+}
 
 // TeamVector
 TEST_F(TestCategory, test_batched_teamvector_nrm_l1_fcomplex) {
@@ -355,6 +474,10 @@ TEST_F(TestCategory, test_batched_teamvector_nrm_l2_fcomplex) {
 }
 TEST_F(TestCategory, test_batched_teamvector_nrm_linf_fcomplex) {
   test_batched_nrm<TestDevice, Kokkos::complex<float>, KokkosBatched::Norm::LInf, KokkosBatched::Mode::TeamVector>();
+}
+TEST_F(TestCategory, test_batched_teamvector_nrm_scaled_l2_fcomplex) {
+  test_batched_nrm<TestDevice, Kokkos::complex<float>, KokkosBatched::Norm::ScaledL2,
+                   KokkosBatched::Mode::TeamVector>();
 }
 #endif
 
@@ -369,6 +492,9 @@ TEST_F(TestCategory, test_batched_serial_nrm_l2_dcomplex) {
 TEST_F(TestCategory, test_batched_serial_nrm_linf_dcomplex) {
   test_batched_nrm<TestDevice, Kokkos::complex<double>, KokkosBatched::Norm::LInf, KokkosBatched::Mode::Serial>();
 }
+TEST_F(TestCategory, test_batched_serial_nrm_scaled_l2_dcomplex) {
+  test_batched_nrm<TestDevice, Kokkos::complex<double>, KokkosBatched::Norm::ScaledL2, KokkosBatched::Mode::Serial>();
+}
 
 // Team
 TEST_F(TestCategory, test_batched_team_nrm_l1_dcomplex) {
@@ -380,6 +506,9 @@ TEST_F(TestCategory, test_batched_team_nrm_l2_dcomplex) {
 TEST_F(TestCategory, test_batched_team_nrm_linf_dcomplex) {
   test_batched_nrm<TestDevice, Kokkos::complex<double>, KokkosBatched::Norm::LInf, KokkosBatched::Mode::Team>();
 }
+TEST_F(TestCategory, test_batched_team_nrm_scaled_l2_dcomplex) {
+  test_batched_nrm<TestDevice, Kokkos::complex<double>, KokkosBatched::Norm::ScaledL2, KokkosBatched::Mode::Team>();
+}
 
 // TeamVector
 TEST_F(TestCategory, test_batched_teamvector_nrm_l1_dcomplex) {
@@ -390,5 +519,9 @@ TEST_F(TestCategory, test_batched_teamvector_nrm_l2_dcomplex) {
 }
 TEST_F(TestCategory, test_batched_teamvector_nrm_linf_dcomplex) {
   test_batched_nrm<TestDevice, Kokkos::complex<double>, KokkosBatched::Norm::LInf, KokkosBatched::Mode::TeamVector>();
+}
+TEST_F(TestCategory, test_batched_teamvector_nrm_scaled_l2_dcomplex) {
+  test_batched_nrm<TestDevice, Kokkos::complex<double>, KokkosBatched::Norm::ScaledL2,
+                   KokkosBatched::Mode::TeamVector>();
 }
 #endif


### PR DESCRIPTION
This PR introduces a new class for batched norm computation.
Based on the [older blas implementation](https://www.netlib.org/lapack/lapack-3.1.1/html/dznrm2.f.html), l2 norm can be computed without overflow/underflow.

- [x] Add a new class `ScaledL2`
- [x] Add an unit test to show that `ScaledL2` gives correct results without overflow while it gives the same results as `L2`