### PR TITLE
[Docs] Batched norm and fix in KokkosBatched_Nrm.hpp

### DIFF
--- a/batched/dense/src/KokkosBatched_Nrm.hpp
+++ b/batched/dense/src/KokkosBatched_Nrm.hpp
@@ -3,6 +3,8 @@
 #ifndef KOKKOSBATCHED_NRM_HPP_
 #define KOKKOSBATCHED_NRM_HPP_
 
+#include "KokkosBatched_Util.hpp"
+
 /// \author Yuuichi Asahi (yuuichi.asahi@cea.fr)
 
 namespace KokkosBatched {
@@ -30,6 +32,7 @@ struct SerialNrm {
 /// If NrmType == Norm::L1, compute L1 norm of each vector in the batch
 /// If NrmType == Norm::L2, compute L2 norm of each vector in the batch
 /// If NrmType == Norm::LInf, compute Linf norm of each vector in the batch
+/// If NrmType == Norm::ScaledL2, compute ScaledL2 norm of each vector in the batch
 /// A nested parallel_for with TeamThreadRange is used.
 /// \tparam MemberType: Kokkos TeamPolicy member type
 /// \tparam NrmType: one of Norm::L1, Norm::L2, Norm::LInf
@@ -51,6 +54,7 @@ struct TeamNrm {
 /// If NrmType == Norm::L1, compute L1 norm of each vector in the batch
 /// If NrmType == Norm::L2, compute L2 norm of each vector in the batch
 /// If NrmType == Norm::LInf, compute Linf norm of each vector in the batch
+/// If NrmType == Norm::ScaledL2, compute ScaledL2 norm of each vector in the batch
 /// A nested parallel_for with TeamVectorRange is used.
 /// \tparam MemberType: Kokkos TeamPolicy member type
 /// \tparam NrmType: one of Norm::L1, Norm::L2, Norm::LInf, Norm::ScaledL2

--- a/batched/dense/unit_test/Test_Batched_Nrm.hpp
+++ b/batched/dense/unit_test/Test_Batched_Nrm.hpp
@@ -61,7 +61,7 @@ struct Functor_BatchedNrm {
 /// \tparam DeviceType Kokkos device type
 /// \tparam ScalarType Kokkos scalar type
 /// \tparam LayoutType Kokkos layout type for the views
-/// \tparam ArgNorm: one of L1, L2, Linf
+/// \tparam ArgNorm: one of L1, L2, Linf, ScaledL2
 /// \tparam ArgMode: one of Mode::Serial, Mode::Team, Mode::TeamVector
 ///
 /// \param[in] Nb Batch size of vectors
@@ -139,8 +139,8 @@ void impl_test_batched_nrm_analytical(const std::size_t Nb) {
 /// 3.4e38 and 1e308 are the largest representable finite values for fp32 and fp64 respectively.
 /// For fp32, where x^2 is expected to overflow
 /// x = [1e20, 1e20, 1e20]
-/// z = [1e200 + 1e200j, 1e200 + 1e200j, 1e200 + 1e200j]
-/// L2 norm: x: sqrt(3) * 1e200, z: sqrt(6) * 1e200
+/// z = [1e20 + 1e20j, 1e20 + 1e20j, 1e20 + 1e20j]
+/// L2 norm: x: sqrt(3) * 1e20, z: sqrt(6) * 1e20
 ///
 /// For fp64, where x^2 is expected to overflow
 /// x = [1e200, 1e200, 1e200]

--- a/docs/source/API/batched/dense-index.rst
+++ b/docs/source/API/batched/dense-index.rst
@@ -12,6 +12,7 @@ API: Batched Dense (DLA)
    dense/batched_axpy
    dense/batched_copy
    dense/batched_dot
+   dense/batched_nrm
    dense/batched_iamax
    dense/batched_trsv
    dense/batched_tbsv
@@ -152,13 +153,13 @@ BLAS 1
      - :doc:`TeamDot <dense/batched_dot>`
      - :doc:`TeamVectorDot <dense/batched_dot>`
    * - NRM2
-     - --
-     - --
-     - --
+     - :doc:`SerialNrm <dense/batched_nrm>`
+     - :doc:`TeamNrm <dense/batched_nrm>`
+     - :doc:`TeamVectorNrm <dense/batched_nrm>`
    * - ASUM
-     - --
-     - --
-     - --
+     - :doc:`SerialNrm <dense/batched_nrm>`
+     - :doc:`TeamNrm <dense/batched_nrm>`
+     - :doc:`TeamVectorNrm <dense/batched_nrm>`
    * - IAMAX
      - :doc:`SerialIamax <dense/batched_iamax>`
      - --

--- a/docs/source/API/batched/dense/batched_dot.rst
+++ b/docs/source/API/batched/dense/batched_dot.rst
@@ -38,6 +38,7 @@ Performs the dot product of two vectors :math:`X` and :math:`Y`.
 .. note::
   
   This kernel does not support the BLAS routine `SDSDOT <https://www.netlib.org/blas/sdsdot.f>`_ which returns the single precision dot product of two single precision vectors with dot product accumulated in double precision.
+  For `DSDOT <https://www.netlib.org/blas/dsdot.f>`_, provide :math:`X` and :math:`Y` in single precision and provide the output :math:`dot` in double precision.
 
 Parameters
 ==========

--- a/docs/source/API/batched/dense/batched_nrm.rst
+++ b/docs/source/API/batched/dense/batched_nrm.rst
@@ -1,0 +1,75 @@
+KokkosBatched::Nrm
+##################
+
+Defined in header: :code:`KokkosBatched_Nrm.hpp`
+
+.. code:: c++
+
+  template <typename NrmType>
+  struct SerialNrm {
+    template <typename XViewType, typename NormViewType>
+    KOKKOS_INLINE_FUNCTION static int invoke(const XViewType &X, const NormViewType &norm);
+  };
+
+  template <typename MemberType, typename NrmType>
+  struct TeamNrm {
+    template <typename XViewType, typename NormViewType>
+    KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const XViewType &X, const NormViewType &norm);
+  };
+
+  template <typename MemberType, typename NrmType>
+  struct TeamVectorNrm {
+    template <typename XViewType, typename NormViewType>
+    KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const XViewType &X, const NormViewType &norm);
+  };
+
+Computes the :math:`L1`, :math:`L2` or :math:`L_\infty` norm of a vector :math:`X`.
+
+.. math::
+
+   \begin{align}
+   norm &= ||x|| \: \text{(if NrmType == KokkosBatched::Norm::L1)} \\
+   norm &= ||x||_2 \: \text{(if NrmType == KokkosBatched::Norm::L2 or NrmType == KokkosBatched::Norm::ScaledL2)} \\
+   norm &= ||x||_\infty \: \text{(if NrmType == KokkosBatched::Norm::LInf)}
+   \end{align}
+
+1. If ``NrmType == KokkosBatched::Norm::L1``, this operation is equivalent to the BLAS routine `SASUM <https://www.netlib.org/blas/sasum.f>`_ (`SCASUM <https://www.netlib.org/blas/scasum.f>`_) or `DASUM <https://www.netlib.org/blas/dasum.f>`_ (`DZASUM <https://www.netlib.org/blas/dzasum.f>`_) for single or double precision for real (complex) vectors.
+2. If ``NrmType == KokkosBatched::Norm::L2`` or ``NrmType == KokkosBatched::Norm::ScaledL2``, this operation is equivalent to the BLAS routine `SNRM2 <https://www.netlib.org/lapack/lapack-3.1.1/html/snrm2.f.html>`_ (`SCNRM2 <https://www.netlib.org/lapack/lapack-3.1.1/html/scnrm2.f.html>`_) or `DNRM2 <https://www.netlib.org/lapack/lapack-3.1.1/html/dnrm2.f.html>`_ (`DZNRM2 <https://www.netlib.org/lapack/lapack-3.1.1/html/dznrm2.f.html>`_) for single or double precision for real (complex) vectors.
+3. If ``NrmType == KokkosBatched::Norm::LInf``, this operation is related to the BLAS routine `ISAMAX <https://www.netlib.org/blas/isamax.f>`_ (`ICAMAX <https://www.netlib.org/blas/icamax.f>`_) or `IDAMAX <https://www.netlib.org/blas/idamax.f>`_ (`IZAMAX <https://www.netlib.org/blas/izamax.f>`_) for single or double precision for real (complex) vectors, where the index of the maximum absolute value is returned in the output :math:`norm`. This routine returns the maximum absolute value instead.
+
+.. note::
+  
+  Though ``NrmType == KokkosBatched::Norm::L2`` is more efficient, it may overflow for large vectors. For large vectors, ``NrmType == KokkosBatched::Norm::ScaledL2`` is recommended as it uses a numerically stable algorithm to compute the :math:`L2` norm that avoids overflow and underflow by scaling the input vector :math:`X` by the maximum absolute value of its elements that has been encountered.
+
+Parameters
+==========
+
+:X: On input, :math:`X` is a length :math:`n` vector
+:norm: On output, :math:`norm` is the computed norm of the vector :math:`X`.
+
+Type Requirements
+-----------------
+
+- ``MemberType`` must be a Kokkos team member handle (only for ``TeamNrm`` and ``TeamVectorNrm``)
+
+- ``NrmType`` must be one of the following:
+   - ``KokkosBatched::Norm::L1`` for :math:`L1` norm
+   - ``KokkosBatched::Norm::L2`` or ``KokkosBatched::Norm::ScaledL2`` for :math:`L2` norm
+   - ``KokkosBatched::Norm::LInf`` for :math:`L_\infty` norm
+
+- ``XViewType`` must be a Kokkos `View <https://kokkos.org/kokkos-core-wiki/API/core/view/view.html>`_ of rank 1 containing a vector or matrix :math:`X`
+- ``NormViewType`` must be a Kokkos `View <https://kokkos.org/kokkos-core-wiki/API/core/view/view.html>`_ of rank 0 containing the output :math:`norm`. The norm is accumulated in the type of the elements of ``NormViewType``
+
+Example
+=======
+
+.. literalinclude:: ../../../../../example/batched_solve/serial_nrm.cpp
+  :language: c++
+  :linenos:
+  :lines: 4-
+
+output:
+
+.. code::
+
+   nrm works correctly!

--- a/example/batched_solve/CMakeLists.txt
+++ b/example/batched_solve/CMakeLists.txt
@@ -40,3 +40,5 @@ kokkoskernels_add_executable(serial_rot SOURCES serial_rot.cpp)
 kokkoskernels_add_executable(serial_rotm SOURCES serial_rotm.cpp)
 
 kokkoskernels_add_executable(serial_dot SOURCES serial_dot.cpp)
+
+kokkoskernels_add_executable(serial_nrm SOURCES serial_nrm.cpp)

--- a/example/batched_solve/serial_dot.cpp
+++ b/example/batched_solve/serial_dot.cpp
@@ -38,7 +38,7 @@ int main(int /*argc*/, char** /*argv*/) {
     Kokkos::deep_copy(x, h_x);
     Kokkos::deep_copy(y, h_y);
 
-    // Compute givens rotation coefficients and apply the rotation to x and y
+    // Compute dot = x^T * y
     ExecutionSpace exec;
     using policy_type = Kokkos::RangePolicy<ExecutionSpace, Kokkos::IndexType<int>>;
     policy_type policy{exec, 0, Nb};

--- a/example/batched_solve/serial_nrm.cpp
+++ b/example/batched_solve/serial_nrm.cpp
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#include <iostream>
+#include <Kokkos_Core.hpp>
+#include <KokkosBatched_Nrm.hpp>
+
+using ExecutionSpace = Kokkos::DefaultExecutionSpace;
+
+/// \brief Example of batched nrm
+/// computing nrm = ||x||_2 for a batch of vectors x.
+///
+/// Usage example:
+///        x: [1, 3, 5]
+///        nrm: sqrt(1^2 + 3^2 + 5^2) = sqrt(35)
+///
+int main(int /*argc*/, char** /*argv*/) {
+  Kokkos::initialize();
+  {
+    using View1DType = Kokkos::View<double*, ExecutionSpace>;
+    using View2DType = Kokkos::View<double**, ExecutionSpace>;
+    const int Nb = 10, n = 3;
+
+    // Vector x
+    View2DType x("x", Nb, n);
+    View1DType norm("norm", Nb);
+
+    // Initialize x
+    auto h_x = Kokkos::create_mirror_view(x);
+    for (int ib = 0; ib < Nb; ib++) {
+      h_x(ib, 0) = 1;
+      h_x(ib, 1) = 3;
+      h_x(ib, 2) = 5;
+    }
+    Kokkos::deep_copy(x, h_x);
+
+    // Compute L2 norm of x
+    ExecutionSpace exec;
+    using policy_type = Kokkos::RangePolicy<ExecutionSpace, Kokkos::IndexType<int>>;
+    policy_type policy{exec, 0, Nb};
+    Kokkos::parallel_for(
+        "nrm", policy, KOKKOS_LAMBDA(int ib) {
+          auto sub_x    = Kokkos::subview(x, ib, Kokkos::ALL());
+          auto sub_norm = Kokkos::subview(norm, ib);
+          KokkosBatched::SerialNrm<KokkosBatched::Norm::L2>::invoke(sub_x, sub_norm);
+        });
+
+    // Confirm that the results are correct
+    auto h_norm  = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, norm);
+    bool correct = true;
+    double eps   = 1.0e-12;
+    for (int ib = 0; ib < Nb; ib++) {
+      if (Kokkos::abs(h_norm(ib) - std::sqrt(35)) > eps) correct = false;
+    }
+
+    if (correct) {
+      std::cout << "nrm works correctly!" << std::endl;
+    }
+  }
+  Kokkos::finalize();
+}

--- a/example/batched_solve/serial_nrm.cpp
+++ b/example/batched_solve/serial_nrm.cpp
@@ -50,7 +50,7 @@ int main(int /*argc*/, char** /*argv*/) {
     bool correct = true;
     double eps   = 1.0e-12;
     for (int ib = 0; ib < Nb; ib++) {
-      if (Kokkos::abs(h_norm(ib) - std::sqrt(35)) > eps) correct = false;
+      if (Kokkos::abs(h_norm(ib) - Kokkos::sqrt(35)) > eps) correct = false;
     }
 
     if (correct) {


### PR DESCRIPTION
- [x] Update dense-index.rst
- [x] Add docs for batched norm
- [x] Add a minimal working example which is embedded in docs
- [x] Minor fix in `dot` documentation and examples
- [x] Minor fix in `nrm` docstrings in src and tests
- [x] Fix missing include in `KokkosBatched_Nrm.hpp`