### PR TITLE
Fix #3153: spgemm tpls not getting called

### DIFF
--- a/perf_test/sparse/KokkosSparse_spgemm.cpp
+++ b/perf_test/sparse/KokkosSparse_spgemm.cpp
@@ -106,7 +106,7 @@ void print_options() {
   std::cerr << "\t[Required] INPUT MATRIX: '--amtx [left_hand_side.mtx]' -- for C=AxA" << std::endl;
 
   std::cerr << "\t[Optional] '--algorithm "
-               "[DEFAULT=KKDEFAULT=KKSPGEMM|KKMEM|KKDENSE]' --> to choose algorithm. "
+               "[DEFAULT|KKDEFAULT=KKSPGEMM|KKMEM|KKDENSE]' --> to choose algorithm. "
                "KKMEM is outdated, use KKSPGEMM instead."
             << std::endl;
   std::cerr << "\t[Optional] --bmtx [righ_hand_side.mtx]' for C = AxB" << std::endl;
@@ -202,7 +202,7 @@ int parse_inputs(KokkosKernels::Experiment::Parameters& params, int argc, char**
       // because there are pre- post processing in these TPL kernel wraps.
     } else if (perf_test::check_arg_str(i, argc, argv, "--algorithm", algoStr)) {
       if (0 == Test::string_compare_no_case(algoStr, "DEFAULT")) {
-        params.algorithm = KokkosSparse::SPGEMM_KK;
+        params.algorithm = KokkosSparse::SPGEMM_DEFAULT;
       } else if (0 == Test::string_compare_no_case(algoStr, "KKDEFAULT")) {
         params.algorithm = KokkosSparse::SPGEMM_KK;
       } else if (0 == Test::string_compare_no_case(algoStr, "KKSPGEMM")) {

--- a/sparse/impl/KokkosSparse_bspgemm_impl_def.hpp
+++ b/sparse/impl/KokkosSparse_bspgemm_impl_def.hpp
@@ -12,9 +12,7 @@ void KokkosBSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_vi
                    b_lno_nnz_view_t_, b_scalar_nnz_view_t_>::KokkosBSPGEMM_numeric(c_row_view_t &rowmapC_,
                                                                                    c_lno_nnz_view_t &entriesC_,
                                                                                    c_scalar_nnz_view_t &valuesC_) {
-  // get the algorithm and execution space.
-  // SPGEMMAlgorithm spgemm_algorithm =
-  // this->handle->get_spgemm_handle()->get_algorithm_type();
+  // get the execution space as enum.
   KokkosKernels::Impl::ExecSpaceType my_exec_space_ = KokkosKernels::Impl::get_exec_space_type<MyExecSpace>();
 
   if (Base::KOKKOSKERNELS_VERBOSE) {

--- a/sparse/impl/KokkosSparse_spgemm_impl.hpp
+++ b/sparse/impl/KokkosSparse_spgemm_impl.hpp
@@ -475,6 +475,17 @@ class KokkosSPGEMM {
                             nnz_lno_persistent_work_view_t &color_adj, c_row_view_t &rowmapC,
                             c_nnz_view_t &entryIndicesC_);
 
+ private:
+  static inline SPGEMMAlgorithm select_algorithm(HandleType *handle) {
+    auto sh          = handle->get_spgemm_handle();
+    auto handle_algo = sh->get_algorithm_type();
+    if (handle_algo == SPGEMM_DEFAULT) {
+      return sh->get_default_native_algorithm();
+    }
+    return handle_algo;
+  }
+
+ public:
   KokkosSPGEMM(HandleType *handle_, nnz_lno_t m_, nnz_lno_t n_, nnz_lno_t k_, const_a_lno_row_view_t row_mapA_,
                const_a_lno_nnz_view_t entriesA_, bool transposeA_, const_b_lno_row_view_t row_mapB_,
                const_b_lno_nnz_view_t entriesB_, bool transposeB_)
@@ -495,7 +506,7 @@ class KokkosSPGEMM {
         use_dynamic_schedule(handle_->is_dynamic_scheduling()),
         KOKKOSKERNELS_VERBOSE(handle_->get_verbose()),
         MyEnumExecSpace(this->handle->get_handle_exec_space()),
-        spgemm_algorithm(this->handle->get_spgemm_handle()->get_algorithm_type()),
+        spgemm_algorithm(select_algorithm(this->handle)),
         spgemm_accumulator(this->handle->get_spgemm_handle()->get_accumulator_type())
   //,row_mapC(), entriesC(), valsC()
   {}
@@ -521,7 +532,7 @@ class KokkosSPGEMM {
         use_dynamic_schedule(handle_->is_dynamic_scheduling()),
         KOKKOSKERNELS_VERBOSE(handle_->get_verbose()),
         MyEnumExecSpace(this->handle->get_handle_exec_space()),
-        spgemm_algorithm(this->handle->get_spgemm_handle()->get_algorithm_type()),
+        spgemm_algorithm(select_algorithm(this->handle)),
         spgemm_accumulator(this->handle->get_spgemm_handle()->get_accumulator_type())
   //,row_mapB(), entriesC(), valsC()
   {}

--- a/sparse/impl/KokkosSparse_spgemm_impl_def.hpp
+++ b/sparse/impl/KokkosSparse_spgemm_impl_def.hpp
@@ -12,9 +12,7 @@ void KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_vie
                   b_lno_nnz_view_t_, b_scalar_nnz_view_t_>::KokkosSPGEMM_numeric(c_row_view_t &rowmapC_,
                                                                                  c_lno_nnz_view_t &entriesC_,
                                                                                  c_scalar_nnz_view_t &valuesC_) {
-  // get the algorithm and execution space.
-  // SPGEMMAlgorithm spgemm_algorithm =
-  // this->handle->get_spgemm_handle()->get_algorithm_type();
+  // get the execution space as enum.
   KokkosKernels::Impl::ExecSpaceType my_exec_space_ = KokkosKernels::Impl::get_exec_space_type<MyExecSpace>();
 
   if (KOKKOSKERNELS_VERBOSE) {

--- a/sparse/impl/KokkosSparse_spgemm_impl_memaccess.hpp
+++ b/sparse/impl/KokkosSparse_spgemm_impl_memaccess.hpp
@@ -235,8 +235,7 @@ void KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_vie
   this->create_read_write_hg(overall_flops, c_flop_rowmap, c_comp_a_net_index, c_comp_b_net_index, c_comp_row_index,
                              c_comp_col_index);
 
-  int write_type                   = 0;  // 0 -- KKMEM, 1-KKSPEED, 2- KKCOLOR 3-KKMULTICOLOR 4-KKMULTICOLOR2
-  SPGEMMAlgorithm spgemm_algorithm = this->handle->get_spgemm_handle()->get_algorithm_type();
+  int write_type = 0;  // 0 -- KKMEM, 1-KKSPEED, 2- KKCOLOR 3-KKMULTICOLOR 4-KKMULTICOLOR2
 
   if (spgemm_algorithm == KokkosKernels::Experimental::Graph::SPGEMM_KK_COLOR) {
     write_type = 2;

--- a/sparse/impl/KokkosSparse_spgemm_symbolic_spec.hpp
+++ b/sparse/impl/KokkosSparse_spgemm_symbolic_spec.hpp
@@ -100,6 +100,8 @@ struct SPGEMM_SYMBOLIC<KernelHandle, a_size_view_t_, a_lno_view_t, b_size_view_t
                               transposeA, row_mapB, entriesB, transposeB, row_mapC);
         break;
       default: {
+        // Note: if algorithm type is SPGEMM_DEFAULT, KokkosSPGEMM's constructor will choose the
+        // correct implementation.
         KokkosSPGEMM<KernelHandle, a_size_view_t_, a_lno_view_t, typename KernelHandle::in_scalar_nnz_view_t,
                      b_size_view_t_, b_lno_view_t, typename KernelHandle::in_scalar_nnz_view_t>
             kspgemm(handle, m, n, k, row_mapA, entriesA, transposeA, row_mapB, entriesB, transposeB);

--- a/sparse/src/KokkosSparse_spgemm_handle.hpp
+++ b/sparse/src/KokkosSparse_spgemm_handle.hpp
@@ -533,9 +533,6 @@ class SPGEMMHandle {
       throw std::invalid_argument("SPGEMMHandle: a cuSPARSE algorithm was selected but cuSPARSE is not enabled");
 #endif
     }
-    if (alg == SPGEMM_DEFAULT) {
-      this->choose_default_algorithm();
-    }
   }
 
   virtual ~SPGEMMHandle() {
@@ -597,60 +594,71 @@ class SPGEMMHandle {
   mklSpgemmHandleType *get_mkl_spgemm_handle() { return this->mkl_spgemm_handle; }
 #endif
 
-  void choose_default_algorithm() {
+  // Return the default native algorithm for this handle's execution space.
+  // this->algorithm_type is not changed.
+  SPGEMMAlgorithm get_default_native_algorithm() {
 #if defined(KOKKOS_ENABLE_SERIAL)
     if (std::is_same<Kokkos::Serial, ExecutionSpace>::value) {
-      this->algorithm_type = SPGEMM_SERIAL;
 #ifdef VERBOSE
       std::cout << "Serial Execution Space, Default Algorithm: SPGEMM_SERIAL" << std::endl;
 #endif
+      return SPGEMM_SERIAL;
     }
 #endif
 
 #if defined(KOKKOS_ENABLE_THREADS)
     if (std::is_same<Kokkos::Threads, ExecutionSpace>::value) {
-      this->algorithm_type = SPGEMM_SERIAL;
 #ifdef VERBOSE
       std::cout << "THREADS Execution Space, Default Algorithm: SPGEMM_SERIAL" << std::endl;
 #endif
+      return SPGEMM_SERIAL;
     }
 #endif
 
 #if defined(KOKKOS_ENABLE_OPENMP)
     if (std::is_same<Kokkos::OpenMP, ExecutionSpace>::value) {
-      this->algorithm_type = SPGEMM_SERIAL;
 #ifdef VERBOSE
       std::cout << "OpenMP Execution Space, Default Algorithm: SPGEMM_SERIAL" << std::endl;
 #endif
+      return SPGEMM_SERIAL;
     }
 #endif
 
 #if defined(KOKKOS_ENABLE_CUDA)
     if (std::is_same<Kokkos::Cuda, ExecutionSpace>::value) {
-      this->algorithm_type = SPGEMM_KK;
 #ifdef VERBOSE
       std::cout << "Cuda Execution Space, Default Algorithm: SPGEMM_KK" << std::endl;
 #endif
+      return SPGEMM_KK;
     }
 #endif
 
 #if defined(KOKKOS_ENABLE_HIP)
     if (std::is_same<Kokkos::HIP, ExecutionSpace>::value) {
-      this->algorithm_type = SPGEMM_KK;
 #ifdef VERBOSE
       std::cout << "HIP Execution Space, Default Algorithm: SPGEMM_KK" << std::endl;
 #endif
+      return SPGEMM_KK;
     }
 #endif
 
 #if defined(KOKKOS_ENABLE_SYCL)
     if (std::is_same<Kokkos::SYCL, ExecutionSpace>::value) {
-      this->algorithm_type = SPGEMM_KK;
 #ifdef VERBOSE
       std::cout << "SYCL Execution Space, Default Algorithm: SPGEMM_KK" << std::endl;
 #endif
+      return SPGEMM_KK;
     }
 #endif
+#ifdef VERBOSE
+    std::cout << "Execution Space not handled directly: defaulting to SPGEMM_KK" << std::endl;
+#endif
+    return SPGEMM_KK;
+  }
+
+  [[deprecated("Do not use choose_default_algorithm since it can prevent TPLs from being used")]] void
+  choose_default_algorithm() {
+    this->algorithm_type = get_default_native_algorithm();
   }
 
   void set_compression(bool compress_second_matrix_) { this->compress_second_matrix = compress_second_matrix_; }
@@ -784,9 +792,9 @@ class SPGEMMHandle {
   }
 };
 
-inline SPGEMMAlgorithm StringToSPGEMMAlgorithm(std::string &name) {
+inline SPGEMMAlgorithm StringToSPGEMMAlgorithm(const std::string &name) {
   if (name == "SPGEMM_DEFAULT")
-    return SPGEMM_KK;
+    return SPGEMM_DEFAULT;
   else if (name == "SPGEMM_KK")
     return SPGEMM_KK;
   else if (name == "SPGEMM_KK_MEMORY")
@@ -798,9 +806,19 @@ inline SPGEMMAlgorithm StringToSPGEMMAlgorithm(std::string &name) {
   else if (name == "SPGEMM_KK_MEMSPEED")
     return SPGEMM_KK;
   else if (name == "SPGEMM_DEBUG")
-    return SPGEMM_SERIAL;
+    return SPGEMM_DEBUG;
   else if (name == "SPGEMM_SERIAL")
     return SPGEMM_SERIAL;
+  else if (name == "SPGEMM_CUSPARSE_DETERMINISTIC")
+    return SPGEMM_CUSPARSE_DETERMINISTIC;
+  else if (name == "SPGEMM_CUSPARSE_NONDETERMINISTIC")
+    return SPGEMM_CUSPARSE_NONDETERMINISTIC;
+  else if (name == "SPGEMM_CUSPARSE_ALG1")
+    return SPGEMM_CUSPARSE_ALG1;
+  else if (name == "SPGEMM_CUSPARSE_ALG2")
+    return SPGEMM_CUSPARSE_ALG2;
+  else if (name == "SPGEMM_CUSPARSE_ALG3")
+    return SPGEMM_CUSPARSE_ALG3;
   else
     throw std::runtime_error("Invalid SPGEMMAlgorithm name");
 }


### PR DESCRIPTION
Fix #3153, where spgemm TPLs were not getting called as expected.

- In SPGEMMHandle constructor, do not call ``choose_default_algorithm`` which overwrote ``SPGEMM_DEFAULT`` with a specific native algorithm. Instead have the native impl internally pick the default.
- Fix ``KokkosSparse::StringToSPGEMMAlgorithm`` (again, preserve ``SPGEMM_DEFAULT``)
- Same thing in spgemm perf test: passing ``--algorithm DEFAULT`` now goes to ``SPGEMM_DEFAULT`` which can be a TPL

Tested locally:
- built with and without cusparse
- ran spgemm perf test with ``--algorithm DEFAULT`` under the kernel logger
- also tried with algorithm chosen like Tpetra does: ``KokkosSparse::StringToSPGEMMAlgorithm("SPGEMM_DEFAULT")``
- checked that the native or cusparse path is taken as expected