### PR TITLE
SYCL: remove Experimental namespace

### DIFF
--- a/benchmarks/blas/KokkosBlas2_gemv_benchmark.cpp
+++ b/benchmarks/blas/KokkosBlas2_gemv_benchmark.cpp
@@ -179,7 +179,7 @@ int main(int argc, char** argv) {
 
   if (params.use_sycl) {
 #if defined(KOKKOS_ENABLE_SYCL)
-    run<Kokkos::Experimental::SYCL>(params);
+    run<Kokkos::SYCL>(params);
 #else
     std::cout << "ERROR: SYCL requested, but not available.\n";
     return 1;

--- a/benchmarks/blas/KokkosBlas2_ger_benchmark.cpp
+++ b/benchmarks/blas/KokkosBlas2_ger_benchmark.cpp
@@ -281,7 +281,7 @@ int main(int argc, char** argv) {
 
   if (params.use_sycl) {
 #if defined(KOKKOS_ENABLE_SYCL)
-    run<Kokkos::Experimental::SYCL>(params);
+    run<Kokkos::SYCL>(params);
 #else
     std::cout << "ERROR: SYCL requested, but not available.\n";
     return 1;

--- a/benchmarks/blas/KokkosBlas3_gemm_benchmark.cpp
+++ b/benchmarks/blas/KokkosBlas3_gemm_benchmark.cpp
@@ -168,7 +168,7 @@ int main(int argc, char** argv) {
 
   if (params.use_sycl) {
 #if defined(KOKKOS_ENABLE_SYCL)
-    run<Kokkos::Experimental::SYCL>(params);
+    run<Kokkos::SYCL>(params);
 #else
     std::cout << "ERROR: SYCL requested, but not available.\n";
     return 1;

--- a/blas/impl/KokkosBlas2_gemv_impl.hpp
+++ b/blas/impl/KokkosBlas2_gemv_impl.hpp
@@ -572,7 +572,7 @@ void twoLevelGemv(const ExecutionSpace& space, const char trans[], typename AVie
         // FIXME SYCL: team_size_recommended() returns too big of a team size.
         // Kernel hangs with 1024 threads on XEHP.
 #ifdef KOKKOS_ENABLE_SYCL
-      if (std::is_same<ExecutionSpace, Kokkos::Experimental::SYCL>::value) {
+      if (std::is_same<ExecutionSpace, Kokkos::SYCL>::value) {
         if (teamSize > 256) teamSize = 256;
       }
 #endif

--- a/blas/impl/KokkosBlas3_gemm_spec.hpp
+++ b/blas/impl/KokkosBlas3_gemm_spec.hpp
@@ -149,7 +149,7 @@ struct GEMM {
       if (std::is_same<execution_space, Kokkos::ROCm>::value) team_size = blockA0;
 #endif
 #if defined(KOKKOS_ENABLE_SYCL)
-      if (std::is_same<execution_space, Kokkos::Experimental::SYCL>::value) team_size = blockA0;
+      if (std::is_same<execution_space, Kokkos::SYCL>::value) team_size = blockA0;
 #endif
 
       // Call the correct kernel

--- a/blas/src/KokkosBlas2_gemv.hpp
+++ b/blas/src/KokkosBlas2_gemv.hpp
@@ -123,7 +123,7 @@ void gemv(const ExecutionSpace& space, const char trans[], typename AViewType::c
   // oneMKL supports both row-major and column-major of A
   // but only supports oneapi::mkl::transpose::nontrans op
   useFallback =
-      useFallback || !std::is_same_v<typename AViewType::memory_space, Kokkos::Experimental::SYCLDeviceUSMSpace>;
+      useFallback || !std::is_same_v<typename AViewType::memory_space, Kokkos::SYCLDeviceUSMSpace>;
 #endif
 #endif
 

--- a/blas/src/KokkosBlas2_gemv.hpp
+++ b/blas/src/KokkosBlas2_gemv.hpp
@@ -122,8 +122,7 @@ void gemv(const ExecutionSpace& space, const char trans[], typename AViewType::c
 #ifdef KOKKOS_ENABLE_SYCL
   // oneMKL supports both row-major and column-major of A
   // but only supports oneapi::mkl::transpose::nontrans op
-  useFallback =
-      useFallback || !std::is_same_v<typename AViewType::memory_space, Kokkos::SYCLDeviceUSMSpace>;
+  useFallback = useFallback || !std::is_same_v<typename AViewType::memory_space, Kokkos::SYCLDeviceUSMSpace>;
 #endif
 #endif
 

--- a/blas/tpls/KokkosBlas1_dot_tpl_spec_avail.hpp
+++ b/blas/tpls/KokkosBlas1_dot_tpl_spec_avail.hpp
@@ -81,7 +81,7 @@ KOKKOSBLAS1_DOT_TPL_SPEC_AVAIL(Kokkos::LayoutLeft, Kokkos::HIP, Kokkos::HIPSpace
 #endif
 
 #if defined(KOKKOSKERNELS_ENABLE_TPL_MKL) && defined(KOKKOS_ENABLE_SYCL)
-KOKKOSBLAS1_DOT_TPL_SPEC_AVAIL(Kokkos::LayoutLeft, Kokkos::Experimental::SYCL, Kokkos::Experimental::SYCLDeviceUSMSpace)
+KOKKOSBLAS1_DOT_TPL_SPEC_AVAIL(Kokkos::LayoutLeft, Kokkos::SYCL, Kokkos::SYCLDeviceUSMSpace)
 #endif
 }  // namespace Impl
 }  // namespace KokkosBlas

--- a/blas/tpls/KokkosBlas1_dot_tpl_spec_decl.hpp
+++ b/blas/tpls/KokkosBlas1_dot_tpl_spec_decl.hpp
@@ -235,19 +235,16 @@ namespace Impl {
     }                                                                                                                 \
   };
 
-#define KOKKOSBLAS1_DOT_TPL_SPEC_DECL_ONEMKL_EXT(ETI_SPEC_AVAIL)                                                    \
-  KOKKOSBLAS1_DOT_TPL_SPEC_DECL_ONEMKL(Kokkos::LayoutLeft, float, float, Kokkos::SYCL,                \
-                                       Kokkos::SYCLDeviceUSMSpace, oneapi::mkl::blas::row_major::dot, \
-                                       ETI_SPEC_AVAIL)                                                              \
-  KOKKOSBLAS1_DOT_TPL_SPEC_DECL_ONEMKL(Kokkos::LayoutLeft, double, double, Kokkos::SYCL,              \
-                                       Kokkos::SYCLDeviceUSMSpace, oneapi::mkl::blas::row_major::dot, \
-                                       ETI_SPEC_AVAIL)                                                              \
-  KOKKOSBLAS1_DOT_TPL_SPEC_DECL_ONEMKL(Kokkos::LayoutLeft, Kokkos::complex<float>, std::complex<float>,             \
-                                       Kokkos::SYCL, Kokkos::SYCLDeviceUSMSpace,        \
-                                       oneapi::mkl::blas::row_major::dotc, ETI_SPEC_AVAIL)                          \
-  KOKKOSBLAS1_DOT_TPL_SPEC_DECL_ONEMKL(Kokkos::LayoutLeft, Kokkos::complex<double>, std::complex<double>,           \
-                                       Kokkos::SYCL, Kokkos::SYCLDeviceUSMSpace,        \
-                                       oneapi::mkl::blas::row_major::dotc, ETI_SPEC_AVAIL)
+#define KOKKOSBLAS1_DOT_TPL_SPEC_DECL_ONEMKL_EXT(ETI_SPEC_AVAIL)                                                       \
+  KOKKOSBLAS1_DOT_TPL_SPEC_DECL_ONEMKL(Kokkos::LayoutLeft, float, float, Kokkos::SYCL, Kokkos::SYCLDeviceUSMSpace,     \
+                                       oneapi::mkl::blas::row_major::dot, ETI_SPEC_AVAIL)                              \
+  KOKKOSBLAS1_DOT_TPL_SPEC_DECL_ONEMKL(Kokkos::LayoutLeft, double, double, Kokkos::SYCL, Kokkos::SYCLDeviceUSMSpace,   \
+                                       oneapi::mkl::blas::row_major::dot, ETI_SPEC_AVAIL)                              \
+  KOKKOSBLAS1_DOT_TPL_SPEC_DECL_ONEMKL(Kokkos::LayoutLeft, Kokkos::complex<float>, std::complex<float>, Kokkos::SYCL,  \
+                                       Kokkos::SYCLDeviceUSMSpace, oneapi::mkl::blas::row_major::dotc, ETI_SPEC_AVAIL) \
+  KOKKOSBLAS1_DOT_TPL_SPEC_DECL_ONEMKL(Kokkos::LayoutLeft, Kokkos::complex<double>, std::complex<double>,              \
+                                       Kokkos::SYCL, Kokkos::SYCLDeviceUSMSpace, oneapi::mkl::blas::row_major::dotc,   \
+                                       ETI_SPEC_AVAIL)
 
 KOKKOSBLAS1_DOT_TPL_SPEC_DECL_ONEMKL_EXT(true)
 KOKKOSBLAS1_DOT_TPL_SPEC_DECL_ONEMKL_EXT(false)

--- a/blas/tpls/KokkosBlas1_dot_tpl_spec_decl.hpp
+++ b/blas/tpls/KokkosBlas1_dot_tpl_spec_decl.hpp
@@ -236,17 +236,17 @@ namespace Impl {
   };
 
 #define KOKKOSBLAS1_DOT_TPL_SPEC_DECL_ONEMKL_EXT(ETI_SPEC_AVAIL)                                                    \
-  KOKKOSBLAS1_DOT_TPL_SPEC_DECL_ONEMKL(Kokkos::LayoutLeft, float, float, Kokkos::Experimental::SYCL,                \
-                                       Kokkos::Experimental::SYCLDeviceUSMSpace, oneapi::mkl::blas::row_major::dot, \
+  KOKKOSBLAS1_DOT_TPL_SPEC_DECL_ONEMKL(Kokkos::LayoutLeft, float, float, Kokkos::SYCL,                \
+                                       Kokkos::SYCLDeviceUSMSpace, oneapi::mkl::blas::row_major::dot, \
                                        ETI_SPEC_AVAIL)                                                              \
-  KOKKOSBLAS1_DOT_TPL_SPEC_DECL_ONEMKL(Kokkos::LayoutLeft, double, double, Kokkos::Experimental::SYCL,              \
-                                       Kokkos::Experimental::SYCLDeviceUSMSpace, oneapi::mkl::blas::row_major::dot, \
+  KOKKOSBLAS1_DOT_TPL_SPEC_DECL_ONEMKL(Kokkos::LayoutLeft, double, double, Kokkos::SYCL,              \
+                                       Kokkos::SYCLDeviceUSMSpace, oneapi::mkl::blas::row_major::dot, \
                                        ETI_SPEC_AVAIL)                                                              \
   KOKKOSBLAS1_DOT_TPL_SPEC_DECL_ONEMKL(Kokkos::LayoutLeft, Kokkos::complex<float>, std::complex<float>,             \
-                                       Kokkos::Experimental::SYCL, Kokkos::Experimental::SYCLDeviceUSMSpace,        \
+                                       Kokkos::SYCL, Kokkos::SYCLDeviceUSMSpace,        \
                                        oneapi::mkl::blas::row_major::dotc, ETI_SPEC_AVAIL)                          \
   KOKKOSBLAS1_DOT_TPL_SPEC_DECL_ONEMKL(Kokkos::LayoutLeft, Kokkos::complex<double>, std::complex<double>,           \
-                                       Kokkos::Experimental::SYCL, Kokkos::Experimental::SYCLDeviceUSMSpace,        \
+                                       Kokkos::SYCL, Kokkos::SYCLDeviceUSMSpace,        \
                                        oneapi::mkl::blas::row_major::dotc, ETI_SPEC_AVAIL)
 
 KOKKOSBLAS1_DOT_TPL_SPEC_DECL_ONEMKL_EXT(true)

--- a/blas/tpls/KokkosBlas1_nrm1_tpl_spec_avail.hpp
+++ b/blas/tpls/KokkosBlas1_nrm1_tpl_spec_avail.hpp
@@ -95,12 +95,12 @@ KOKKOSBLAS1_NRM1_TPL_SPEC_AVAIL_ROCBLAS(Kokkos::complex<float>, Kokkos::LayoutLe
     enum : bool { value = true };                                                                                     \
   };
 
-KOKKOSBLAS1_NRM1_TPL_SPEC_AVAIL_MKL_SYCL(double, Kokkos::LayoutLeft, Kokkos::Experimental::SYCLDeviceUSMSpace)
-KOKKOSBLAS1_NRM1_TPL_SPEC_AVAIL_MKL_SYCL(float, Kokkos::LayoutLeft, Kokkos::Experimental::SYCLDeviceUSMSpace)
+KOKKOSBLAS1_NRM1_TPL_SPEC_AVAIL_MKL_SYCL(double, Kokkos::LayoutLeft, Kokkos::SYCLDeviceUSMSpace)
+KOKKOSBLAS1_NRM1_TPL_SPEC_AVAIL_MKL_SYCL(float, Kokkos::LayoutLeft, Kokkos::SYCLDeviceUSMSpace)
 KOKKOSBLAS1_NRM1_TPL_SPEC_AVAIL_MKL_SYCL(Kokkos::complex<double>, Kokkos::LayoutLeft,
-                                         Kokkos::Experimental::SYCLDeviceUSMSpace)
+                                         Kokkos::SYCLDeviceUSMSpace)
 KOKKOSBLAS1_NRM1_TPL_SPEC_AVAIL_MKL_SYCL(Kokkos::complex<float>, Kokkos::LayoutLeft,
-                                         Kokkos::Experimental::SYCLDeviceUSMSpace)
+                                         Kokkos::SYCLDeviceUSMSpace)
 
 #endif  // KOKKOS_ENABLE_SYCL
 #endif  // KOKKOSKERNELS_ENABLE_TPL_MKL

--- a/blas/tpls/KokkosBlas1_nrm1_tpl_spec_avail.hpp
+++ b/blas/tpls/KokkosBlas1_nrm1_tpl_spec_avail.hpp
@@ -97,10 +97,8 @@ KOKKOSBLAS1_NRM1_TPL_SPEC_AVAIL_ROCBLAS(Kokkos::complex<float>, Kokkos::LayoutLe
 
 KOKKOSBLAS1_NRM1_TPL_SPEC_AVAIL_MKL_SYCL(double, Kokkos::LayoutLeft, Kokkos::SYCLDeviceUSMSpace)
 KOKKOSBLAS1_NRM1_TPL_SPEC_AVAIL_MKL_SYCL(float, Kokkos::LayoutLeft, Kokkos::SYCLDeviceUSMSpace)
-KOKKOSBLAS1_NRM1_TPL_SPEC_AVAIL_MKL_SYCL(Kokkos::complex<double>, Kokkos::LayoutLeft,
-                                         Kokkos::SYCLDeviceUSMSpace)
-KOKKOSBLAS1_NRM1_TPL_SPEC_AVAIL_MKL_SYCL(Kokkos::complex<float>, Kokkos::LayoutLeft,
-                                         Kokkos::SYCLDeviceUSMSpace)
+KOKKOSBLAS1_NRM1_TPL_SPEC_AVAIL_MKL_SYCL(Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::SYCLDeviceUSMSpace)
+KOKKOSBLAS1_NRM1_TPL_SPEC_AVAIL_MKL_SYCL(Kokkos::complex<float>, Kokkos::LayoutLeft, Kokkos::SYCLDeviceUSMSpace)
 
 #endif  // KOKKOS_ENABLE_SYCL
 #endif  // KOKKOSKERNELS_ENABLE_TPL_MKL

--- a/blas/tpls/KokkosBlas1_nrm1_tpl_spec_decl.hpp
+++ b/blas/tpls/KokkosBlas1_nrm1_tpl_spec_decl.hpp
@@ -292,38 +292,36 @@ void onemklAsumWrapper(const ExecutionSpace& space, RViewType& R, const XViewTyp
   Kokkos::deep_copy(space, R, res);
 }
 
-#define KOKKOSBLAS1_NRM1_ONEMKL(SCALAR, LAYOUT, MEMSPACE)                                                              \
-  template <>                                                                                                          \
-  struct Nrm1<                                                                                                         \
-      Kokkos::SYCL,                                                                                      \
-      Kokkos::View<typename KokkosKernels::ArithTraits<SCALAR>::mag_type, LAYOUT, Kokkos::HostSpace,                   \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                           \
-      Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<Kokkos::SYCL, MEMSPACE>,                        \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                           \
-      1, true,                                                                                                         \
-      nrm1_eti_spec_avail<Kokkos::SYCL,                                                                  \
-                          Kokkos::View<typename KokkosKernels::ArithTraits<SCALAR>::mag_type, LAYOUT,                  \
-                                       Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                    \
-                          Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<Kokkos::SYCL, MEMSPACE>,    \
-                                       Kokkos::MemoryTraits<Kokkos::Unmanaged>>>::value> {                             \
-    using execution_space = Kokkos::SYCL;                                                                \
-    using RV        = Kokkos::View<typename KokkosKernels::ArithTraits<SCALAR>::mag_type, LAYOUT, Kokkos::HostSpace,   \
-                            Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                           \
-    using XV        = Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<Kokkos::SYCL, MEMSPACE>,        \
-                            Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                           \
-    using size_type = typename XV::size_type;                                                                          \
-                                                                                                                       \
-    static void nrm1(const execution_space& space, RV& R, const XV& X) {                                               \
-      Kokkos::Profiling::pushRegion("KokkosBlas::nrm1[TPL_ONEMKL," #SCALAR "]");                                       \
-      const size_type numElems = X.extent(0);                                                                          \
-      if (numElems < static_cast<size_type>(INT_MAX)) {                                                                \
-        onemklAsumWrapper(space, R, X);                                                                                \
-      } else {                                                                                                         \
-        Nrm1<execution_space, RV, XV, 1, false, nrm1_eti_spec_avail<Kokkos::SYCL, RV, XV>::value>::nrm1( \
-            space, R, X);                                                                                              \
-      }                                                                                                                \
-      Kokkos::Profiling::popRegion();                                                                                  \
-    }                                                                                                                  \
+#define KOKKOSBLAS1_NRM1_ONEMKL(SCALAR, LAYOUT, MEMSPACE)                                                             \
+  template <>                                                                                                         \
+  struct Nrm1<Kokkos::SYCL,                                                                                           \
+              Kokkos::View<typename KokkosKernels::ArithTraits<SCALAR>::mag_type, LAYOUT, Kokkos::HostSpace,          \
+                           Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                  \
+              Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<Kokkos::SYCL, MEMSPACE>,                             \
+                           Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                  \
+              1, true,                                                                                                \
+              nrm1_eti_spec_avail<Kokkos::SYCL,                                                                       \
+                                  Kokkos::View<typename KokkosKernels::ArithTraits<SCALAR>::mag_type, LAYOUT,         \
+                                               Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,           \
+                                  Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<Kokkos::SYCL, MEMSPACE>,         \
+                                               Kokkos::MemoryTraits<Kokkos::Unmanaged>>>::value> {                    \
+    using execution_space = Kokkos::SYCL;                                                                             \
+    using RV        = Kokkos::View<typename KokkosKernels::ArithTraits<SCALAR>::mag_type, LAYOUT, Kokkos::HostSpace,  \
+                            Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                          \
+    using XV        = Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<Kokkos::SYCL, MEMSPACE>,                     \
+                            Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                          \
+    using size_type = typename XV::size_type;                                                                         \
+                                                                                                                      \
+    static void nrm1(const execution_space& space, RV& R, const XV& X) {                                              \
+      Kokkos::Profiling::pushRegion("KokkosBlas::nrm1[TPL_ONEMKL," #SCALAR "]");                                      \
+      const size_type numElems = X.extent(0);                                                                         \
+      if (numElems < static_cast<size_type>(INT_MAX)) {                                                               \
+        onemklAsumWrapper(space, R, X);                                                                               \
+      } else {                                                                                                        \
+        Nrm1<execution_space, RV, XV, 1, false, nrm1_eti_spec_avail<Kokkos::SYCL, RV, XV>::value>::nrm1(space, R, X); \
+      }                                                                                                               \
+      Kokkos::Profiling::popRegion();                                                                                 \
+    }                                                                                                                 \
   };
 
 KOKKOSBLAS1_NRM1_ONEMKL(float, Kokkos::LayoutLeft, Kokkos::SYCLDeviceUSMSpace)

--- a/blas/tpls/KokkosBlas1_nrm1_tpl_spec_decl.hpp
+++ b/blas/tpls/KokkosBlas1_nrm1_tpl_spec_decl.hpp
@@ -295,21 +295,21 @@ void onemklAsumWrapper(const ExecutionSpace& space, RViewType& R, const XViewTyp
 #define KOKKOSBLAS1_NRM1_ONEMKL(SCALAR, LAYOUT, MEMSPACE)                                                              \
   template <>                                                                                                          \
   struct Nrm1<                                                                                                         \
-      Kokkos::Experimental::SYCL,                                                                                      \
+      Kokkos::SYCL,                                                                                      \
       Kokkos::View<typename KokkosKernels::ArithTraits<SCALAR>::mag_type, LAYOUT, Kokkos::HostSpace,                   \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                           \
-      Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<Kokkos::Experimental::SYCL, MEMSPACE>,                        \
+      Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<Kokkos::SYCL, MEMSPACE>,                        \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                           \
       1, true,                                                                                                         \
-      nrm1_eti_spec_avail<Kokkos::Experimental::SYCL,                                                                  \
+      nrm1_eti_spec_avail<Kokkos::SYCL,                                                                  \
                           Kokkos::View<typename KokkosKernels::ArithTraits<SCALAR>::mag_type, LAYOUT,                  \
                                        Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                    \
-                          Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<Kokkos::Experimental::SYCL, MEMSPACE>,    \
+                          Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<Kokkos::SYCL, MEMSPACE>,    \
                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>>::value> {                             \
-    using execution_space = Kokkos::Experimental::SYCL;                                                                \
+    using execution_space = Kokkos::SYCL;                                                                \
     using RV        = Kokkos::View<typename KokkosKernels::ArithTraits<SCALAR>::mag_type, LAYOUT, Kokkos::HostSpace,   \
                             Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                           \
-    using XV        = Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<Kokkos::Experimental::SYCL, MEMSPACE>,        \
+    using XV        = Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<Kokkos::SYCL, MEMSPACE>,        \
                             Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                           \
     using size_type = typename XV::size_type;                                                                          \
                                                                                                                        \
@@ -319,23 +319,23 @@ void onemklAsumWrapper(const ExecutionSpace& space, RViewType& R, const XViewTyp
       if (numElems < static_cast<size_type>(INT_MAX)) {                                                                \
         onemklAsumWrapper(space, R, X);                                                                                \
       } else {                                                                                                         \
-        Nrm1<execution_space, RV, XV, 1, false, nrm1_eti_spec_avail<Kokkos::Experimental::SYCL, RV, XV>::value>::nrm1( \
+        Nrm1<execution_space, RV, XV, 1, false, nrm1_eti_spec_avail<Kokkos::SYCL, RV, XV>::value>::nrm1( \
             space, R, X);                                                                                              \
       }                                                                                                                \
       Kokkos::Profiling::popRegion();                                                                                  \
     }                                                                                                                  \
   };
 
-KOKKOSBLAS1_NRM1_ONEMKL(float, Kokkos::LayoutLeft, Kokkos::Experimental::SYCLDeviceUSMSpace)
-KOKKOSBLAS1_NRM1_ONEMKL(double, Kokkos::LayoutLeft, Kokkos::Experimental::SYCLDeviceUSMSpace)
-KOKKOSBLAS1_NRM1_ONEMKL(Kokkos::complex<float>, Kokkos::LayoutLeft, Kokkos::Experimental::SYCLDeviceUSMSpace)
-KOKKOSBLAS1_NRM1_ONEMKL(Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::Experimental::SYCLDeviceUSMSpace)
+KOKKOSBLAS1_NRM1_ONEMKL(float, Kokkos::LayoutLeft, Kokkos::SYCLDeviceUSMSpace)
+KOKKOSBLAS1_NRM1_ONEMKL(double, Kokkos::LayoutLeft, Kokkos::SYCLDeviceUSMSpace)
+KOKKOSBLAS1_NRM1_ONEMKL(Kokkos::complex<float>, Kokkos::LayoutLeft, Kokkos::SYCLDeviceUSMSpace)
+KOKKOSBLAS1_NRM1_ONEMKL(Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::SYCLDeviceUSMSpace)
 
 #if defined(KOKKOSKERNELS_INST_MEMSPACE_SYCLSHAREDSPACE)
-KOKKOSBLAS1_NRM1_ONEMKL(float, Kokkos::LayoutLeft, Kokkos::Experimental::SYCLSharedUSMSpace)
-KOKKOSBLAS1_NRM1_ONEMKL(double, Kokkos::LayoutLeft, Kokkos::Experimental::SYCLSharedUSMSpace)
-KOKKOSBLAS1_NRM1_ONEMKL(Kokkos::complex<float>, Kokkos::LayoutLeft, Kokkos::Experimental::SYCLSharedUSMSpace)
-KOKKOSBLAS1_NRM1_ONEMKL(Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::Experimental::SYCLSharedUSMSpace)
+KOKKOSBLAS1_NRM1_ONEMKL(float, Kokkos::LayoutLeft, Kokkos::SYCLSharedUSMSpace)
+KOKKOSBLAS1_NRM1_ONEMKL(double, Kokkos::LayoutLeft, Kokkos::SYCLSharedUSMSpace)
+KOKKOSBLAS1_NRM1_ONEMKL(Kokkos::complex<float>, Kokkos::LayoutLeft, Kokkos::SYCLSharedUSMSpace)
+KOKKOSBLAS1_NRM1_ONEMKL(Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::SYCLSharedUSMSpace)
 #endif
 
 }  // namespace Impl

--- a/blas/tpls/KokkosBlas1_nrm2_tpl_spec_avail.hpp
+++ b/blas/tpls/KokkosBlas1_nrm2_tpl_spec_avail.hpp
@@ -63,8 +63,7 @@ KOKKOSBLAS1_NRM2_TPL_SPEC_AVAIL(Kokkos::LayoutLeft, Kokkos::HIP, Kokkos::HIPSpac
 #endif
 
 #if defined(KOKKOSKERNELS_ENABLE_TPL_MKL) && defined(KOKKOS_ENABLE_SYCL)
-KOKKOSBLAS1_NRM2_TPL_SPEC_AVAIL(Kokkos::LayoutLeft, Kokkos::SYCL,
-                                Kokkos::SYCLDeviceUSMSpace)
+KOKKOSBLAS1_NRM2_TPL_SPEC_AVAIL(Kokkos::LayoutLeft, Kokkos::SYCL, Kokkos::SYCLDeviceUSMSpace)
 #endif
 
 }  // namespace Impl

--- a/blas/tpls/KokkosBlas1_nrm2_tpl_spec_avail.hpp
+++ b/blas/tpls/KokkosBlas1_nrm2_tpl_spec_avail.hpp
@@ -63,8 +63,8 @@ KOKKOSBLAS1_NRM2_TPL_SPEC_AVAIL(Kokkos::LayoutLeft, Kokkos::HIP, Kokkos::HIPSpac
 #endif
 
 #if defined(KOKKOSKERNELS_ENABLE_TPL_MKL) && defined(KOKKOS_ENABLE_SYCL)
-KOKKOSBLAS1_NRM2_TPL_SPEC_AVAIL(Kokkos::LayoutLeft, Kokkos::Experimental::SYCL,
-                                Kokkos::Experimental::SYCLDeviceUSMSpace)
+KOKKOSBLAS1_NRM2_TPL_SPEC_AVAIL(Kokkos::LayoutLeft, Kokkos::SYCL,
+                                Kokkos::SYCLDeviceUSMSpace)
 #endif
 
 }  // namespace Impl

--- a/blas/tpls/KokkosBlas1_nrm2_tpl_spec_decl.hpp
+++ b/blas/tpls/KokkosBlas1_nrm2_tpl_spec_decl.hpp
@@ -315,17 +315,17 @@ namespace Impl {
   };
 
 #define KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_ONEMKL_EXT(ETI_SPEC_AVAIL)                                                     \
-  KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_ONEMKL(Kokkos::LayoutLeft, float, float, Kokkos::Experimental::SYCL,                 \
-                                        Kokkos::Experimental::SYCLDeviceUSMSpace, oneapi::mkl::blas::row_major::nrm2, \
+  KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_ONEMKL(Kokkos::LayoutLeft, float, float, Kokkos::SYCL,                 \
+                                        Kokkos::SYCLDeviceUSMSpace, oneapi::mkl::blas::row_major::nrm2, \
                                         ETI_SPEC_AVAIL)                                                               \
-  KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_ONEMKL(Kokkos::LayoutLeft, double, double, Kokkos::Experimental::SYCL,               \
-                                        Kokkos::Experimental::SYCLDeviceUSMSpace, oneapi::mkl::blas::row_major::nrm2, \
+  KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_ONEMKL(Kokkos::LayoutLeft, double, double, Kokkos::SYCL,               \
+                                        Kokkos::SYCLDeviceUSMSpace, oneapi::mkl::blas::row_major::nrm2, \
                                         ETI_SPEC_AVAIL)                                                               \
   KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_ONEMKL(Kokkos::LayoutLeft, Kokkos::complex<float>, std::complex<float>,              \
-                                        Kokkos::Experimental::SYCL, Kokkos::Experimental::SYCLDeviceUSMSpace,         \
+                                        Kokkos::SYCL, Kokkos::SYCLDeviceUSMSpace,         \
                                         oneapi::mkl::blas::row_major::nrm2, ETI_SPEC_AVAIL)                           \
   KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_ONEMKL(Kokkos::LayoutLeft, Kokkos::complex<double>, std::complex<double>,            \
-                                        Kokkos::Experimental::SYCL, Kokkos::Experimental::SYCLDeviceUSMSpace,         \
+                                        Kokkos::SYCL, Kokkos::SYCLDeviceUSMSpace,         \
                                         oneapi::mkl::blas::row_major::nrm2, ETI_SPEC_AVAIL)
 
 KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_ONEMKL_EXT(true)

--- a/blas/tpls/KokkosBlas1_nrm2_tpl_spec_decl.hpp
+++ b/blas/tpls/KokkosBlas1_nrm2_tpl_spec_decl.hpp
@@ -314,19 +314,17 @@ namespace Impl {
     }                                                                                                                  \
   };
 
-#define KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_ONEMKL_EXT(ETI_SPEC_AVAIL)                                                     \
-  KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_ONEMKL(Kokkos::LayoutLeft, float, float, Kokkos::SYCL,                 \
-                                        Kokkos::SYCLDeviceUSMSpace, oneapi::mkl::blas::row_major::nrm2, \
-                                        ETI_SPEC_AVAIL)                                                               \
-  KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_ONEMKL(Kokkos::LayoutLeft, double, double, Kokkos::SYCL,               \
-                                        Kokkos::SYCLDeviceUSMSpace, oneapi::mkl::blas::row_major::nrm2, \
-                                        ETI_SPEC_AVAIL)                                                               \
-  KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_ONEMKL(Kokkos::LayoutLeft, Kokkos::complex<float>, std::complex<float>,              \
-                                        Kokkos::SYCL, Kokkos::SYCLDeviceUSMSpace,         \
-                                        oneapi::mkl::blas::row_major::nrm2, ETI_SPEC_AVAIL)                           \
-  KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_ONEMKL(Kokkos::LayoutLeft, Kokkos::complex<double>, std::complex<double>,            \
-                                        Kokkos::SYCL, Kokkos::SYCLDeviceUSMSpace,         \
-                                        oneapi::mkl::blas::row_major::nrm2, ETI_SPEC_AVAIL)
+#define KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_ONEMKL_EXT(ETI_SPEC_AVAIL)                                                      \
+  KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_ONEMKL(Kokkos::LayoutLeft, float, float, Kokkos::SYCL, Kokkos::SYCLDeviceUSMSpace,    \
+                                        oneapi::mkl::blas::row_major::nrm2, ETI_SPEC_AVAIL)                            \
+  KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_ONEMKL(Kokkos::LayoutLeft, double, double, Kokkos::SYCL, Kokkos::SYCLDeviceUSMSpace,  \
+                                        oneapi::mkl::blas::row_major::nrm2, ETI_SPEC_AVAIL)                            \
+  KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_ONEMKL(Kokkos::LayoutLeft, Kokkos::complex<float>, std::complex<float>, Kokkos::SYCL, \
+                                        Kokkos::SYCLDeviceUSMSpace, oneapi::mkl::blas::row_major::nrm2,                \
+                                        ETI_SPEC_AVAIL)                                                                \
+  KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_ONEMKL(Kokkos::LayoutLeft, Kokkos::complex<double>, std::complex<double>,             \
+                                        Kokkos::SYCL, Kokkos::SYCLDeviceUSMSpace, oneapi::mkl::blas::row_major::nrm2,  \
+                                        ETI_SPEC_AVAIL)
 
 KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_ONEMKL_EXT(true)
 KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_ONEMKL_EXT(false)

--- a/blas/tpls/KokkosBlas2_gemv_tpl_spec_avail.hpp
+++ b/blas/tpls/KokkosBlas2_gemv_tpl_spec_avail.hpp
@@ -123,13 +123,13 @@ KOKKOSBLAS2_GEMV_TPL_SPEC_AVAIL_ROCBLAS(Kokkos::complex<float>, Kokkos::LayoutRi
   struct gemv_tpl_spec_avail<                                                                            \
       ExecSpace,                                                                                         \
       Kokkos::View<const SCALAR**, LAYOUT,                                                               \
-                   Kokkos::Device<Kokkos::Experimental::SYCL, Kokkos::Experimental::SYCLDeviceUSMSpace>, \
+                   Kokkos::Device<Kokkos::SYCL, Kokkos::SYCLDeviceUSMSpace>, \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                            \
       Kokkos::View<const SCALAR*, LAYOUT,                                                                \
-                   Kokkos::Device<Kokkos::Experimental::SYCL, Kokkos::Experimental::SYCLDeviceUSMSpace>, \
+                   Kokkos::Device<Kokkos::SYCL, Kokkos::SYCLDeviceUSMSpace>, \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                            \
       Kokkos::View<SCALAR*, LAYOUT,                                                                      \
-                   Kokkos::Device<Kokkos::Experimental::SYCL, Kokkos::Experimental::SYCLDeviceUSMSpace>, \
+                   Kokkos::Device<Kokkos::SYCL, Kokkos::SYCLDeviceUSMSpace>, \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged> > > {                                         \
     enum : bool { value = true };                                                                        \
   };

--- a/blas/tpls/KokkosBlas2_gemv_tpl_spec_avail.hpp
+++ b/blas/tpls/KokkosBlas2_gemv_tpl_spec_avail.hpp
@@ -118,20 +118,17 @@ KOKKOSBLAS2_GEMV_TPL_SPEC_AVAIL_ROCBLAS(Kokkos::complex<float>, Kokkos::LayoutRi
 
 #if defined(KOKKOS_ENABLE_SYCL)
 
-#define KOKKOSBLAS2_GEMV_TPL_SPEC_AVAIL_ONEMKL(SCALAR, LAYOUT)                                           \
-  template <class ExecSpace>                                                                             \
-  struct gemv_tpl_spec_avail<                                                                            \
-      ExecSpace,                                                                                         \
-      Kokkos::View<const SCALAR**, LAYOUT,                                                               \
-                   Kokkos::Device<Kokkos::SYCL, Kokkos::SYCLDeviceUSMSpace>, \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                            \
-      Kokkos::View<const SCALAR*, LAYOUT,                                                                \
-                   Kokkos::Device<Kokkos::SYCL, Kokkos::SYCLDeviceUSMSpace>, \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                            \
-      Kokkos::View<SCALAR*, LAYOUT,                                                                      \
-                   Kokkos::Device<Kokkos::SYCL, Kokkos::SYCLDeviceUSMSpace>, \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> > > {                                         \
-    enum : bool { value = true };                                                                        \
+#define KOKKOSBLAS2_GEMV_TPL_SPEC_AVAIL_ONEMKL(SCALAR, LAYOUT)                                       \
+  template <class ExecSpace>                                                                         \
+  struct gemv_tpl_spec_avail<                                                                        \
+      ExecSpace,                                                                                     \
+      Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<Kokkos::SYCL, Kokkos::SYCLDeviceUSMSpace>, \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                        \
+      Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<Kokkos::SYCL, Kokkos::SYCLDeviceUSMSpace>,  \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                        \
+      Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<Kokkos::SYCL, Kokkos::SYCLDeviceUSMSpace>,        \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> > > {                                     \
+    enum : bool { value = true };                                                                    \
   };
 
 KOKKOSBLAS2_GEMV_TPL_SPEC_AVAIL_ONEMKL(double, Kokkos::LayoutLeft)

--- a/blas/tpls/KokkosBlas2_gemv_tpl_spec_decl.hpp
+++ b/blas/tpls/KokkosBlas2_gemv_tpl_spec_decl.hpp
@@ -613,11 +613,11 @@ struct kokkos_to_std_type_map<T, true> {
 #define KOKKOSBLAS2_GEMV_ONEMKL(SCALAR, LAYOUT, MEM_SPACE, ETI_SPEC_AVAIL)                                              \
   template <class ExecSpace>                                                                                            \
   struct GEMV<ExecSpace,                                                                                                \
-              Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<Kokkos::SYCL, MEM_SPACE>,               \
+              Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<Kokkos::SYCL, MEM_SPACE>,                             \
                            Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                   \
-              Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<Kokkos::SYCL, MEM_SPACE>,                \
+              Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<Kokkos::SYCL, MEM_SPACE>,                              \
                            Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                   \
-              Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<Kokkos::SYCL, MEM_SPACE>,                      \
+              Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<Kokkos::SYCL, MEM_SPACE>,                                    \
                            Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                   \
               true, ETI_SPEC_AVAIL> {                                                                                   \
     using device_type = Kokkos::Device<ExecSpace, MEM_SPACE>;                                                           \

--- a/blas/tpls/KokkosBlas2_gemv_tpl_spec_decl.hpp
+++ b/blas/tpls/KokkosBlas2_gemv_tpl_spec_decl.hpp
@@ -613,11 +613,11 @@ struct kokkos_to_std_type_map<T, true> {
 #define KOKKOSBLAS2_GEMV_ONEMKL(SCALAR, LAYOUT, MEM_SPACE, ETI_SPEC_AVAIL)                                              \
   template <class ExecSpace>                                                                                            \
   struct GEMV<ExecSpace,                                                                                                \
-              Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Experimental::SYCL, MEM_SPACE>,               \
+              Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<Kokkos::SYCL, MEM_SPACE>,               \
                            Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                   \
-              Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<Kokkos::Experimental::SYCL, MEM_SPACE>,                \
+              Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<Kokkos::SYCL, MEM_SPACE>,                \
                            Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                   \
-              Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<Kokkos::Experimental::SYCL, MEM_SPACE>,                      \
+              Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<Kokkos::SYCL, MEM_SPACE>,                      \
                            Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                   \
               true, ETI_SPEC_AVAIL> {                                                                                   \
     using device_type = Kokkos::Device<ExecSpace, MEM_SPACE>;                                                           \
@@ -654,14 +654,14 @@ struct kokkos_to_std_type_map<T, true> {
     }                                                                                                                   \
   };
 
-KOKKOSBLAS2_GEMV_ONEMKL(float, Kokkos::LayoutLeft, Kokkos::Experimental::SYCLDeviceUSMSpace, true)
-KOKKOSBLAS2_GEMV_ONEMKL(float, Kokkos::LayoutRight, Kokkos::Experimental::SYCLDeviceUSMSpace, true)
-KOKKOSBLAS2_GEMV_ONEMKL(double, Kokkos::LayoutLeft, Kokkos::Experimental::SYCLDeviceUSMSpace, true)
-KOKKOSBLAS2_GEMV_ONEMKL(double, Kokkos::LayoutRight, Kokkos::Experimental::SYCLDeviceUSMSpace, true)
-KOKKOSBLAS2_GEMV_ONEMKL(Kokkos::complex<float>, Kokkos::LayoutLeft, Kokkos::Experimental::SYCLDeviceUSMSpace, true)
-KOKKOSBLAS2_GEMV_ONEMKL(Kokkos::complex<float>, Kokkos::LayoutRight, Kokkos::Experimental::SYCLDeviceUSMSpace, true)
-KOKKOSBLAS2_GEMV_ONEMKL(Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::Experimental::SYCLDeviceUSMSpace, true)
-KOKKOSBLAS2_GEMV_ONEMKL(Kokkos::complex<double>, Kokkos::LayoutRight, Kokkos::Experimental::SYCLDeviceUSMSpace, true)
+KOKKOSBLAS2_GEMV_ONEMKL(float, Kokkos::LayoutLeft, Kokkos::SYCLDeviceUSMSpace, true)
+KOKKOSBLAS2_GEMV_ONEMKL(float, Kokkos::LayoutRight, Kokkos::SYCLDeviceUSMSpace, true)
+KOKKOSBLAS2_GEMV_ONEMKL(double, Kokkos::LayoutLeft, Kokkos::SYCLDeviceUSMSpace, true)
+KOKKOSBLAS2_GEMV_ONEMKL(double, Kokkos::LayoutRight, Kokkos::SYCLDeviceUSMSpace, true)
+KOKKOSBLAS2_GEMV_ONEMKL(Kokkos::complex<float>, Kokkos::LayoutLeft, Kokkos::SYCLDeviceUSMSpace, true)
+KOKKOSBLAS2_GEMV_ONEMKL(Kokkos::complex<float>, Kokkos::LayoutRight, Kokkos::SYCLDeviceUSMSpace, true)
+KOKKOSBLAS2_GEMV_ONEMKL(Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::SYCLDeviceUSMSpace, true)
+KOKKOSBLAS2_GEMV_ONEMKL(Kokkos::complex<double>, Kokkos::LayoutRight, Kokkos::SYCLDeviceUSMSpace, true)
 }  // namespace Impl
 }  // namespace KokkosBlas
 #endif

--- a/blas/unit_test/Test_Blas2_gemv.hpp
+++ b/blas/unit_test/Test_Blas2_gemv.hpp
@@ -226,7 +226,7 @@ TEST_F(TestCategory, gemv_double) {
     (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F(TestCategory, gemv_complex_double) {
 #if defined(KOKKOS_ENABLE_SYCL)
-  constexpr bool skip_complex = std::is_same_v<typename TestDevice::execution_space, Kokkos::Experimental::SYCL>;
+  constexpr bool skip_complex = std::is_same_v<typename TestDevice::execution_space, Kokkos::SYCL>;
 #else
   constexpr bool skip_complex = false;
 #endif

--- a/blas/unit_test/Test_Blas2_gemv_util.hpp
+++ b/blas/unit_test/Test_Blas2_gemv_util.hpp
@@ -92,7 +92,7 @@ template <class GemvFunc, class ScalarA, class ScalarX, class ScalarY, class Dev
 struct GEMVTest {
   static void run(const char *mode) {
 #if defined(KOKKOS_ENABLE_SYCL)
-    constexpr bool skip_complex = std::is_same_v<typename Device::execution_space, Kokkos::Experimental::SYCL> &&
+    constexpr bool skip_complex = std::is_same_v<typename Device::execution_space, Kokkos::SYCL> &&
                                   KokkosKernels::ArithTraits<ScalarA>::is_complex;
 #else
     constexpr bool skip_complex = false;

--- a/blas/unit_test/Test_Blas3_gemm.hpp
+++ b/blas/unit_test/Test_Blas3_gemm.hpp
@@ -382,7 +382,7 @@ TEST_F(TestCategory, gemm_double) {
     (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F(TestCategory, gemm_complex_double) {
 #if defined(KOKKOS_ENABLE_SYCL)
-  constexpr bool skip_complex = std::is_same_v<typename TestDevice::execution_space, Kokkos::Experimental::SYCL>;
+  constexpr bool skip_complex = std::is_same_v<typename TestDevice::execution_space, Kokkos::SYCL>;
 #else
   constexpr bool skip_complex = false;
 #endif
@@ -400,7 +400,7 @@ TEST_F(TestCategory, gemm_complex_double) {
     (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
 TEST_F(TestCategory, gemm_complex_float) {
 #if defined(KOKKOS_ENABLE_SYCL)
-  constexpr bool skip_complex = std::is_same_v<typename TestDevice::execution_space, Kokkos::Experimental::SYCL>;
+  constexpr bool skip_complex = std::is_same_v<typename TestDevice::execution_space, Kokkos::SYCL>;
 #else
   constexpr bool skip_complex = false;
 #endif

--- a/cmake/KokkosKernels_config.h.in
+++ b/cmake/KokkosKernels_config.h.in
@@ -53,13 +53,10 @@
 #cmakedefine KOKKOSKERNELS_INST_EXECSPACE_HIP
 #cmakedefine KOKKOSKERNELS_INST_MEMSPACE_HIPSPACE
 #cmakedefine KOKKOSKERNELS_INST_MEMSPACE_HIPMANAGEDSPACE
-/* Whether to build kernels for execution space Kokkos::Experimental::SYCL */
+/* Whether to build kernels for execution space Kokkos::SYCL */
 #cmakedefine KOKKOSKERNELS_INST_EXECSPACE_SYCL
 #cmakedefine KOKKOSKERNELS_INST_MEMSPACE_SYCLSPACE
 #cmakedefine KOKKOSKERNELS_INST_MEMSPACE_SYCLSHAREDSPACE
-/* Whether to build kernels for execution space Kokkos::Experimental::OpenMPTarget */
-#cmakedefine KOKKOSKERNELS_INST_EXECSPACE_OPENMPTARGET
-#cmakedefine KOKKOSKERNELS_INST_MEMSPACE_OPENMPTARGETSPACE
 /* Whether to build kernels for execution space Kokkos::OpenMP */
 #cmakedefine KOKKOSKERNELS_INST_EXECSPACE_OPENMP
 /* Whether to build kernels for execution space Kokkos::Threads */

--- a/cmake/kokkoskernels_eti_devices.cmake
+++ b/cmake/kokkoskernels_eti_devices.cmake
@@ -11,7 +11,7 @@ set(EXEC_SPACES
     EXECSPACE_SERIAL)
 set(EXECSPACE_CUDA_CPP_TYPE          Kokkos::Cuda)
 set(EXECSPACE_HIP_CPP_TYPE           Kokkos::HIP)
-set(EXECSPACE_SYCL_CPP_TYPE          Kokkos::Experimental::SYCL)
+set(EXECSPACE_SYCL_CPP_TYPE          Kokkos::SYCL)
 set(EXECSPACE_OPENMP_CPP_TYPE        Kokkos::OpenMP)
 set(EXECSPACE_THREADS_CPP_TYPE       Kokkos::Threads)
 set(EXECSPACE_SERIAL_CPP_TYPE        Kokkos::Serial)
@@ -28,8 +28,8 @@ set(MEMSPACE_CUDASPACE_CPP_TYPE          Kokkos::CudaSpace)
 set(MEMSPACE_CUDAUVMSPACE_CPP_TYPE       Kokkos::CudaUVMSpace)
 set(MEMSPACE_HIPSPACE_CPP_TYPE           Kokkos::HIPSpace)
 set(MEMSPACE_HIPMANAGEDSPACE_CPP_TYPE    Kokkos::HIPManagedSpace)
-set(MEMSPACE_SYCLSPACE_CPP_TYPE          Kokkos::Experimental::SYCLDeviceUSMSpace)
-set(MEMSPACE_SYCLSHAREDSPACE_CPP_TYPE    Kokkos::Experimental::SYCLSharedUSMSpace)
+set(MEMSPACE_SYCLSPACE_CPP_TYPE          Kokkos::SYCLDeviceUSMSpace)
+set(MEMSPACE_SYCLSHAREDSPACE_CPP_TYPE    Kokkos::SYCLSharedUSMSpace)
 set(MEMSPACE_HOSTSPACE_CPP_TYPE          Kokkos::HostSpace)
 
 if(KOKKOS_ENABLE_CUDA)
@@ -82,10 +82,10 @@ endif()
 
 if(KOKKOS_ENABLE_SYCL)
   kokkoskernels_add_option("INST_EXECSPACE_SYCL" ${KOKKOSKERNELS_INST_EXECSPACE_SYCL_DEFAULT} BOOL
-    "Whether to pre instantiate kernels for the execution space Kokkos::Experimental::SYCL. Disabling this when Kokkos_ENABLE_SYCL is enabled may increase build times. Default: ON if Kokkos is SYCL-enabled, OFF otherwise.")
+    "Whether to pre instantiate kernels for the execution space Kokkos::SYCL. Disabling this when Kokkos_ENABLE_SYCL is enabled may increase build times. Default: ON if Kokkos is SYCL-enabled, OFF otherwise.")
 
   kokkoskernels_add_option("INST_MEMSPACE_SYCLSPACE" ${KOKKOSKERNELS_INST_EXECSPACE_SYCL_DEFAULT} BOOL
-    "Whether to pre instantiate kernels for the memory space Kokkos::Experimental::SYCLSpace.  Disabling this when Kokkos_ENABLE_SYCL is enabled may increase build times. Default: ON if Kokkos is SYCL-enabled, OFF otherwise.")
+    "Whether to pre instantiate kernels for the memory space Kokkos::SYCLSpace.  Disabling this when Kokkos_ENABLE_SYCL is enabled may increase build times. Default: ON if Kokkos is SYCL-enabled, OFF otherwise.")
 
   if(KOKKOSKERNELS_INST_EXECSPACE_SYCL AND KOKKOSKERNELS_INST_MEMSPACE_SYCLSPACE)
     list(APPEND DEVICE_LIST "<SYCL,SYCLDeviceUSMSpace>")

--- a/common/src/KokkosKernels_ExecSpaceUtils.hpp
+++ b/common/src/KokkosKernels_ExecSpaceUtils.hpp
@@ -185,8 +185,7 @@ inline void kk_get_free_total_memory<Kokkos::HIPManagedSpace>(size_t& free_mem, 
 // Note: we are querying memory associated with the default SYCL queue.
 #if defined(KOKKOS_ENABLE_SYCL) && defined(KOKKOS_ARCH_INTEL_GPU)
 template <>
-inline void kk_get_free_total_memory<Kokkos::SYCLDeviceUSMSpace>(size_t& free_mem, size_t& total_mem,
-                                                                               int n_streams) {
+inline void kk_get_free_total_memory<Kokkos::SYCLDeviceUSMSpace>(size_t& free_mem, size_t& total_mem, int n_streams) {
   sycl::queue queue;
   sycl::device device = queue.get_device();
 
@@ -208,8 +207,7 @@ inline void kk_get_free_total_memory<Kokkos::SYCLDeviceUSMSpace>(size_t& free_me
 }
 
 template <>
-inline void kk_get_free_total_memory<Kokkos::SYCLHostUSMSpace>(size_t& free_mem, size_t& total_mem,
-                                                                             int n_streams) {
+inline void kk_get_free_total_memory<Kokkos::SYCLHostUSMSpace>(size_t& free_mem, size_t& total_mem, int n_streams) {
   kk_get_free_total_memory<Kokkos::SYCLDeviceUSMSpace>(free_mem, total_mem, n_streams);
 }
 
@@ -219,8 +217,7 @@ inline void kk_get_free_total_memory<Kokkos::SYCLHostUSMSpace>(size_t& free_mem,
 }
 
 template <>
-inline void kk_get_free_total_memory<Kokkos::SYCLSharedUSMSpace>(size_t& free_mem, size_t& total_mem,
-                                                                               int n_streams) {
+inline void kk_get_free_total_memory<Kokkos::SYCLSharedUSMSpace>(size_t& free_mem, size_t& total_mem, int n_streams) {
   kk_get_free_total_memory<Kokkos::SYCLDeviceUSMSpace>(free_mem, total_mem, n_streams);
 }
 

--- a/common/src/KokkosKernels_ExecSpaceUtils.hpp
+++ b/common/src/KokkosKernels_ExecSpaceUtils.hpp
@@ -52,7 +52,7 @@ KOKKOS_FORCEINLINE_FUNCTION ExecSpaceType kk_get_exec_space_type() {
 #endif
 
 #if defined(KOKKOS_ENABLE_SYCL)
-  if (std::is_same<Kokkos::Experimental::SYCL, ExecutionSpace>::value) {
+  if (std::is_same<Kokkos::SYCL, ExecutionSpace>::value) {
     exec_space = Exec_SYCL;
   }
 #endif
@@ -79,7 +79,7 @@ constexpr inline bool is_gpu_exec_space_v<Kokkos::HIP> = true;
 
 #ifdef KOKKOS_ENABLE_SYCL
 template <>
-constexpr inline bool is_gpu_exec_space_v<Kokkos::Experimental::SYCL> = true;
+constexpr inline bool is_gpu_exec_space_v<Kokkos::SYCL> = true;
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -185,7 +185,7 @@ inline void kk_get_free_total_memory<Kokkos::HIPManagedSpace>(size_t& free_mem, 
 // Note: we are querying memory associated with the default SYCL queue.
 #if defined(KOKKOS_ENABLE_SYCL) && defined(KOKKOS_ARCH_INTEL_GPU)
 template <>
-inline void kk_get_free_total_memory<Kokkos::Experimental::SYCLDeviceUSMSpace>(size_t& free_mem, size_t& total_mem,
+inline void kk_get_free_total_memory<Kokkos::SYCLDeviceUSMSpace>(size_t& free_mem, size_t& total_mem,
                                                                                int n_streams) {
   sycl::queue queue;
   sycl::device device = queue.get_device();
@@ -203,30 +203,30 @@ inline void kk_get_free_total_memory<Kokkos::Experimental::SYCLDeviceUSMSpace>(s
 }
 
 template <>
-inline void kk_get_free_total_memory<Kokkos::Experimental::SYCLDeviceUSMSpace>(size_t& free_mem, size_t& total_mem) {
-  kk_get_free_total_memory<Kokkos::Experimental::SYCLDeviceUSMSpace>(free_mem, total_mem, 1);
+inline void kk_get_free_total_memory<Kokkos::SYCLDeviceUSMSpace>(size_t& free_mem, size_t& total_mem) {
+  kk_get_free_total_memory<Kokkos::SYCLDeviceUSMSpace>(free_mem, total_mem, 1);
 }
 
 template <>
-inline void kk_get_free_total_memory<Kokkos::Experimental::SYCLHostUSMSpace>(size_t& free_mem, size_t& total_mem,
+inline void kk_get_free_total_memory<Kokkos::SYCLHostUSMSpace>(size_t& free_mem, size_t& total_mem,
                                                                              int n_streams) {
-  kk_get_free_total_memory<Kokkos::Experimental::SYCLDeviceUSMSpace>(free_mem, total_mem, n_streams);
+  kk_get_free_total_memory<Kokkos::SYCLDeviceUSMSpace>(free_mem, total_mem, n_streams);
 }
 
 template <>
-inline void kk_get_free_total_memory<Kokkos::Experimental::SYCLHostUSMSpace>(size_t& free_mem, size_t& total_mem) {
-  kk_get_free_total_memory<Kokkos::Experimental::SYCLHostUSMSpace>(free_mem, total_mem, 1);
+inline void kk_get_free_total_memory<Kokkos::SYCLHostUSMSpace>(size_t& free_mem, size_t& total_mem) {
+  kk_get_free_total_memory<Kokkos::SYCLHostUSMSpace>(free_mem, total_mem, 1);
 }
 
 template <>
-inline void kk_get_free_total_memory<Kokkos::Experimental::SYCLSharedUSMSpace>(size_t& free_mem, size_t& total_mem,
+inline void kk_get_free_total_memory<Kokkos::SYCLSharedUSMSpace>(size_t& free_mem, size_t& total_mem,
                                                                                int n_streams) {
-  kk_get_free_total_memory<Kokkos::Experimental::SYCLDeviceUSMSpace>(free_mem, total_mem, n_streams);
+  kk_get_free_total_memory<Kokkos::SYCLDeviceUSMSpace>(free_mem, total_mem, n_streams);
 }
 
 template <>
-inline void kk_get_free_total_memory<Kokkos::Experimental::SYCLSharedUSMSpace>(size_t& free_mem, size_t& total_mem) {
-  kk_get_free_total_memory<Kokkos::Experimental::SYCLSharedUSMSpace>(free_mem, total_mem, 1);
+inline void kk_get_free_total_memory<Kokkos::SYCLSharedUSMSpace>(size_t& free_mem, size_t& total_mem) {
+  kk_get_free_total_memory<Kokkos::SYCLSharedUSMSpace>(free_mem, total_mem, 1);
 }
 #endif
 
@@ -237,7 +237,7 @@ inline int kk_get_max_vector_size() {
 
 #ifdef KOKKOS_ENABLE_SYCL
 template <>
-inline int kk_get_max_vector_size<Kokkos::Experimental::SYCL>() {
+inline int kk_get_max_vector_size<Kokkos::SYCL>() {
   // FIXME SYCL: hardcoding to 8 is a workaround that seems to work for all
   // kernels. Wait for max subgroup size query to be fixed in SYCL and/or
   // Kokkos. Then TeamPolicy::vector_length_max() can be used for all

--- a/common/unit_test/Test_Common_AlignPtrTo.hpp
+++ b/common/unit_test/Test_Common_AlignPtrTo.hpp
@@ -121,7 +121,7 @@ void test_alignPtrTo() {
 
 // if SYCL is enabled, only TEST_FN 1 and 4 should work with older compiler versions
 #if defined(KOKKOS_ENABLE_SYCL) && KOKKOS_COMPILER_INTEL_LLVM < 20250000
-  if constexpr (std::is_same_v<ExecSpace, Kokkos::Experimental::SYCL>) {
+  if constexpr (std::is_same_v<ExecSpace, Kokkos::SYCL>) {
     if constexpr ((1 == TEST_FN) || (4 == TEST_FN)) {
       EXPECT_EQ(0, errs);
     } else {

--- a/graph/unit_test/Test_Graph_graph_color.hpp
+++ b/graph/unit_test/Test_Graph_graph_color.hpp
@@ -99,7 +99,7 @@ void test_coloring(lno_t numRows, size_type nnz, lno_t bandwidth, lno_t row_size
 
   // FIXME SYCL: re-enable this when EB is working
 #ifdef KOKKOS_ENABLE_SYCL
-  if (!std::is_same<typename device::execution_space, Kokkos::Experimental::SYCL>::value) {
+  if (!std::is_same<typename device::execution_space, Kokkos::SYCL>::value) {
     coloring_algorithms.push_back(COLORING_EB);
   }
 #else

--- a/ode/unit_test/Test_ODE_RK_counts.hpp
+++ b/ode/unit_test/Test_ODE_RK_counts.hpp
@@ -123,7 +123,7 @@ void test_RK_count() {
   Test::RK_Count<RK>(TestDevice(), TestProblem::EnrightD4(), 1.e-5, 1.e-9, 932);
 #if defined(KOKKOS_ENABLE_SYCL)
   if constexpr ((RK != KokkosODE::Experimental::RK_type::RKF12) &&
-                !std::is_same_v<typename TestDevice::execution_space, Kokkos::Experimental::SYCL>) {
+                !std::is_same_v<typename TestDevice::execution_space, Kokkos::SYCL>) {
 #else
   if constexpr (RK != KokkosODE::Experimental::RK_type::RKF12) {
 #endif

--- a/perf_test/KokkosKernels_perf_test_instantiation.hpp
+++ b/perf_test/KokkosKernels_perf_test_instantiation.hpp
@@ -97,7 +97,7 @@ int main_instantiation(int argc, char** argv) {
   if (params.use_sycl) {
 #if defined(KOKKOS_ENABLE_SYCL)
     std::cout << "Running on SYCL backend.\n";
-    KOKKOSKERNELS_PERF_TEST_NAME<Kokkos::Experimental::SYCL>(argc, argv, params);
+    KOKKOSKERNELS_PERF_TEST_NAME<Kokkos::SYCL>(argc, argv, params);
     ran = true;
 #else
     std::cout << "ERROR: SYCL requested, but not available.\n";

--- a/perf_test/blas/blas1/KokkosBlas_dot_perf_test.cpp
+++ b/perf_test/blas/blas1/KokkosBlas_dot_perf_test.cpp
@@ -197,7 +197,7 @@ int main(int argc, char** argv) {
 
   if (useSYCL) {
 #if defined(KOKKOS_ENABLE_SYCL)
-    run<Kokkos::Experimental::SYCL>(params.m, params.repeat);
+    run<Kokkos::SYCL>(params.m, params.repeat);
 #else
     std::cout << "ERROR: SYCL requested, but not available.\n";
     return 1;

--- a/sparse/src/KokkosSparse_spgemm_handle.hpp
+++ b/sparse/src/KokkosSparse_spgemm_handle.hpp
@@ -644,7 +644,7 @@ class SPGEMMHandle {
 #endif
 
 #if defined(KOKKOS_ENABLE_SYCL)
-    if (std::is_same<Kokkos::Experimental::SYCL, ExecutionSpace>::value) {
+    if (std::is_same<Kokkos::SYCL, ExecutionSpace>::value) {
       this->algorithm_type = SPGEMM_KK;
 #ifdef VERBOSE
       std::cout << "SYCL Execution Space, Default Algorithm: SPGEMM_KK" << std::endl;

--- a/sparse/src/KokkosSparse_spmv.hpp
+++ b/sparse/src/KokkosSparse_spmv.hpp
@@ -240,7 +240,7 @@ void spmv(const ExecutionSpace& space, Handle* handle, const char mode[], const 
         useNative = useNative || (mode[0] == Conjugate[0]);
       }
 #ifdef KOKKOS_ENABLE_SYCL
-      if constexpr (std::is_same_v<ExecutionSpace, Kokkos::Experimental::SYCL>) {
+      if constexpr (std::is_same_v<ExecutionSpace, Kokkos::SYCL>) {
         useNative = useNative || (mode[0] != NoTranspose[0]);
       }
 #endif

--- a/sparse/src/KokkosSparse_spmv_handle.hpp
+++ b/sparse/src/KokkosSparse_spmv_handle.hpp
@@ -171,8 +171,8 @@ struct MKL_SpMV_Data : public TPL_SpMV_Data<ExecutionSpace> {
 #endif
 
 #if defined(KOKKOS_ENABLE_SYCL)
-struct OneMKL_SpMV_Data : public TPL_SpMV_Data<Kokkos::Experimental::SYCL> {
-  OneMKL_SpMV_Data(const Kokkos::Experimental::SYCL& exec_) : TPL_SpMV_Data(exec_) {}
+struct OneMKL_SpMV_Data : public TPL_SpMV_Data<Kokkos::SYCL> {
+  OneMKL_SpMV_Data(const Kokkos::SYCL& exec_) : TPL_SpMV_Data(exec_) {}
   ~OneMKL_SpMV_Data() {
     // Make sure no spmv is still running with this handle, if exec uses an
     // out-of-order queue (rare case)

--- a/sparse/tpls/KokkosSparse_spmv_tpl_spec_avail.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_tpl_spec_avail.hpp
@@ -158,18 +158,17 @@ KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_MKL(Kokkos::complex<double>, Kokkos::OpenMP)
 #endif
 
 #if defined(KOKKOS_ENABLE_SYCL)
-#define KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_ONEMKL(SCALAR, ORDINAL, MEMSPACE)                                       \
-  template <>                                                                                                    \
-  struct spmv_tpl_spec_avail<                                                                                    \
-      Kokkos::SYCL,                                                                                \
-      KokkosSparse::Impl::SPMVHandleImpl<Kokkos::SYCL, MEMSPACE, SCALAR, ORDINAL, ORDINAL>,        \
-      KokkosSparse::CrsMatrix<const SCALAR, const ORDINAL, Kokkos::Device<Kokkos::SYCL, MEMSPACE>, \
-                              Kokkos::MemoryTraits<Kokkos::Unmanaged>, const ORDINAL>,                           \
-      Kokkos::View<const SCALAR*, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::SYCL, MEMSPACE>,      \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>,                              \
-      Kokkos::View<SCALAR*, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::SYCL, MEMSPACE>,            \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>> {                                                   \
-    enum : bool { value = true };                                                                                \
+#define KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_ONEMKL(SCALAR, ORDINAL, MEMSPACE)                                \
+  template <>                                                                                             \
+  struct spmv_tpl_spec_avail<                                                                             \
+      Kokkos::SYCL, KokkosSparse::Impl::SPMVHandleImpl<Kokkos::SYCL, MEMSPACE, SCALAR, ORDINAL, ORDINAL>, \
+      KokkosSparse::CrsMatrix<const SCALAR, const ORDINAL, Kokkos::Device<Kokkos::SYCL, MEMSPACE>,        \
+                              Kokkos::MemoryTraits<Kokkos::Unmanaged>, const ORDINAL>,                    \
+      Kokkos::View<const SCALAR*, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::SYCL, MEMSPACE>,             \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>,                       \
+      Kokkos::View<SCALAR*, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::SYCL, MEMSPACE>,                   \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>> {                                            \
+    enum : bool { value = true };                                                                         \
   };
 
 // intel-oneapi-mkl/2023.2.0: spmv with complex data types produce:

--- a/sparse/tpls/KokkosSparse_spmv_tpl_spec_avail.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_tpl_spec_avail.hpp
@@ -161,13 +161,13 @@ KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_MKL(Kokkos::complex<double>, Kokkos::OpenMP)
 #define KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_ONEMKL(SCALAR, ORDINAL, MEMSPACE)                                       \
   template <>                                                                                                    \
   struct spmv_tpl_spec_avail<                                                                                    \
-      Kokkos::Experimental::SYCL,                                                                                \
-      KokkosSparse::Impl::SPMVHandleImpl<Kokkos::Experimental::SYCL, MEMSPACE, SCALAR, ORDINAL, ORDINAL>,        \
-      KokkosSparse::CrsMatrix<const SCALAR, const ORDINAL, Kokkos::Device<Kokkos::Experimental::SYCL, MEMSPACE>, \
+      Kokkos::SYCL,                                                                                \
+      KokkosSparse::Impl::SPMVHandleImpl<Kokkos::SYCL, MEMSPACE, SCALAR, ORDINAL, ORDINAL>,        \
+      KokkosSparse::CrsMatrix<const SCALAR, const ORDINAL, Kokkos::Device<Kokkos::SYCL, MEMSPACE>, \
                               Kokkos::MemoryTraits<Kokkos::Unmanaged>, const ORDINAL>,                           \
-      Kokkos::View<const SCALAR*, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::Experimental::SYCL, MEMSPACE>,      \
+      Kokkos::View<const SCALAR*, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::SYCL, MEMSPACE>,      \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>,                              \
-      Kokkos::View<SCALAR*, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::Experimental::SYCL, MEMSPACE>,            \
+      Kokkos::View<SCALAR*, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::SYCL, MEMSPACE>,            \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>> {                                                   \
     enum : bool { value = true };                                                                                \
   };
@@ -178,26 +178,26 @@ KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_MKL(Kokkos::complex<double>, Kokkos::OpenMP)
 // TODO: Revisit with later versions and selectively enable this if it's
 // working.
 
-KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_ONEMKL(float, std::int32_t, Kokkos::Experimental::SYCLDeviceUSMSpace)
-KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_ONEMKL(double, std::int32_t, Kokkos::Experimental::SYCLDeviceUSMSpace)
+KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_ONEMKL(float, std::int32_t, Kokkos::SYCLDeviceUSMSpace)
+KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_ONEMKL(double, std::int32_t, Kokkos::SYCLDeviceUSMSpace)
 /*
 KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_ONEMKL(
     Kokkos::complex<float>, std::int32_t,
-    Kokkos::Experimental::SYCLDeviceUSMSpace)
+    Kokkos::SYCLDeviceUSMSpace)
 KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_ONEMKL(
     Kokkos::complex<double>, std::int32_t,
-    Kokkos::Experimental::SYCLDeviceUSMSpace)
+    Kokkos::SYCLDeviceUSMSpace)
 */
 
-KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_ONEMKL(float, std::int64_t, Kokkos::Experimental::SYCLDeviceUSMSpace)
-KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_ONEMKL(double, std::int64_t, Kokkos::Experimental::SYCLDeviceUSMSpace)
+KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_ONEMKL(float, std::int64_t, Kokkos::SYCLDeviceUSMSpace)
+KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_ONEMKL(double, std::int64_t, Kokkos::SYCLDeviceUSMSpace)
 /*
 KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_ONEMKL(
     Kokkos::complex<float>, std::int64_t,
-    Kokkos::Experimental::SYCLDeviceUSMSpace)
+    Kokkos::SYCLDeviceUSMSpace)
 KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_ONEMKL(
     Kokkos::complex<double>, std::int64_t,
-    Kokkos::Experimental::SYCLDeviceUSMSpace)
+    Kokkos::SYCLDeviceUSMSpace)
 */
 #endif
 

--- a/sparse/tpls/KokkosSparse_spmv_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_tpl_spec_decl.hpp
@@ -519,36 +519,34 @@ inline void spmv_onemkl(const execution_space& exec, Handle* handle, oneapi::mkl
                             reinterpret_cast<onemkl_scalar_type*>(y.data()));
 }
 
-#define KOKKOSSPARSE_SPMV_ONEMKL(SCALAR, ORDINAL, MEMSPACE)                                                            \
-  template <>                                                                                                          \
-  struct SPMV<                                                                                                         \
-      Kokkos::SYCL,                                                                                      \
-      KokkosSparse::Impl::SPMVHandleImpl<Kokkos::SYCL, MEMSPACE, SCALAR, ORDINAL, ORDINAL>,              \
-      KokkosSparse::CrsMatrix<SCALAR const, ORDINAL const, Kokkos::Device<Kokkos::SYCL, MEMSPACE>,       \
-                              Kokkos::MemoryTraits<Kokkos::Unmanaged>, ORDINAL const>,                                 \
-      Kokkos::View<SCALAR const*, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::SYCL, MEMSPACE>,            \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>,                                    \
-      Kokkos::View<SCALAR*, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::SYCL, MEMSPACE>,                  \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                           \
-      true> {                                                                                                          \
-    using execution_space = Kokkos::SYCL;                                                                \
-    using device_type     = Kokkos::Device<execution_space, MEMSPACE>;                                                 \
-    using Handle = KokkosSparse::Impl::SPMVHandleImpl<Kokkos::SYCL, MEMSPACE, SCALAR, ORDINAL, ORDINAL>; \
-    using AMatrix =                                                                                                    \
-        CrsMatrix<SCALAR const, ORDINAL const, device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged>, ORDINAL const>;   \
-    using XVector = Kokkos::View<SCALAR const*, Kokkos::LayoutLeft, device_type,                                       \
-                                 Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>;                      \
-    using YVector = Kokkos::View<SCALAR*, Kokkos::LayoutLeft, device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;   \
-    using coefficient_type = typename YVector::non_const_value_type;                                                   \
-                                                                                                                       \
-    static void spmv(const execution_space& exec, Handle* handle, const char mode[], const coefficient_type& alpha,    \
-                     const AMatrix& A, const XVector& x, const coefficient_type& beta, const YVector& y) {             \
-      std::string label = "KokkosSparse::spmv[TPL_ONEMKL," + KokkosKernels::ArithTraits<SCALAR>::name() + "]";         \
-      Kokkos::Profiling::pushRegion(label);                                                                            \
-      oneapi::mkl::transpose mkl_mode = mode_kk_to_onemkl(mode[0]);                                                    \
-      spmv_onemkl(exec, handle, mkl_mode, alpha, A, x, beta, y);                                                       \
-      Kokkos::Profiling::popRegion();                                                                                  \
-    }                                                                                                                  \
+#define KOKKOSSPARSE_SPMV_ONEMKL(SCALAR, ORDINAL, MEMSPACE)                                                          \
+  template <>                                                                                                        \
+  struct SPMV<Kokkos::SYCL, KokkosSparse::Impl::SPMVHandleImpl<Kokkos::SYCL, MEMSPACE, SCALAR, ORDINAL, ORDINAL>,    \
+              KokkosSparse::CrsMatrix<SCALAR const, ORDINAL const, Kokkos::Device<Kokkos::SYCL, MEMSPACE>,           \
+                                      Kokkos::MemoryTraits<Kokkos::Unmanaged>, ORDINAL const>,                       \
+              Kokkos::View<SCALAR const*, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::SYCL, MEMSPACE>,                \
+                           Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>,                          \
+              Kokkos::View<SCALAR*, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::SYCL, MEMSPACE>,                      \
+                           Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                 \
+              true> {                                                                                                \
+    using execution_space = Kokkos::SYCL;                                                                            \
+    using device_type     = Kokkos::Device<execution_space, MEMSPACE>;                                               \
+    using Handle          = KokkosSparse::Impl::SPMVHandleImpl<Kokkos::SYCL, MEMSPACE, SCALAR, ORDINAL, ORDINAL>;    \
+    using AMatrix =                                                                                                  \
+        CrsMatrix<SCALAR const, ORDINAL const, device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged>, ORDINAL const>; \
+    using XVector = Kokkos::View<SCALAR const*, Kokkos::LayoutLeft, device_type,                                     \
+                                 Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>;                    \
+    using YVector = Kokkos::View<SCALAR*, Kokkos::LayoutLeft, device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged>>; \
+    using coefficient_type = typename YVector::non_const_value_type;                                                 \
+                                                                                                                     \
+    static void spmv(const execution_space& exec, Handle* handle, const char mode[], const coefficient_type& alpha,  \
+                     const AMatrix& A, const XVector& x, const coefficient_type& beta, const YVector& y) {           \
+      std::string label = "KokkosSparse::spmv[TPL_ONEMKL," + KokkosKernels::ArithTraits<SCALAR>::name() + "]";       \
+      Kokkos::Profiling::pushRegion(label);                                                                          \
+      oneapi::mkl::transpose mkl_mode = mode_kk_to_onemkl(mode[0]);                                                  \
+      spmv_onemkl(exec, handle, mkl_mode, alpha, A, x, beta, y);                                                     \
+      Kokkos::Profiling::popRegion();                                                                                \
+    }                                                                                                                \
   };
 
 KOKKOSSPARSE_SPMV_ONEMKL(float, std::int32_t, Kokkos::SYCLDeviceUSMSpace)

--- a/sparse/tpls/KokkosSparse_spmv_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_tpl_spec_decl.hpp
@@ -522,18 +522,18 @@ inline void spmv_onemkl(const execution_space& exec, Handle* handle, oneapi::mkl
 #define KOKKOSSPARSE_SPMV_ONEMKL(SCALAR, ORDINAL, MEMSPACE)                                                            \
   template <>                                                                                                          \
   struct SPMV<                                                                                                         \
-      Kokkos::Experimental::SYCL,                                                                                      \
-      KokkosSparse::Impl::SPMVHandleImpl<Kokkos::Experimental::SYCL, MEMSPACE, SCALAR, ORDINAL, ORDINAL>,              \
-      KokkosSparse::CrsMatrix<SCALAR const, ORDINAL const, Kokkos::Device<Kokkos::Experimental::SYCL, MEMSPACE>,       \
+      Kokkos::SYCL,                                                                                      \
+      KokkosSparse::Impl::SPMVHandleImpl<Kokkos::SYCL, MEMSPACE, SCALAR, ORDINAL, ORDINAL>,              \
+      KokkosSparse::CrsMatrix<SCALAR const, ORDINAL const, Kokkos::Device<Kokkos::SYCL, MEMSPACE>,       \
                               Kokkos::MemoryTraits<Kokkos::Unmanaged>, ORDINAL const>,                                 \
-      Kokkos::View<SCALAR const*, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::Experimental::SYCL, MEMSPACE>,            \
+      Kokkos::View<SCALAR const*, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::SYCL, MEMSPACE>,            \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>,                                    \
-      Kokkos::View<SCALAR*, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::Experimental::SYCL, MEMSPACE>,                  \
+      Kokkos::View<SCALAR*, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::SYCL, MEMSPACE>,                  \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                           \
       true> {                                                                                                          \
-    using execution_space = Kokkos::Experimental::SYCL;                                                                \
+    using execution_space = Kokkos::SYCL;                                                                \
     using device_type     = Kokkos::Device<execution_space, MEMSPACE>;                                                 \
-    using Handle = KokkosSparse::Impl::SPMVHandleImpl<Kokkos::Experimental::SYCL, MEMSPACE, SCALAR, ORDINAL, ORDINAL>; \
+    using Handle = KokkosSparse::Impl::SPMVHandleImpl<Kokkos::SYCL, MEMSPACE, SCALAR, ORDINAL, ORDINAL>; \
     using AMatrix =                                                                                                    \
         CrsMatrix<SCALAR const, ORDINAL const, device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged>, ORDINAL const>;   \
     using XVector = Kokkos::View<SCALAR const*, Kokkos::LayoutLeft, device_type,                                       \
@@ -551,23 +551,23 @@ inline void spmv_onemkl(const execution_space& exec, Handle* handle, oneapi::mkl
     }                                                                                                                  \
   };
 
-KOKKOSSPARSE_SPMV_ONEMKL(float, std::int32_t, Kokkos::Experimental::SYCLDeviceUSMSpace)
-KOKKOSSPARSE_SPMV_ONEMKL(double, std::int32_t, Kokkos::Experimental::SYCLDeviceUSMSpace)
+KOKKOSSPARSE_SPMV_ONEMKL(float, std::int32_t, Kokkos::SYCLDeviceUSMSpace)
+KOKKOSSPARSE_SPMV_ONEMKL(double, std::int32_t, Kokkos::SYCLDeviceUSMSpace)
 /*
 KOKKOSSPARSE_SPMV_ONEMKL(Kokkos::complex<float>, std::int32_t,
-                       Kokkos::Experimental::SYCLDeviceUSMSpace)
+                       Kokkos::SYCLDeviceUSMSpace)
 KOKKOSSPARSE_SPMV_ONEMKL(Kokkos::complex<double>, std::int32_t,
-                       Kokkos::Experimental::SYCLDeviceUSMSpace)
+                       Kokkos::SYCLDeviceUSMSpace)
 */
 
-KOKKOSSPARSE_SPMV_ONEMKL(float, std::int64_t, Kokkos::Experimental::SYCLDeviceUSMSpace)
-KOKKOSSPARSE_SPMV_ONEMKL(double, std::int64_t, Kokkos::Experimental::SYCLDeviceUSMSpace)
+KOKKOSSPARSE_SPMV_ONEMKL(float, std::int64_t, Kokkos::SYCLDeviceUSMSpace)
+KOKKOSSPARSE_SPMV_ONEMKL(double, std::int64_t, Kokkos::SYCLDeviceUSMSpace)
 /*
 KOKKOSSPARSE_SPMV_ONEMKL(Kokkos::complex<float>, std::int64_t,
-                         Kokkos::Experimental::SYCLDeviceUSMSpace
+                         Kokkos::SYCLDeviceUSMSpace
                          )
 KOKKOSSPARSE_SPMV_ONEMKL(Kokkos::complex<double>, std::int64_t,
-                         Kokkos::Experimental::SYCLDeviceUSMSpace
+                         Kokkos::SYCLDeviceUSMSpace
                          )
 */
 #endif

--- a/sparse/unit_test/Test_Sparse_coo2crs.hpp
+++ b/sparse/unit_test/Test_Sparse_coo2crs.hpp
@@ -202,7 +202,7 @@ void doAllCoo2Crs(size_t m, size_t n) {
 
 TEST_F(TestCategory, sparse_coo2crs) {
 #if defined(KOKKOS_ENABLE_SYCL)
-  if constexpr (std::is_same_v<typename TestDevice::execution_space, Kokkos::Experimental::SYCL>) {
+  if constexpr (std::is_same_v<typename TestDevice::execution_space, Kokkos::SYCL>) {
     std::cout << "Not running coo2csr on SYCL execution space" << std::endl;
     return;
   }
@@ -236,7 +236,7 @@ TEST_F(TestCategory, sparse_coo2crs) {
 
 TEST_F(TestCategory, sparse_coo2crs_staticMatrix_edgeCases) {
 #if defined(KOKKOS_ENABLE_SYCL)
-  if constexpr (std::is_same_v<typename TestDevice::execution_space, Kokkos::Experimental::SYCL>) {
+  if constexpr (std::is_same_v<typename TestDevice::execution_space, Kokkos::SYCL>) {
     std::cout << "Not running coo2csr on SYCL execution space" << std::endl;
     return;
   }

--- a/test_common/Test_SYCL.hpp
+++ b/test_common/Test_SYCL.hpp
@@ -16,4 +16,4 @@ class sycl_test : public ::testing::Test {
 };
 
 #define TestCategory sycl_test
-#define TestDevice Kokkos::Experimental::SYCL
+#define TestDevice Kokkos::SYCL


### PR DESCRIPTION
Also removing a mention of openmptarget from our config file since it was removed...