### PR TITLE
Add genuine l1 norm

### DIFF
--- a/batched/KokkosBatched_Util.hpp
+++ b/batched/KokkosBatched_Util.hpp
@@ -256,6 +256,7 @@ struct Norm {
   struct L2 {};
   struct LInf {};
   struct ScaledL2 {};
+  struct GenuineL1 {};
 };
 
 template <class T>
@@ -272,6 +273,9 @@ struct is_norm<Norm::LInf> : std::true_type {};
 
 template <>
 struct is_norm<Norm::ScaledL2> : std::true_type {};
+
+template <>
+struct is_norm<Norm::GenuineL1> : std::true_type {};
 
 template <class T>
 constexpr bool is_norm_v = is_norm<T>::value;

--- a/batched/dense/impl/KokkosBatched_Nrm_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Nrm_Internal.hpp
@@ -224,7 +224,9 @@ KOKKOS_INLINE_FUNCTION void TeamNrmInternal<MemberType, NrmType>::invoke(const M
   } else if constexpr (std::is_same_v<NrmType, Norm::GenuineL1>) {
     Kokkos::parallel_reduce(
         Kokkos::TeamThreadRange(member, n),
-        [&](const int i, NrmValueType &thread_nrm) { thread_nrm += KokkosKernels::ArithTraits<ValueType>::abs(x[i * xs0]); },
+        [&](const int i, NrmValueType &thread_nrm) {
+          thread_nrm += KokkosKernels::ArithTraits<ValueType>::abs(x[i * xs0]);
+        },
         nrm);
   }
 
@@ -287,7 +289,9 @@ KOKKOS_INLINE_FUNCTION void TeamVectorNrmInternal<MemberType, NrmType>::invoke(c
   } else if constexpr (std::is_same_v<NrmType, Norm::GenuineL1>) {
     Kokkos::parallel_reduce(
         Kokkos::TeamVectorRange(member, n),
-        [&](const int i, NrmValueType &thread_nrm) { thread_nrm += KokkosKernels::ArithTraits<ValueType>::abs(x[i * xs0]); },
+        [&](const int i, NrmValueType &thread_nrm) {
+          thread_nrm += KokkosKernels::ArithTraits<ValueType>::abs(x[i * xs0]);
+        },
         nrm);
   }
   *norm = nrm;

--- a/batched/dense/impl/KokkosBatched_Nrm_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Nrm_Internal.hpp
@@ -159,6 +159,10 @@ KOKKOS_INLINE_FUNCTION void SerialNrmInternal<NrmType>::invoke(const int n, cons
       }
       nrm = scale * KokkosKernels::ArithTraits<NrmValueType>::sqrt(sumsq);
     }
+  } else if constexpr (std::is_same_v<NrmType, Norm::GenuineL1>) {
+    for (int i = 0; i < n; ++i) {
+      nrm += KokkosKernels::ArithTraits<ValueType>::abs(x[i * xs0]);
+    }
   }
 
   *norm = nrm;
@@ -217,6 +221,11 @@ KOKKOS_INLINE_FUNCTION void TeamNrmInternal<MemberType, NrmType>::invoke(const M
       const auto [scale, sumsq] = accumulator.reference();
       nrm                       = scale * KokkosKernels::ArithTraits<NrmValueType>::sqrt(sumsq);
     }
+  } else if constexpr (std::is_same_v<NrmType, Norm::GenuineL1>) {
+    Kokkos::parallel_reduce(
+        Kokkos::TeamThreadRange(member, n),
+        [&](const int i, NrmValueType &thread_nrm) { thread_nrm += KokkosKernels::ArithTraits<ValueType>::abs(x[i * xs0]); },
+        nrm);
   }
 
   *norm = nrm;
@@ -275,6 +284,11 @@ KOKKOS_INLINE_FUNCTION void TeamVectorNrmInternal<MemberType, NrmType>::invoke(c
       const auto [scale, sumsq] = accumulator.reference();
       nrm                       = scale * KokkosKernels::ArithTraits<NrmValueType>::sqrt(sumsq);
     }
+  } else if constexpr (std::is_same_v<NrmType, Norm::GenuineL1>) {
+    Kokkos::parallel_reduce(
+        Kokkos::TeamVectorRange(member, n),
+        [&](const int i, NrmValueType &thread_nrm) { thread_nrm += KokkosKernels::ArithTraits<ValueType>::abs(x[i * xs0]); },
+        nrm);
   }
   *norm = nrm;
 }

