### PR TITLE
Fixing the olcf workflow

### DIFF
--- a/.gitlab/frontier-ctest.cmake
+++ b/.gitlab/frontier-ctest.cmake
@@ -10,17 +10,17 @@ set(CTEST_UPDATE_COMMAND /usr/bin/git)
 set(CTEST_CONFIGURE_COMMAND "cmake -S ${CTEST_SOURCE_DIRECTORY} \
 			    	   -B ${CTEST_BINARY_DIRECTORY} \
 			    	   -DCMAKE_CXX_COMPILER=hipcc \
-			    	   -DCMAKE_INSTALL_PREFIX=$ENV{PWD}/kokkos-kernels/install
-			    	   -DCMAKE_BUILD_TYPE="Release"
-			    	   -DCMAKE_VERBOSE_MAKEFILE=ON
-				   -DKokkos_ROOT=${CTEST_SOURCE_DIRECTORY}/kokkos/install
-			    	   -DKokkosKernels_INST_COMPLEX_DOUBLE=ON
-			    	   -DKokkosKernels_ENABLE_TPL_ROCSOLVER=ON
-			    	   -DKokkosKernels_ENABLE_TPL_ROCSPARSE=ON
-			    	   -DKokkosKernels_ENABLE_TPL_ROCBLAS=ON
-			    	   -DKokkosKernels_ENABLE_TESTS=ON
-			    	   -DKokkosKernels_ENABLE_EXAMPLES:BOOL=ON
-			    	   -DKokkosKernels_ENABLE_BENCHMARKS:BOOL=ON
+			    	   -DCMAKE_INSTALL_PREFIX=$ENV{PWD}/kokkos-kernels/install \
+			    	   -DCMAKE_BUILD_TYPE="Release" \
+			    	   -DCMAKE_VERBOSE_MAKEFILE=ON \
+				   -DKokkos_ROOT=${CTEST_SOURCE_DIRECTORY}/kokkos/install \
+			    	   -DKokkosKernels_INST_COMPLEX_DOUBLE=ON \
+			    	   -DKokkosKernels_ENABLE_TPL_ROCSOLVER=ON \
+			    	   -DKokkosKernels_ENABLE_TPL_ROCSPARSE=ON \
+			    	   -DKokkosKernels_ENABLE_TPL_ROCBLAS=ON \
+			    	   -DKokkosKernels_ENABLE_TESTS=ON \
+			    	   -DKokkosKernels_ENABLE_EXAMPLES:BOOL=ON \
+			    	   -DKokkosKernels_ENABLE_BENCHMARKS:BOOL=ON \
       			    	   -DKokkosKernels_RUN_BENCHMARKS:BOOL=ON")
 
 set(CTEST_BUILD_COMMAND "cmake --build ${CTEST_BINARY_DIRECTORY} -j 48")

--- a/.gitlab/frontier-ctest.cmake
+++ b/.gitlab/frontier-ctest.cmake
@@ -8,20 +8,20 @@ set(CTEST_START_WITH_EMPTY_BINARY_DIRECTORY TRUE)
 
 set(CTEST_UPDATE_COMMAND /usr/bin/git)
 set(CTEST_CONFIGURE_COMMAND "cmake -S ${CTEST_SOURCE_DIRECTORY} \
-			    	   -B ${CTEST_BINARY_DIRECTORY} \
-			    	   -DCMAKE_CXX_COMPILER=hipcc \
-			    	   -DCMAKE_INSTALL_PREFIX=$ENV{PWD}/kokkos-kernels/install \
-			    	   -DCMAKE_BUILD_TYPE="Release" \
-			    	   -DCMAKE_VERBOSE_MAKEFILE=ON \
-				   -DKokkos_ROOT=${CTEST_SOURCE_DIRECTORY}/kokkos/install \
-			    	   -DKokkosKernels_INST_COMPLEX_DOUBLE=ON \
-			    	   -DKokkosKernels_ENABLE_TPL_ROCSOLVER=ON \
-			    	   -DKokkosKernels_ENABLE_TPL_ROCSPARSE=ON \
-			    	   -DKokkosKernels_ENABLE_TPL_ROCBLAS=ON \
-			    	   -DKokkosKernels_ENABLE_TESTS=ON \
-			    	   -DKokkosKernels_ENABLE_EXAMPLES:BOOL=ON \
-			    	   -DKokkosKernels_ENABLE_BENCHMARKS:BOOL=ON \
-      			    	   -DKokkosKernels_RUN_BENCHMARKS:BOOL=ON")
+                                   -B ${CTEST_BINARY_DIRECTORY} \
+                                   -DCMAKE_CXX_COMPILER=hipcc \
+                                   -DCMAKE_INSTALL_PREFIX=$ENV{PWD}/kokkos-kernels/install \
+                                   -DCMAKE_BUILD_TYPE="Release" \
+                                   -DCMAKE_VERBOSE_MAKEFILE=ON \
+                                   -DKokkos_ROOT=${CTEST_SOURCE_DIRECTORY}/kokkos/install \
+                                   -DKokkosKernels_INST_COMPLEX_DOUBLE=ON \
+                                   -DKokkosKernels_ENABLE_TPL_ROCSOLVER=ON \
+                                   -DKokkosKernels_ENABLE_TPL_ROCSPARSE=ON \
+                                   -DKokkosKernels_ENABLE_TPL_ROCBLAS=ON \
+                                   -DKokkosKernels_ENABLE_TESTS=ON \
+                                   -DKokkosKernels_ENABLE_EXAMPLES:BOOL=ON \
+                                   -DKokkosKernels_ENABLE_BENCHMARKS:BOOL=ON \
+                                   -DKokkosKernels_RUN_BENCHMARKS:BOOL=ON")
 
 set(CTEST_BUILD_COMMAND "cmake --build ${CTEST_BINARY_DIRECTORY} -j 48")
 


### PR DESCRIPTION
There were missing line return statements in the cmake fragment