### PR TITLE
Benchmark - Blas1: result of nrminf on host

### DIFF
--- a/benchmarks/blas/CMakeLists.txt
+++ b/benchmarks/blas/CMakeLists.txt
@@ -1,6 +1,7 @@
 kokkoskernels_include_directories(${CMAKE_CURRENT_BINARY_DIR})
 kokkoskernels_include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
+
 kokkoskernels_add_benchmark(
   Blas1_Benchmark
   SOURCES

--- a/benchmarks/blas/KokkosBlas1_nrminf_benchmark.cpp
+++ b/benchmarks/blas/KokkosBlas1_nrminf_benchmark.cpp
@@ -22,7 +22,7 @@ static void run(benchmark::State& state) {
   Kokkos::View<Scalar*, Device> x(Kokkos::view_alloc(Kokkos::WithoutInitializing, "x"), m);
 
   // Create 1D view w/ Device as the ExecSpace; this is the output vector
-  Kokkos::View<Scalar, Device> r("result");
+  Kokkos::View<Scalar, Kokkos::HostSpace> r("result");
 
   // Declaring variable pool w/ a seeded random number;
   // a parallel random number generator, so you
@@ -34,7 +34,7 @@ static void run(benchmark::State& state) {
 
   Kokkos::fence();
   for (auto _ : state) {
-    KokkosBlas::nrminf(space, r, x);
+    // KokkosBlas::nrminf(space, r, x);
     space.fence();
   }
   const size_t iterFlop   = (size_t)2 * m;

--- a/benchmarks/blas/KokkosBlas1_nrminf_benchmark.cpp
+++ b/benchmarks/blas/KokkosBlas1_nrminf_benchmark.cpp
@@ -34,7 +34,7 @@ static void run(benchmark::State& state) {
 
   Kokkos::fence();
   for (auto _ : state) {
-    // KokkosBlas::nrminf(space, r, x);
+    KokkosBlas::nrminf(space, r, x);
     space.fence();
   }
   const size_t iterFlop   = (size_t)2 * m;

--- a/benchmarks/blas/KokkosBlas1_nrminf_mv_benchmark.cpp
+++ b/benchmarks/blas/KokkosBlas1_nrminf_mv_benchmark.cpp
@@ -20,7 +20,7 @@ static void run(benchmark::State& state) {
 
   Kokkos::View<Scalar**, Kokkos::LayoutLeft, Device> x(Kokkos::view_alloc(Kokkos::WithoutInitializing, "x"), m, n);
 
-  Kokkos::View<Scalar*, Device> norms("norms", n);
+  Kokkos::View<Scalar*, Kokkos::HostSpace> norms("norms", n);
 
   // Declaring variable pool w/ a seeded random number;
   // a parallel random number generator, so you

--- a/blas/src/KokkosBlas1_nrminf.hpp
+++ b/blas/src/KokkosBlas1_nrminf.hpp
@@ -68,10 +68,10 @@ typename KokkosKernels::Details::InnerProductSpaceTraits<typename XVector::non_c
 /// corresponding entry in X.
 ///
 /// \tparam execution_space, the execution space in which the kernel will run.
-/// \tparam RMV rank-0 or rank-1 Kokkos::View specialization.
+/// \tparam RV rank-0 or rank-1 Kokkos::View specialization.
 /// \tparam XMV rank-1 or rank-2 Kokkos::View specialization.  It must have
-///   the same rank as RMV, and its entries must be assignable to
-///   those of RMV.
+///   the same rank as RV's rank + 1, and its entries must be assignable to
+///   those of RV.
 template <class execution_space, class RV, class XMV>
 void nrminf(const execution_space& space, const RV& R, const XMV& X,
             typename std::enable_if<Kokkos::is_view_v<RV>, int>::type = 0) {
@@ -113,14 +113,12 @@ void nrminf(const execution_space& space, const RV& R, const XMV& X,
 
   // Create unmanaged versions of the input Views.  RV and XMV may be
   // rank 1 or rank 2.
-  typedef Kokkos::View<typename std::conditional<RV::rank == 0, typename RV::non_const_value_type,
-                                                 typename RV::non_const_value_type*>::type,
-                       UnifiedRVLayout, typename RV::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >
-      RV_Internal;
-  typedef Kokkos::View<typename std::conditional<XMV::rank == 1, typename XMV::const_value_type*,
-                                                 typename XMV::const_value_type**>::type,
-                       UnifiedXLayout, typename XMV::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >
-      XMV_Internal;
+  using RV_Internal = Kokkos::View<typename std::conditional<RV::rank == 0, typename RV::non_const_value_type,
+							     typename RV::non_const_value_type*>::type,
+				   UnifiedRVLayout, typename RV::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+  using XMV_Internal = Kokkos::View<typename std::conditional<XMV::rank == 1, typename XMV::const_value_type*,
+							      typename XMV::const_value_type**>::type,
+				    UnifiedXLayout, typename XMV::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
 
   RV_Internal R_internal  = R;
   XMV_Internal X_internal = X;
@@ -133,10 +131,10 @@ void nrminf(const execution_space& space, const RV& R, const XMV& X,
 /// Replace each entry in R with the nrminfolute value (magnitude) of the
 /// corresponding entry in X.
 ///
-/// \tparam RMV 1-D or 2-D Kokkos::View specialization.
+/// \tparam RV 1-D or 2-D Kokkos::View specialization.
 /// \tparam XMV 1-D or 2-D Kokkos::View specialization.  It must have
-///   the same rank as RMV, and its entries must be assignable to
-///   those of RMV.
+///   the same rank as RV's rank + 1, and its entries must be assignable to
+///   those of RV.
 template <class RV, class XMV>
 void nrminf(const RV& R, const XMV& X, typename std::enable_if<Kokkos::is_view_v<RV>, int>::type = 0) {
   nrminf(typename XMV::execution_space{}, R, X);

--- a/blas/src/KokkosBlas1_nrminf.hpp
+++ b/blas/src/KokkosBlas1_nrminf.hpp
@@ -33,12 +33,11 @@ typename KokkosKernels::Details::InnerProductSpaceTraits<typename XVector::non_c
 
   using XVector_Internal = Kokkos::View<typename XVector::const_value_type*,
                                         typename KokkosKernels::Impl::GetUnifiedLayout<XVector>::array_layout,
-                                        typename XVector::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
+                                        typename XVector::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
 
   using layout_t = typename XVector_Internal::array_layout;
 
-  using RVector_Internal =
-      Kokkos::View<mag_type, layout_t, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
+  using RVector_Internal = Kokkos::View<mag_type, layout_t, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
 
   mag_type result;
   RVector_Internal R = RVector_Internal(&result, layout_t());
@@ -113,12 +112,12 @@ void nrminf(const execution_space& space, const RV& R, const XMV& X,
 
   // Create unmanaged versions of the input Views.  RV and XMV may be
   // rank 1 or rank 2.
-  using RV_Internal = Kokkos::View<typename std::conditional<RV::rank == 0, typename RV::non_const_value_type,
-							     typename RV::non_const_value_type*>::type,
-				   UnifiedRVLayout, typename RV::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+  using RV_Internal  = Kokkos::View<typename std::conditional<RV::rank == 0, typename RV::non_const_value_type,
+                                                             typename RV::non_const_value_type*>::type,
+                                   UnifiedRVLayout, typename RV::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
   using XMV_Internal = Kokkos::View<typename std::conditional<XMV::rank == 1, typename XMV::const_value_type*,
-							      typename XMV::const_value_type**>::type,
-				    UnifiedXLayout, typename XMV::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+                                                              typename XMV::const_value_type**>::type,
+                                    UnifiedXLayout, typename XMV::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
 
   RV_Internal R_internal  = R;
   XMV_Internal X_internal = X;
@@ -131,8 +130,8 @@ void nrminf(const execution_space& space, const RV& R, const XMV& X,
 /// Replace each entry in R with the nrminfolute value (magnitude) of the
 /// corresponding entry in X.
 ///
-/// \tparam RV 1-D or 2-D Kokkos::View specialization.
-/// \tparam XMV 1-D or 2-D Kokkos::View specialization.  It must have
+/// \tparam RV rank-1 or rank-2 Kokkos::View specialization.
+/// \tparam XMV rank-1 or rank-2 Kokkos::View specialization.  It must have
 ///   the same rank as RV's rank + 1, and its entries must be assignable to
 ///   those of RV.
 template <class RV, class XMV>

--- a/docs/source/API/blas-index.rst
+++ b/docs/source/API/blas-index.rst
@@ -10,6 +10,7 @@ API: BLAS
    blas/blas1_axpby
    blas/blas1_dot
    blas/blas1_iamax
+   blas/blas1_nrminf
    blas/blas1_nrm1
    blas/blas1_nrm2
    blas/blas1_rotg

--- a/docs/source/API/blas/blas1_nrminf.rst
+++ b/docs/source/API/blas/blas1_nrminf.rst
@@ -70,4 +70,4 @@ output:
 
 .. code::
 
-   X_nrm: 300 Expected: 300
+   X_nrm: 50.011 Expected: 50.011

--- a/docs/source/API/blas/blas1_nrminf.rst
+++ b/docs/source/API/blas/blas1_nrminf.rst
@@ -63,7 +63,7 @@ Type Requirements
 Example
 =======
 
-.. literalinclude:: ../../../../example/wiki/blas/KokkosBlas1_wiki_nrminf.cpp
+.. literalinclude:: ../../../../example/docs/blas/KokkosBlas1_docs_nrminf.cpp
   :language: c++
 
 output:

--- a/docs/source/API/blas/blas1_nrminf.rst
+++ b/docs/source/API/blas/blas1_nrminf.rst
@@ -1,0 +1,73 @@
+KokkosBlas::nrminf
+##################
+
+Defined in header: :code:`KokkosBlas1_nrminf.hpp`
+
+.. code:: c++
+
+  template <class execution_space, class XVector, typename std::enable_if<Kokkos::is_execution_space_v<execution_space>, int>::type = 0>
+  typename KokkosKernels::Details::InnerProductSpaceTraits<typename XVector::non_const_value_type>::mag_type
+  nrminf(const execution_space& space, const XVector& x);
+
+  template <class XVector>
+  typename KokkosKernels::Details::InnerProductSpaceTraits<typename XVector::non_const_value_type>::mag_type
+  nrminf(const XVector& x);
+
+  template <class execution_space, class RV, class XMV>
+  void nrminf(const execution_space& space, const RV& R, const XMV& X,
+              typename std::enable_if<Kokkos::is_view_v<RV>, int>::type = 0);
+
+  template <class RV, class XMV>
+  void nrminf(const RV& R, const XMV& X, typename std::enable_if<Kokkos::is_view_v<RV>, int>::type = 0)
+
+Computes the norm inf (maximum absolute value) of the X vector(s) and returns or stores the result in R.
+
+1. returns the largest magnitude in ``X`` and fences the ``space`` instance.
+2. returns the largest magnitude in ``X`` and fences the default instance of ``typename XVector::execution_space``.
+3. returns the largest magnitude in each column of ``X``, stores it in the corresponding entry of ``R`` and fences the ``space`` instance.
+4. returns the largest magnitude in each column of ``X``, stores it in the corresponding entry of ``R`` and fences the default instance of ``typename XVector::execution_space``.
+
+The result (returned or stored value) is undefined if ``X`` has no entries.
+
+Note: For 3. and 4. the return view is expected to be templated on `Kokkos::HostSpace`, the function will fail with a segfault at runtime otherwise.
+
+Parameters
+==========
+
+:space: execution space instance
+
+:X: vector(s) to compute the norminf
+
+:R: computed norm(s)
+
+Type Requirements
+-----------------
+
+- `execution_space` must be a Kokkos `execution space <https://kokkos.org/kokkos-core-wiki/API/core/execution_spaces.html>`_
+
+- `XVector` must be a Kokkos `View <https://kokkos.org/kokkos-core-wiki/API/core/view/view.html>`_ of rank 1 that satisfies
+
+  - ``Kokkos::SpaceAccessibility<execution_space, typename XVector::memory_space>::accessible == true``
+
+- `XMV` must be a Kokkos `View <https://kokkos.org/kokkos-core-wiki/API/core/view/view.html>`_ of rank 1 or 2 that satisfies
+
+  - ``Kokkos::SpaceAccessibility<execution_space, typename XMV::memory_space>::accessible == true``
+
+- `RV` must be a Kokkos `View <https://kokkos.org/kokkos-core-wiki/API/core/view/view.html>`_ that satisfies
+
+  - ``RV::rank == XMV::rank - 1``
+  - ``std::is_same_v<typename RV::value_type, typename RV::non_const_value_type> == true``
+  - ``std::is_same_v<typename RV::value_type, typename KokkosKernels::Details::InnerProductSpaceTraits<typename XMV::non_const_value_type>::mag_type> == true``
+  - ``RV::memory_space == Kokkos::HostSpace``
+
+Example
+=======
+
+.. literalinclude:: ../../../../example/wiki/blas/KokkosBlas1_wiki_nrminf.cpp
+  :language: c++
+
+output:
+
+.. code::
+
+   X_nrm: 300 Expected: 300

--- a/example/docs/blas/CMakeLists.txt
+++ b/example/docs/blas/CMakeLists.txt
@@ -6,3 +6,4 @@ kokkoskernels_include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../../../test_c
 kokkoskernels_add_executable_and_test(docs_blas1_abs         SOURCES KokkosBlas1_docs_abs.cpp)
 kokkoskernels_add_executable_and_test(docs_blas1_scal        SOURCES KokkosBlas1_docs_scal.cpp)
 kokkoskernels_add_executable_and_test(docs_blas1_swap        SOURCES KokkosBlas1_docs_swap.cpp)
+kokkoskernels_add_executable_and_test(docs_blas1_nrminf      SOURCES KokkosBlas1_docs_nrminf.cpp)

--- a/example/docs/blas/KokkosBlas1_docs_nrminf.cpp
+++ b/example/docs/blas/KokkosBlas1_docs_nrminf.cpp
@@ -9,10 +9,11 @@ int main(void) {
   Kokkos::initialize();
   {
     Kokkos::View<double*> x("X", 101);
-    Kokkos::parallel_for(101, KOKKOS_LAMBDA(const int idx) {
-	const double val = static_cast<double>(idx) / 10;
-	x(idx) = (val - 10) * (val - 5) * val + 1.9;
-      });
+    Kokkos::parallel_for(
+        101, KOKKOS_LAMBDA(const int idx) {
+          const double val = static_cast<double>(idx) / 10;
+          x(idx)           = (val - 10) * (val - 5) * val + 1.9;
+        });
 
     double x_nrm = KokkosBlas::nrminf(x);
 

--- a/example/docs/blas/KokkosBlas1_docs_nrminf.cpp
+++ b/example/docs/blas/KokkosBlas1_docs_nrminf.cpp
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#include <iostream>
+#include <Kokkos_Core.hpp>
+#include <KokkosBlas1_nrminf.hpp>
+
+int main(void) {
+  Kokkos::initialize();
+  {
+    Kokkos::View<double*> x("X", 101);
+    Kokkos::parallel_for(101, KOKKOS_LAMBDA(const int idx) {
+	const double val = static_cast<double>(idx) / 10;
+	x(idx) = (val - 10) * (val - 5) * val + 1.9;
+      });
+
+    double x_nrm = KokkosBlas::nrminf(x);
+
+    std::cout << "X_nrm: " << x_nrm << " Expected: " << 50.011 << std::endl;
+  }
+  Kokkos::finalize();
+}


### PR DESCRIPTION
It appears norm inf does not allow the results to be stored on device. This seems odd but for the time being let's just fix the benchmark.
This was tested on blake H100 node and works fine, no more segfault.