### PR TITLE
Sparse - SpMV: Fix for BsrSpMV with tensore cores

### DIFF
--- a/sparse/impl/KokkosSparse_spmv_bsrmatrix_spec.hpp
+++ b/sparse/impl/KokkosSparse_spmv_bsrmatrix_spec.hpp
@@ -190,9 +190,9 @@ struct SPMV_MV_BSRMATRIX<ExecutionSpace, Handle, AMatrix, XVector, YVector, fals
 
 #if defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_ARCH_AMPERE)
     {
-      typedef Kokkos::Experimental::half_t Half;
-      typedef typename AMatrix::non_const_value_type AScalar;
-      typedef typename XVector::non_const_value_type XScalar;
+      using kokkos_half_t = Kokkos::Experimental::half_t;
+      using AScalar = typename AMatrix::non_const_value_type;
+      using XScalar = typename XVector::non_const_value_type;
 
       /* Ampere has double += double * double and float += half * half
 
@@ -204,7 +204,7 @@ struct SPMV_MV_BSRMATRIX<ExecutionSpace, Handle, AMatrix, XVector, YVector, fals
         auto precision = handle->bsr_tc_precision;
         switch (precision) {
           case KokkosSparse::Experimental::Bsr_TC_Precision::Mixed: {
-            BsrMatrixSpMVTensorCoreDispatcher<ExecutionSpace, AMatrix, half, XVector, half, YVector, float, 16, 16,
+            BsrMatrixSpMVTensorCoreDispatcher<ExecutionSpace, AMatrix, kokkos_half_t, XVector, kokkos_half_t, YVector, float, 16, 16,
                                               16>::dispatch(space, alpha, A, X, beta, Y);
             Kokkos::Profiling::popRegion();
             return;
@@ -217,11 +217,11 @@ struct SPMV_MV_BSRMATRIX<ExecutionSpace, Handle, AMatrix, XVector, YVector, fals
           }
           case KokkosSparse::Experimental::Bsr_TC_Precision::Automatic:
           default: {
-            constexpr bool operandsHalfHalfFloat = std::is_same<AScalar, Half>::value &&
-                                                   std::is_same<XScalar, Half>::value &&
+            constexpr bool operandsHalfHalfFloat = std::is_same<AScalar, kokkos_half_t>::value &&
+                                                   std::is_same<XScalar, kokkos_half_t>::value &&
                                                    std::is_same<YScalar, float>::value;
             if (operandsHalfHalfFloat) {
-              BsrMatrixSpMVTensorCoreDispatcher<ExecutionSpace, AMatrix, half, XVector, half, YVector, float, 16, 16,
+              BsrMatrixSpMVTensorCoreDispatcher<ExecutionSpace, AMatrix, kokkos_half_t, XVector, kokkos_half_t, YVector, float, 16, 16,
                                                 16>::dispatch(space, alpha, A, X, beta, Y);
               Kokkos::Profiling::popRegion();
               return;
@@ -241,7 +241,7 @@ struct SPMV_MV_BSRMATRIX<ExecutionSpace, Handle, AMatrix, XVector, YVector, fals
          use it for all matrices
       */
       if (Method::TensorCores == method) {
-        BsrMatrixSpMVTensorCoreDispatcher<ExecutionSpace, AMatrix, half, XVector, half, YVector, float, 16, 16,
+        BsrMatrixSpMVTensorCoreDispatcher<ExecutionSpace, AMatrix, kokkos_half_t, XVector, kokkos_half_t, YVector, float, 16, 16,
                                           16>::dispatch(space, alpha, A, X, beta, Y);
         Kokkos::Profiling::popRegion();
         return;

--- a/sparse/impl/KokkosSparse_spmv_bsrmatrix_spec.hpp
+++ b/sparse/impl/KokkosSparse_spmv_bsrmatrix_spec.hpp
@@ -191,8 +191,8 @@ struct SPMV_MV_BSRMATRIX<ExecutionSpace, Handle, AMatrix, XVector, YVector, fals
 #if defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_ARCH_AMPERE)
     {
       using kokkos_half_t = Kokkos::Experimental::half_t;
-      using AScalar = typename AMatrix::non_const_value_type;
-      using XScalar = typename XVector::non_const_value_type;
+      using AScalar       = typename AMatrix::non_const_value_type;
+      using XScalar       = typename XVector::non_const_value_type;
 
       /* Ampere has double += double * double and float += half * half
 
@@ -204,8 +204,8 @@ struct SPMV_MV_BSRMATRIX<ExecutionSpace, Handle, AMatrix, XVector, YVector, fals
         auto precision = handle->bsr_tc_precision;
         switch (precision) {
           case KokkosSparse::Experimental::Bsr_TC_Precision::Mixed: {
-            BsrMatrixSpMVTensorCoreDispatcher<ExecutionSpace, AMatrix, kokkos_half_t, XVector, kokkos_half_t, YVector, float, 16, 16,
-                                              16>::dispatch(space, alpha, A, X, beta, Y);
+            BsrMatrixSpMVTensorCoreDispatcher<ExecutionSpace, AMatrix, kokkos_half_t, XVector, kokkos_half_t, YVector,
+                                              float, 16, 16, 16>::dispatch(space, alpha, A, X, beta, Y);
             Kokkos::Profiling::popRegion();
             return;
           }
@@ -221,8 +221,8 @@ struct SPMV_MV_BSRMATRIX<ExecutionSpace, Handle, AMatrix, XVector, YVector, fals
                                                    std::is_same<XScalar, kokkos_half_t>::value &&
                                                    std::is_same<YScalar, float>::value;
             if (operandsHalfHalfFloat) {
-              BsrMatrixSpMVTensorCoreDispatcher<ExecutionSpace, AMatrix, kokkos_half_t, XVector, kokkos_half_t, YVector, float, 16, 16,
-                                                16>::dispatch(space, alpha, A, X, beta, Y);
+              BsrMatrixSpMVTensorCoreDispatcher<ExecutionSpace, AMatrix, kokkos_half_t, XVector, kokkos_half_t, YVector,
+                                                float, 16, 16, 16>::dispatch(space, alpha, A, X, beta, Y);
               Kokkos::Profiling::popRegion();
               return;
             } else {
@@ -241,8 +241,8 @@ struct SPMV_MV_BSRMATRIX<ExecutionSpace, Handle, AMatrix, XVector, YVector, fals
          use it for all matrices
       */
       if (Method::TensorCores == method) {
-        BsrMatrixSpMVTensorCoreDispatcher<ExecutionSpace, AMatrix, kokkos_half_t, XVector, kokkos_half_t, YVector, float, 16, 16,
-                                          16>::dispatch(space, alpha, A, X, beta, Y);
+        BsrMatrixSpMVTensorCoreDispatcher<ExecutionSpace, AMatrix, kokkos_half_t, XVector, kokkos_half_t, YVector,
+                                          float, 16, 16, 16>::dispatch(space, alpha, A, X, beta, Y);
         Kokkos::Profiling::popRegion();
         return;
       }

--- a/sparse/impl/KokkosSparse_spmv_bsrmatrix_spec.hpp
+++ b/sparse/impl/KokkosSparse_spmv_bsrmatrix_spec.hpp
@@ -204,9 +204,9 @@ struct SPMV_MV_BSRMATRIX<ExecutionSpace, Handle, AMatrix, XVector, YVector, fals
         auto precision = handle->bsr_tc_precision;
         switch (precision) {
           case KokkosSparse::Experimental::Bsr_TC_Precision::Mixed: {
-	    // Note here the "half" type is that defined by CUDA
-            BsrMatrixSpMVTensorCoreDispatcher<ExecutionSpace, AMatrix, half, XVector, half, YVector,
-                                              float, 16, 16, 16>::dispatch(space, alpha, A, X, beta, Y);
+            // Note here the "half" type is that defined by CUDA
+            BsrMatrixSpMVTensorCoreDispatcher<ExecutionSpace, AMatrix, half, XVector, half, YVector, float, 16, 16,
+                                              16>::dispatch(space, alpha, A, X, beta, Y);
             Kokkos::Profiling::popRegion();
             return;
           }
@@ -222,9 +222,9 @@ struct SPMV_MV_BSRMATRIX<ExecutionSpace, Handle, AMatrix, XVector, YVector, fals
                                                    std::is_same<XScalar, kokkos_half_t>::value &&
                                                    std::is_same<YScalar, float>::value;
             if (operandsHalfHalfFloat) {
-	      // Note here the "half" type is that defined by CUDA
-              BsrMatrixSpMVTensorCoreDispatcher<ExecutionSpace, AMatrix, half, XVector, half, YVector,
-                                                float, 16, 16, 16>::dispatch(space, alpha, A, X, beta, Y);
+              // Note here the "half" type is that defined by CUDA
+              BsrMatrixSpMVTensorCoreDispatcher<ExecutionSpace, AMatrix, half, XVector, half, YVector, float, 16, 16,
+                                                16>::dispatch(space, alpha, A, X, beta, Y);
               Kokkos::Profiling::popRegion();
               return;
             } else {
@@ -244,9 +244,9 @@ struct SPMV_MV_BSRMATRIX<ExecutionSpace, Handle, AMatrix, XVector, YVector, fals
          use it for all matrices
       */
       if (Method::TensorCores == method) {
-	// Note here the "half" type is that defined by CUDA
-        BsrMatrixSpMVTensorCoreDispatcher<ExecutionSpace, AMatrix, half, XVector, half, YVector,
-                                          float, 16, 16, 16>::dispatch(space, alpha, A, X, beta, Y);
+        // Note here the "half" type is that defined by CUDA
+        BsrMatrixSpMVTensorCoreDispatcher<ExecutionSpace, AMatrix, half, XVector, half, YVector, float, 16, 16,
+                                          16>::dispatch(space, alpha, A, X, beta, Y);
         Kokkos::Profiling::popRegion();
         return;
       }

--- a/sparse/impl/KokkosSparse_spmv_bsrmatrix_spec.hpp
+++ b/sparse/impl/KokkosSparse_spmv_bsrmatrix_spec.hpp
@@ -237,6 +237,7 @@ struct SPMV_MV_BSRMATRIX<ExecutionSpace, Handle, AMatrix, XVector, YVector, fals
     }
 #elif defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_ARCH_VOLTA)
     {
+      using kokkos_half_t = Kokkos::Experimental::half_t;
       /* Volta has float += half * half
          use it for all matrices
       */

--- a/sparse/impl/KokkosSparse_spmv_bsrmatrix_spec.hpp
+++ b/sparse/impl/KokkosSparse_spmv_bsrmatrix_spec.hpp
@@ -204,7 +204,8 @@ struct SPMV_MV_BSRMATRIX<ExecutionSpace, Handle, AMatrix, XVector, YVector, fals
         auto precision = handle->bsr_tc_precision;
         switch (precision) {
           case KokkosSparse::Experimental::Bsr_TC_Precision::Mixed: {
-            BsrMatrixSpMVTensorCoreDispatcher<ExecutionSpace, AMatrix, kokkos_half_t, XVector, kokkos_half_t, YVector,
+	    // Note here the "half" type is that defined by CUDA
+            BsrMatrixSpMVTensorCoreDispatcher<ExecutionSpace, AMatrix, half, XVector, half, YVector,
                                               float, 16, 16, 16>::dispatch(space, alpha, A, X, beta, Y);
             Kokkos::Profiling::popRegion();
             return;
@@ -221,7 +222,8 @@ struct SPMV_MV_BSRMATRIX<ExecutionSpace, Handle, AMatrix, XVector, YVector, fals
                                                    std::is_same<XScalar, kokkos_half_t>::value &&
                                                    std::is_same<YScalar, float>::value;
             if (operandsHalfHalfFloat) {
-              BsrMatrixSpMVTensorCoreDispatcher<ExecutionSpace, AMatrix, kokkos_half_t, XVector, kokkos_half_t, YVector,
+	      // Note here the "half" type is that defined by CUDA
+              BsrMatrixSpMVTensorCoreDispatcher<ExecutionSpace, AMatrix, half, XVector, half, YVector,
                                                 float, 16, 16, 16>::dispatch(space, alpha, A, X, beta, Y);
               Kokkos::Profiling::popRegion();
               return;
@@ -242,7 +244,8 @@ struct SPMV_MV_BSRMATRIX<ExecutionSpace, Handle, AMatrix, XVector, YVector, fals
          use it for all matrices
       */
       if (Method::TensorCores == method) {
-        BsrMatrixSpMVTensorCoreDispatcher<ExecutionSpace, AMatrix, kokkos_half_t, XVector, kokkos_half_t, YVector,
+	// Note here the "half" type is that defined by CUDA
+        BsrMatrixSpMVTensorCoreDispatcher<ExecutionSpace, AMatrix, half, XVector, half, YVector,
                                           float, 16, 16, 16>::dispatch(space, alpha, A, X, beta, Y);
         Kokkos::Profiling::popRegion();
         return;


### PR DESCRIPTION
Fixes #2189 
The half type is not used consistently with upper/lower case. Fixing it and also changing the typedef to make it more specific to Kokkos.