### PR TITLE
Explicitly include Kokkos_Half.hpp when using Kokkos::Experimental::[b]half_t

### DIFF
--- a/common/src/KokkosKernels_ArithTraits.hpp
+++ b/common/src/KokkosKernels_ArithTraits.hpp
@@ -21,6 +21,7 @@
 /// \brief Declaration and definition of KokkosKernels::ArithTraits
 
 #include <KokkosKernels_config.h>
+#include <Kokkos_Half.hpp>
 #include <Kokkos_NumericTraits.hpp>
 #include <Kokkos_MathematicalFunctions.hpp>
 #include <Kokkos_Complex.hpp>

--- a/common/src/KokkosKernels_ArithTraits.hpp
+++ b/common/src/KokkosKernels_ArithTraits.hpp
@@ -21,11 +21,14 @@
 /// \brief Declaration and definition of KokkosKernels::ArithTraits
 
 #include <KokkosKernels_config.h>
+
+#include <Kokkos_Macros.hpp>
+#if KOKKOS_VERSION_GREATER_EQUAL(5, 1, 1)
 #include <Kokkos_Half.hpp>
+#endif
 #include <Kokkos_NumericTraits.hpp>
 #include <Kokkos_MathematicalFunctions.hpp>
 #include <Kokkos_Complex.hpp>
-#include <Kokkos_Macros.hpp>
 
 #include <impl/Kokkos_QuadPrecisionMath.hpp>
 

--- a/common/src/KokkosKernels_ArithTraits.hpp
+++ b/common/src/KokkosKernels_ArithTraits.hpp
@@ -23,7 +23,7 @@
 #include <KokkosKernels_config.h>
 
 #include <Kokkos_Macros.hpp>
-#if KOKKOS_VERSION_GREATER_EQUAL(5, 1, 1)
+#if KOKKOS_VERSION_GREATER(5, 1, 1)
 #include <Kokkos_Half.hpp>
 #endif
 #include <Kokkos_NumericTraits.hpp>

--- a/sparse/src/KokkosSparse_IOUtils.hpp
+++ b/sparse/src/KokkosSparse_IOUtils.hpp
@@ -8,7 +8,7 @@
 #include "KokkosSparse_SellMatrix.hpp"
 
 #include <Kokkos_Macros.hpp>
-#if KOKKOS_VERSION_GREATER_EQUAL(5, 1, 1)
+#if KOKKOS_VERSION_GREATER(5, 1, 1)
 #include <Kokkos_Half.hpp>
 #endif
 

--- a/sparse/src/KokkosSparse_IOUtils.hpp
+++ b/sparse/src/KokkosSparse_IOUtils.hpp
@@ -7,6 +7,8 @@
 #include "KokkosSparse_CrsMatrix.hpp"
 #include "KokkosSparse_SellMatrix.hpp"
 
+#include <Kokkos_Half.hpp>
+
 #include <regex>
 #include <random>
 

--- a/sparse/src/KokkosSparse_IOUtils.hpp
+++ b/sparse/src/KokkosSparse_IOUtils.hpp
@@ -7,7 +7,10 @@
 #include "KokkosSparse_CrsMatrix.hpp"
 #include "KokkosSparse_SellMatrix.hpp"
 
+#include <Kokkos_Macros.hpp>
+#if KOKKOS_VERSION_GREATER_EQUAL(5, 1, 1)
 #include <Kokkos_Half.hpp>
+#endif
 
 #include <regex>
 #include <random>


### PR DESCRIPTION
Fixes https://my.cdash.org/builds/3680847/build by including the `Kokkos_Half.hpp` in all source files that don't include `Kokkos_Core.hpp` already.