--- a/batched/dense/src/KokkosBatched_Nrm.hpp
+++ b/batched/dense/src/KokkosBatched_Nrm.hpp
@@ -17,11 +17,13 @@ namespace KokkosBatched {
 /// No nested parallel_for is used inside of the function.
 /// \tparam NrmType: one of Norm::L1, Norm::L2, Norm::LInf, Norm::ScaledL2, Norm::GenuineL1
 /// \note With L1 and GenuineL1, we compute the norm by sum (|Re(x_i)| + |Im(x_i)|) and sum (|x_i|), respectively.
-/// Though L2 is more efficient, it may overflow for large vectors. For large vectors, use ScaledL2, which computes the norm by scaling the vector to avoid overflow.
+/// Though L2 is more efficient, it may overflow for large vectors. For large vectors, use ScaledL2, which computes the
+/// norm by scaling the vector to avoid overflow.
 template <typename NrmType>
 struct SerialNrm {
   static_assert(is_norm_v<NrmType>,
-                "KokkosBatched::SerialNrm: NrmType must be one of Norm::L1, Norm::L2, Norm::LInf, Norm::ScaledL2, Norm::GenuineL1");
+                "KokkosBatched::SerialNrm: NrmType must be one of Norm::L1, Norm::L2, Norm::LInf, Norm::ScaledL2, "
+                "Norm::GenuineL1");
   /// \tparam XViewType: Type for input X, needs to be a 1D view
   /// \tparam NormViewType: Type for output norm, needs to be a 0D view
   ///
@@ -41,11 +43,13 @@ struct SerialNrm {
 /// \tparam MemberType: Kokkos TeamPolicy member type
 /// \tparam NrmType: one of Norm::L1, Norm::L2, Norm::LInf, Norm::ScaledL2, Norm::GenuineL1
 /// \note With L1 and GenuineL1, we compute the norm by sum (|Re(x_i)| + |Im(x_i)|) and sum (|x_i|), respectively.
-/// Though L2 is more efficient, it may overflow for large vectors. For large vectors, use ScaledL2, which computes the norm by scaling the vector to avoid overflow.
+/// Though L2 is more efficient, it may overflow for large vectors. For large vectors, use ScaledL2, which computes the
+/// norm by scaling the vector to avoid overflow.
 template <typename MemberType, typename NrmType>
 struct TeamNrm {
-  static_assert(is_norm_v<NrmType>,
-                "KokkosBatched::TeamNrm: NrmType must be one of Norm::L1, Norm::L2, Norm::LInf, Norm::ScaledL2, Norm::GenuineL1");
+  static_assert(
+      is_norm_v<NrmType>,
+      "KokkosBatched::TeamNrm: NrmType must be one of Norm::L1, Norm::L2, Norm::LInf, Norm::ScaledL2, Norm::GenuineL1");
   /// \tparam XViewType: Type for input X, needs to be a 1D view
   /// \tparam NormViewType: Type for output norm, needs to be a 0D view
   ///
@@ -62,16 +66,18 @@ struct TeamNrm {
 /// If NrmType == Norm::LInf, compute Linf norm of each vector in the batch
 /// If NrmType == Norm::ScaledL2, compute ScaledL2 norm of each vector in the batch
 /// If NrmType == Norm::GenuineL1, compute GenuineL1 norm of each vector in the batch
-/// 
+///
 /// A nested parallel_for with TeamVectorRange is used.
 /// \tparam MemberType: Kokkos TeamPolicy member type
 /// \tparam NrmType: one of Norm::L1, Norm::L2, Norm::LInf, Norm::ScaledL2, Norm::GenuineL1
 /// \note With L1 and GenuineL1, we compute the norm by sum (|Re(x_i)| + |Im(x_i)|) and sum (|x_i|), respectively.
-/// Though L2 is more efficient, it may overflow for large vectors. For large vectors, use ScaledL2, which computes the norm by scaling the vector to avoid overflow.
+/// Though L2 is more efficient, it may overflow for large vectors. For large vectors, use ScaledL2, which computes the
+/// norm by scaling the vector to avoid overflow.
 template <typename MemberType, typename NrmType>
 struct TeamVectorNrm {
   static_assert(is_norm_v<NrmType>,
-                "KokkosBatched::TeamVectorNrm: NrmType must be one of Norm::L1, Norm::L2, Norm::LInf, Norm::ScaledL2, Norm::GenuineL1");
+                "KokkosBatched::TeamVectorNrm: NrmType must be one of Norm::L1, Norm::L2, Norm::LInf, Norm::ScaledL2, "
+                "Norm::GenuineL1");
   /// \tparam XViewType: Type for input X, needs to be a 1D view
   /// \tparam NormViewType: Type for output norm, needs to be a 0D view
   ///

--- a/batched/dense/src/KokkosBatched_Nrm.hpp
+++ b/batched/dense/src/KokkosBatched_Nrm.hpp
@@ -13,12 +13,15 @@ namespace KokkosBatched {
 /// If NrmType == Norm::L2, compute L2 norm of each vector in the batch
 /// If NrmType == Norm::LInf, compute Linf norm of each vector in the batch
 /// If NrmType == Norm::ScaledL2, compute ScaledL2 norm of each vector in the batch
+/// If NrmType == Norm::GenuineL1, compute GenuineL1 norm of each vector in the batch
 /// No nested parallel_for is used inside of the function.
-/// \tparam NrmType: one of Norm::L1, Norm::L2, Norm::LInf, Norm::ScaledL2
+/// \tparam NrmType: one of Norm::L1, Norm::L2, Norm::LInf, Norm::ScaledL2, Norm::GenuineL1
+/// \note With L1 and GenuineL1, we compute the norm by sum (|Re(x_i)| + |Im(x_i)|) and sum (|x_i|), respectively.
+/// Though L2 is more efficient, it may overflow for large vectors. For large vectors, use ScaledL2, which computes the norm by scaling the vector to avoid overflow.
 template <typename NrmType>
 struct SerialNrm {
   static_assert(is_norm_v<NrmType>,
-                "KokkosBatched::SerialNrm: NrmType must be one of Norm::L1, Norm::L2, Norm::LInf, Norm::ScaledL2");
+                "KokkosBatched::SerialNrm: NrmType must be one of Norm::L1, Norm::L2, Norm::LInf, Norm::ScaledL2, Norm::GenuineL1");
   /// \tparam XViewType: Type for input X, needs to be a 1D view
   /// \tparam NormViewType: Type for output norm, needs to be a 0D view
   ///
@@ -33,13 +36,16 @@ struct SerialNrm {
 /// If NrmType == Norm::L2, compute L2 norm of each vector in the batch
 /// If NrmType == Norm::LInf, compute Linf norm of each vector in the batch
 /// If NrmType == Norm::ScaledL2, compute ScaledL2 norm of each vector in the batch
+/// If NrmType == Norm::GenuineL1, compute GenuineL1 norm of each vector in the batch
 /// A nested parallel_for with TeamThreadRange is used.
 /// \tparam MemberType: Kokkos TeamPolicy member type
-/// \tparam NrmType: one of Norm::L1, Norm::L2, Norm::LInf
+/// \tparam NrmType: one of Norm::L1, Norm::L2, Norm::LInf, Norm::ScaledL2, Norm::GenuineL1
+/// \note With L1 and GenuineL1, we compute the norm by sum (|Re(x_i)| + |Im(x_i)|) and sum (|x_i|), respectively.
+/// Though L2 is more efficient, it may overflow for large vectors. For large vectors, use ScaledL2, which computes the norm by scaling the vector to avoid overflow.
 template <typename MemberType, typename NrmType>
 struct TeamNrm {
   static_assert(is_norm_v<NrmType>,
-                "KokkosBatched::TeamNrm: NrmType must be one of Norm::L1, Norm::L2, Norm::LInf, Norm::ScaledL2");
+                "KokkosBatched::TeamNrm: NrmType must be one of Norm::L1, Norm::L2, Norm::LInf, Norm::ScaledL2, Norm::GenuineL1");
   /// \tparam XViewType: Type for input X, needs to be a 1D view
   /// \tparam NormViewType: Type for output norm, needs to be a 0D view
   ///
@@ -55,13 +61,17 @@ struct TeamNrm {
 /// If NrmType == Norm::L2, compute L2 norm of each vector in the batch
 /// If NrmType == Norm::LInf, compute Linf norm of each vector in the batch
 /// If NrmType == Norm::ScaledL2, compute ScaledL2 norm of each vector in the batch
+/// If NrmType == Norm::GenuineL1, compute GenuineL1 norm of each vector in the batch
+/// 
 /// A nested parallel_for with TeamVectorRange is used.
 /// \tparam MemberType: Kokkos TeamPolicy member type
-/// \tparam NrmType: one of Norm::L1, Norm::L2, Norm::LInf, Norm::ScaledL2
+/// \tparam NrmType: one of Norm::L1, Norm::L2, Norm::LInf, Norm::ScaledL2, Norm::GenuineL1
+/// \note With L1 and GenuineL1, we compute the norm by sum (|Re(x_i)| + |Im(x_i)|) and sum (|x_i|), respectively.
+/// Though L2 is more efficient, it may overflow for large vectors. For large vectors, use ScaledL2, which computes the norm by scaling the vector to avoid overflow.
 template <typename MemberType, typename NrmType>
 struct TeamVectorNrm {
   static_assert(is_norm_v<NrmType>,
-                "KokkosBatched::TeamVectorNrm: NrmType must be one of Norm::L1, Norm::L2, Norm::LInf, Norm::ScaledL2");
+                "KokkosBatched::TeamVectorNrm: NrmType must be one of Norm::L1, Norm::L2, Norm::LInf, Norm::ScaledL2, Norm::GenuineL1");
   /// \tparam XViewType: Type for input X, needs to be a 1D view
   /// \tparam NormViewType: Type for output norm, needs to be a 0D view
   ///

--- a/batched/dense/unit_test/Test_Batched_Nrm.hpp
+++ b/batched/dense/unit_test/Test_Batched_Nrm.hpp
@@ -370,7 +370,7 @@ TEST_F(TestCategory, test_batched_serial_nrm_scaled_l2_float) {
 }
 TEST_F(TestCategory, test_batched_serial_nrm_genuinel1_float) {
   test_batched_nrm<TestDevice, float, KokkosBatched::Norm::GenuineL1, KokkosBatched::Mode::Serial>();
-};
+}
 
 // Team
 TEST_F(TestCategory, test_batched_team_nrm_l1_float) {
@@ -476,7 +476,7 @@ TEST_F(TestCategory, test_batched_serial_nrm_scaled_l2_fcomplex) {
 }
 TEST_F(TestCategory, test_batched_serial_nrm_genuinel1_fcomplex) {
   test_batched_nrm<TestDevice, Kokkos::complex<float>, KokkosBatched::Norm::GenuineL1, KokkosBatched::Mode::Serial>();
-};
+}
 
 // Team
 TEST_F(TestCategory, test_batched_team_nrm_l1_fcomplex) {

--- a/batched/dense/unit_test/Test_Batched_Nrm.hpp
+++ b/batched/dense/unit_test/Test_Batched_Nrm.hpp
@@ -57,11 +57,12 @@ struct Functor_BatchedNrm {
 /// L1 norm: x: 9, z: 21
 /// L2 norm: x: sqrt(1^2 + 3^2 + 5^2) = sqrt(35), z: sqrt((1^2 + 2^2) + (3^2 + 4^2) + (5^2 + 6^2)) = sqrt(91)
 /// Linf norm: x: 5, z: sqrt(5^2 + 6^2) = sqrt(61)
+/// GenuineL1 norm: x: 9, z: sqrt(1^2 + 2^2) + sqrt(3^2 + 4^2) + sqrt(5^2 + 6^2) = sqrt(5) + sqrt(25) + sqrt(61)
 ///
 /// \tparam DeviceType Kokkos device type
 /// \tparam ScalarType Kokkos scalar type
 /// \tparam LayoutType Kokkos layout type for the views
-/// \tparam ArgNorm: one of L1, L2, Linf, ScaledL2
+/// \tparam ArgNorm: one of L1, L2, Linf, ScaledL2, GenuineL1
 /// \tparam ArgMode: one of Mode::Serial, Mode::Team, Mode::TeamVector
 ///
 /// \param[in] Nb Batch size of vectors
@@ -98,18 +99,21 @@ void impl_test_batched_nrm_analytical(const std::size_t Nb) {
                        : std::is_same_v<ArgNorm, Norm::L2>       ? Kokkos::sqrt(RealType(91))
                        : std::is_same_v<ArgNorm, Norm::LInf>     ? Kokkos::sqrt(RealType(61))
                        : std::is_same_v<ArgNorm, Norm::ScaledL2> ? Kokkos::sqrt(RealType(91))
-                                                                 : RealType(-1);
+                       : std::is_same_v<ArgNorm, Norm::GenuineL1>
+                           ? (Kokkos::sqrt(RealType(5)) + 5 + Kokkos::sqrt(RealType(61)))
+                           : RealType(-1);
     } else {
       h_x(ib, 0) = ScalarType(1);
       h_x(ib, 1) = ScalarType(3);
       h_x(ib, 2) = ScalarType(5);
 
       // L1 norm: 9, L2 norm: sqrt(35), Linf norm: 5
-      h_norm_ref(ib) = std::is_same_v<ArgNorm, Norm::L1>         ? RealType(9)
-                       : std::is_same_v<ArgNorm, Norm::L2>       ? ats::sqrt(RealType(35))
-                       : std::is_same_v<ArgNorm, Norm::LInf>     ? RealType(5)
-                       : std::is_same_v<ArgNorm, Norm::ScaledL2> ? ats::sqrt(RealType(35))
-                                                                 : RealType(-1);
+      h_norm_ref(ib) = std::is_same_v<ArgNorm, Norm::L1>          ? RealType(9)
+                       : std::is_same_v<ArgNorm, Norm::L2>        ? ats::sqrt(RealType(35))
+                       : std::is_same_v<ArgNorm, Norm::LInf>      ? RealType(5)
+                       : std::is_same_v<ArgNorm, Norm::ScaledL2>  ? ats::sqrt(RealType(35))
+                       : std::is_same_v<ArgNorm, Norm::GenuineL1> ? RealType(9)
+                                                                  : RealType(-1);
     }
   }
 
@@ -222,7 +226,7 @@ void impl_test_batched_nrm_overflow(const std::size_t Nb) {
 /// \tparam DeviceType Kokkos device type
 /// \tparam ScalarType Kokkos scalar type
 /// \tparam LayoutType Kokkos layout type for the views
-/// \tparam ArgNorm: one of L1, L2, Linf, ScaledL2
+/// \tparam ArgNorm: one of L1, L2, Linf, ScaledL2, GenuineL1
 /// \tparam ArgMode: one of Mode::Serial, Mode::Team, Mode::TeamVector
 ///
 /// \param[in] Nb Batch size of vectors
@@ -290,6 +294,10 @@ void impl_test_batched_nrm(const std::size_t Nb, const std::size_t N) {
         const auto abs_val = ats::abs(h_x(ib, i));
         if (abs_val > norm_tmp) norm_tmp = abs_val;
       }
+    } else if constexpr (std::is_same_v<ArgNorm, Norm::GenuineL1>) {
+      for (std::size_t i = 0; i < N; i++) {
+        norm_tmp += ats::abs(h_x(ib, i));
+      }
     }
     h_norm_ref(ib) = norm_tmp;
   }
@@ -354,14 +362,15 @@ TEST_F(TestCategory, test_batched_serial_nrm_l1_float) {
 TEST_F(TestCategory, test_batched_serial_nrm_l2_float) {
   test_batched_nrm<TestDevice, float, KokkosBatched::Norm::L2, KokkosBatched::Mode::Serial>();
 }
-
 TEST_F(TestCategory, test_batched_serial_nrm_linf_float) {
   test_batched_nrm<TestDevice, float, KokkosBatched::Norm::LInf, KokkosBatched::Mode::Serial>();
 }
-
 TEST_F(TestCategory, test_batched_serial_nrm_scaled_l2_float) {
   test_batched_nrm<TestDevice, float, KokkosBatched::Norm::ScaledL2, KokkosBatched::Mode::Serial>();
 }
+TEST_F(TestCategory, test_batched_serial_nrm_genuinel1_float) {
+  test_batched_nrm<TestDevice, float, KokkosBatched::Norm::GenuineL1, KokkosBatched::Mode::Serial>();
+};
 
 // Team
 TEST_F(TestCategory, test_batched_team_nrm_l1_float) {
@@ -376,6 +385,9 @@ TEST_F(TestCategory, test_batched_team_nrm_linf_float) {
 TEST_F(TestCategory, test_batched_team_nrm_scaled_l2_float) {
   test_batched_nrm<TestDevice, float, KokkosBatched::Norm::ScaledL2, KokkosBatched::Mode::Team>();
 }
+TEST_F(TestCategory, test_batched_team_nrm_genuinel1_float) {
+  test_batched_nrm<TestDevice, float, KokkosBatched::Norm::GenuineL1, KokkosBatched::Mode::Team>();
+}
 
 // TeamVector
 TEST_F(TestCategory, test_batched_teamvector_nrm_l1_float) {
@@ -389,6 +401,9 @@ TEST_F(TestCategory, test_batched_teamvector_nrm_linf_float) {
 }
 TEST_F(TestCategory, test_batched_teamvector_nrm_scaled_l2_float) {
   test_batched_nrm<TestDevice, float, KokkosBatched::Norm::ScaledL2, KokkosBatched::Mode::TeamVector>();
+}
+TEST_F(TestCategory, test_batched_teamvector_nrm_genuinel1_float) {
+  test_batched_nrm<TestDevice, float, KokkosBatched::Norm::GenuineL1, KokkosBatched::Mode::TeamVector>();
 }
 #endif
 
@@ -406,6 +421,9 @@ TEST_F(TestCategory, test_batched_serial_nrm_linf_double) {
 TEST_F(TestCategory, test_batched_serial_nrm_scaled_l2_double) {
   test_batched_nrm<TestDevice, double, KokkosBatched::Norm::ScaledL2, KokkosBatched::Mode::Serial>();
 }
+TEST_F(TestCategory, test_batched_serial_nrm_genuinel1_double) {
+  test_batched_nrm<TestDevice, double, KokkosBatched::Norm::GenuineL1, KokkosBatched::Mode::Serial>();
+}
 
 // Team
 TEST_F(TestCategory, test_batched_team_nrm_l1_double) {
@@ -420,6 +438,9 @@ TEST_F(TestCategory, test_batched_team_nrm_linf_double) {
 TEST_F(TestCategory, test_batched_team_nrm_scaled_l2_double) {
   test_batched_nrm<TestDevice, double, KokkosBatched::Norm::ScaledL2, KokkosBatched::Mode::Team>();
 }
+TEST_F(TestCategory, test_batched_team_nrm_genuinel1_double) {
+  test_batched_nrm<TestDevice, double, KokkosBatched::Norm::GenuineL1, KokkosBatched::Mode::Team>();
+}
 
 // TeamVector
 TEST_F(TestCategory, test_batched_teamvector_nrm_l1_double) {
@@ -433,6 +454,9 @@ TEST_F(TestCategory, test_batched_teamvector_nrm_linf_double) {
 }
 TEST_F(TestCategory, test_batched_teamvector_nrm_scaled_l2_double) {
   test_batched_nrm<TestDevice, double, KokkosBatched::Norm::ScaledL2, KokkosBatched::Mode::TeamVector>();
+}
+TEST_F(TestCategory, test_batched_teamvector_nrm_genuinel1_double) {
+  test_batched_nrm<TestDevice, double, KokkosBatched::Norm::GenuineL1, KokkosBatched::Mode::TeamVector>();
 }
 #endif
 
@@ -450,6 +474,9 @@ TEST_F(TestCategory, test_batched_serial_nrm_linf_fcomplex) {
 TEST_F(TestCategory, test_batched_serial_nrm_scaled_l2_fcomplex) {
   test_batched_nrm<TestDevice, Kokkos::complex<float>, KokkosBatched::Norm::ScaledL2, KokkosBatched::Mode::Serial>();
 }
+TEST_F(TestCategory, test_batched_serial_nrm_genuinel1_fcomplex) {
+  test_batched_nrm<TestDevice, Kokkos::complex<float>, KokkosBatched::Norm::GenuineL1, KokkosBatched::Mode::Serial>();
+};
 
 // Team
 TEST_F(TestCategory, test_batched_team_nrm_l1_fcomplex) {
@@ -464,6 +491,9 @@ TEST_F(TestCategory, test_batched_team_nrm_linf_fcomplex) {
 TEST_F(TestCategory, test_batched_team_nrm_scaled_l2_fcomplex) {
   test_batched_nrm<TestDevice, Kokkos::complex<float>, KokkosBatched::Norm::ScaledL2, KokkosBatched::Mode::Team>();
 }
+TEST_F(TestCategory, test_batched_team_nrm_genuinel1_fcomplex) {
+  test_batched_nrm<TestDevice, Kokkos::complex<float>, KokkosBatched::Norm::GenuineL1, KokkosBatched::Mode::Team>();
+}
 
 // TeamVector
 TEST_F(TestCategory, test_batched_teamvector_nrm_l1_fcomplex) {
@@ -477,6 +507,10 @@ TEST_F(TestCategory, test_batched_teamvector_nrm_linf_fcomplex) {
 }
 TEST_F(TestCategory, test_batched_teamvector_nrm_scaled_l2_fcomplex) {
   test_batched_nrm<TestDevice, Kokkos::complex<float>, KokkosBatched::Norm::ScaledL2,
+                   KokkosBatched::Mode::TeamVector>();
+}
+TEST_F(TestCategory, test_batched_teamvector_nrm_genuinel1_fcomplex) {
+  test_batched_nrm<TestDevice, Kokkos::complex<float>, KokkosBatched::Norm::GenuineL1,
                    KokkosBatched::Mode::TeamVector>();
 }
 #endif
@@ -495,6 +529,9 @@ TEST_F(TestCategory, test_batched_serial_nrm_linf_dcomplex) {
 TEST_F(TestCategory, test_batched_serial_nrm_scaled_l2_dcomplex) {
   test_batched_nrm<TestDevice, Kokkos::complex<double>, KokkosBatched::Norm::ScaledL2, KokkosBatched::Mode::Serial>();
 }
+TEST_F(TestCategory, test_batched_serial_nrm_genuinel1_dcomplex) {
+  test_batched_nrm<TestDevice, Kokkos::complex<double>, KokkosBatched::Norm::GenuineL1, KokkosBatched::Mode::Serial>();
+}
 
 // Team
 TEST_F(TestCategory, test_batched_team_nrm_l1_dcomplex) {
@@ -509,6 +546,9 @@ TEST_F(TestCategory, test_batched_team_nrm_linf_dcomplex) {
 TEST_F(TestCategory, test_batched_team_nrm_scaled_l2_dcomplex) {
   test_batched_nrm<TestDevice, Kokkos::complex<double>, KokkosBatched::Norm::ScaledL2, KokkosBatched::Mode::Team>();
 }
+TEST_F(TestCategory, test_batched_team_nrm_genuinel1_dcomplex) {
+  test_batched_nrm<TestDevice, Kokkos::complex<double>, KokkosBatched::Norm::GenuineL1, KokkosBatched::Mode::Team>();
+}
 
 // TeamVector
 TEST_F(TestCategory, test_batched_teamvector_nrm_l1_dcomplex) {
@@ -522,6 +562,10 @@ TEST_F(TestCategory, test_batched_teamvector_nrm_linf_dcomplex) {
 }
 TEST_F(TestCategory, test_batched_teamvector_nrm_scaled_l2_dcomplex) {
   test_batched_nrm<TestDevice, Kokkos::complex<double>, KokkosBatched::Norm::ScaledL2,
+                   KokkosBatched::Mode::TeamVector>();
+}
+TEST_F(TestCategory, test_batched_teamvector_nrm_genuinel1_dcomplex) {
+  test_batched_nrm<TestDevice, Kokkos::complex<double>, KokkosBatched::Norm::GenuineL1,
                    KokkosBatched::Mode::TeamVector>();
 }
 #endif

--- a/docs/source/API/batched/dense/batched_nrm.rst
+++ b/docs/source/API/batched/dense/batched_nrm.rst
@@ -27,15 +27,17 @@ Computes the :math:`L1`, :math:`L2` or :math:`L_\infty` norm of a vector :math:`
 
 .. math::
 
-   \begin{align}
-   norm &= ||x|| \: \text{(if NrmType == KokkosBatched::Norm::L1)} \\
-   norm &= ||x||_2 \: \text{(if NrmType == KokkosBatched::Norm::L2 or NrmType == KokkosBatched::Norm::ScaledL2)} \\
-   norm &= ||x||_\infty \: \text{(if NrmType == KokkosBatched::Norm::LInf)}
-   \end{align}
+   \begin{aligned}
+   \|x\|_1 &= \sum_{i=1}^n \left( |\operatorname{Re}(x_i)| + |\operatorname{Im}(x_i)| \right) \: \text{if NrmType == KokkosBatched::Norm::L1} \\
+   \|x\| &= \sum_{i=1}^n \sqrt{|\operatorname{Re}(x_i)|^2 + |\operatorname{Im}(x_i)|^2} \: \text{if NrmType == KokkosBatched::Norm::GenuineL1} \\
+   \|x\|_2 &= \sqrt{\sum_{i=1}^n \left(|\operatorname{Re}(x_i)|^2 + |\operatorname{Im}(x_i)|^2\right)} \: \text{if NrmType == KokkosBatched::Norm::L2 or NrmType == KokkosBatched::Norm::ScaledL2} \\
+   \|x\|_\infty &= \max_i \sqrt{|\operatorname{Re}(x_i)|^2 + |\operatorname{Im}(x_i)|^2} \: \text{if NrmType == KokkosBatched::Norm::LInf}
+   \end{aligned}
 
-1. If ``NrmType == KokkosBatched::Norm::L1``, this operation is equivalent to the BLAS routine `SASUM <https://www.netlib.org/blas/sasum.f>`_ (`SCASUM <https://www.netlib.org/blas/scasum.f>`_) or `DASUM <https://www.netlib.org/blas/dasum.f>`_ (`DZASUM <https://www.netlib.org/blas/dzasum.f>`_) for single or double precision for real (complex) vectors.
-2. If ``NrmType == KokkosBatched::Norm::L2`` or ``NrmType == KokkosBatched::Norm::ScaledL2``, this operation is equivalent to the BLAS routine `SNRM2 <https://www.netlib.org/lapack/lapack-3.1.1/html/snrm2.f.html>`_ (`SCNRM2 <https://www.netlib.org/lapack/lapack-3.1.1/html/scnrm2.f.html>`_) or `DNRM2 <https://www.netlib.org/lapack/lapack-3.1.1/html/dnrm2.f.html>`_ (`DZNRM2 <https://www.netlib.org/lapack/lapack-3.1.1/html/dznrm2.f.html>`_) for single or double precision for real (complex) vectors.
-3. If ``NrmType == KokkosBatched::Norm::LInf``, this operation is related to the BLAS routine `ISAMAX <https://www.netlib.org/blas/isamax.f>`_ (`ICAMAX <https://www.netlib.org/blas/icamax.f>`_) or `IDAMAX <https://www.netlib.org/blas/idamax.f>`_ (`IZAMAX <https://www.netlib.org/blas/izamax.f>`_) for single or double precision for real (complex) vectors, where the index of the maximum absolute value is returned in the output :math:`norm`. This routine returns the maximum absolute value instead.
+- If ``NrmType == KokkosBatched::Norm::L1``, this operation is equivalent to the BLAS routine `SASUM <https://www.netlib.org/blas/sasum.f>`_ (`SCASUM <https://www.netlib.org/blas/scasum.f>`_) or `DASUM <https://www.netlib.org/blas/dasum.f>`_ (`DZASUM <https://www.netlib.org/blas/dzasum.f>`_) for single or double precision for real (complex) vectors.
+- If ``NrmType == KokkosBatched::Norm::GenuineL1``, this operation is equivalent to the BLAS routine `SASUM <https://www.netlib.org/blas/sasum.f>`_ (`SCSUM1 <https://www.netlib.org/lapack/lapack_routine/scsum1.f>`_) or `DASUM <https://www.netlib.org/blas/dasum.f>`_ (`DZSUM1 <https://www.netlib.org/lapack/lapack_routine/dzsum1.f>`_) for single or double precision for real (complex) vectors.
+- If ``NrmType == KokkosBatched::Norm::L2`` or ``NrmType == KokkosBatched::Norm::ScaledL2``, this operation is equivalent to the BLAS routine `SNRM2 <https://www.netlib.org/lapack/lapack-3.1.1/html/snrm2.f.html>`_ (`SCNRM2 <https://www.netlib.org/lapack/lapack-3.1.1/html/scnrm2.f.html>`_) or `DNRM2 <https://www.netlib.org/lapack/lapack-3.1.1/html/dnrm2.f.html>`_ (`DZNRM2 <https://www.netlib.org/lapack/lapack-3.1.1/html/dznrm2.f.html>`_) for single or double precision for real (complex) vectors.
+- If ``NrmType == KokkosBatched::Norm::LInf``, this operation is related to the BLAS routine `ISAMAX <https://www.netlib.org/blas/isamax.f>`_ (`ICAMAX <https://www.netlib.org/blas/icamax.f>`_) or `IDAMAX <https://www.netlib.org/blas/idamax.f>`_ (`IZAMAX <https://www.netlib.org/blas/izamax.f>`_) for single or double precision for real (complex) vectors, where the index of the maximum absolute value is returned in the output :math:`norm`. This routine returns the maximum absolute value instead.
 
 .. note::
   
@@ -53,7 +55,8 @@ Type Requirements
 - ``MemberType`` must be a Kokkos team member handle (only for ``TeamNrm`` and ``TeamVectorNrm``)
 
 - ``NrmType`` must be one of the following:
-   - ``KokkosBatched::Norm::L1`` for :math:`L1` norm
+   - ``KokkosBatched::Norm::L1`` for :math:`L1` norm that sums the absolute values of real and imaginary parts of complex vectors
+   - ``KokkosBatched::Norm::GenuineL1`` for :math:`L1` norm that sums the absolute values of complex vectors
    - ``KokkosBatched::Norm::L2`` or ``KokkosBatched::Norm::ScaledL2`` for :math:`L2` norm
    - ``KokkosBatched::Norm::LInf`` for :math:`L_\infty` norm
 


### PR DESCRIPTION
This PR aims at supporting [sum1](https://www.netlib.org/lapack/explore-html/d3/db4/group__sum1_ga8756a22fe9a68f34ade5c320611d54e9.html#ga8756a22fe9a68f34ade5c320611d54e9).
In my understanding, it seems common to call asum as L1 norm, so I call it Genuine L1 norm as described in the lapack docs. We also need two versions of LInf norms.

- [x] Add new L1 norm computation
- [x] Add unit-tests for this 
- [x] Update documentation 