### PR TITLE
TPL - gtest: fixing warning coming out of gtest.h

### DIFF
--- a/tpls/gtest/gtest/gtest.h
+++ b/tpls/gtest/gtest/gtest.h
@@ -5532,7 +5532,7 @@ inline void PrintTo(char16_t c, ::std::ostream* os) {
 }
 #ifdef __cpp_lib_char8_t
 inline void PrintTo(char8_t c, ::std::ostream* os) {
-  PrintTo(ImplicitCast_<char32_t>(c), os);
+  PrintTo(static_cast<char32_t>(c), os);
 }
 #endif
 


### PR DESCRIPTION
Just fixing a small warning that comes out with newer clang versions, for instance clang 21 on my laptop...