### PR TITLE
Compatibility updates for deprecated out-of-rank extent usages

### DIFF
--- a/batched/dense/impl/KokkosBatched_Trsm_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Trsm_Serial_Impl.hpp
@@ -19,7 +19,11 @@ KOKKOS_INLINE_FUNCTION static int checkTrsmInput([[maybe_unused]] const AViewTyp
   static_assert(AViewType::rank == 2, "KokkosBatched::trsm: AViewType must have rank 2.");
   static_assert(BViewType::rank == 1 || BViewType::rank == 2, "KokkosBatched::trsm: BViewType must have rank 1 or 2.");
 #ifndef NDEBUG
-  const int m = B.extent(0), n = B.extent(1);
+  const int m = B.extent(0);
+  int n = 1;
+  if constexpr (BViewType::rank == 2) {
+    n = B.extent(1);
+  }
   const int nrowa = std::is_same_v<ArgSide, Side::Left> ? m : n;
   const int lda   = A.extent(0);
 
@@ -55,8 +59,12 @@ struct SerialTrsm<Side::Left, Uplo::Lower, Trans::NoTranspose, ArgDiag, Algo::Tr
     // Quick return if possible
     if (B.size() == 0) return 0;
 
-    size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
-    size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
+    size_t B_extent_1 = 1; //B_rank == 1 ? 1 : B.extent(1);
+    size_t B_stride_1 = 1; //B_rank == 1 ? 1 : B.stride(1);
+    if constexpr (B_rank == 2) {
+      B_extent_1 = B.extent(1);
+      B_stride_1 = B.stride(1);
+    }
 
     typedef typename BViewType::value_type vector_type;
     // typedef typename vector_type::value_type value_type;
@@ -97,8 +105,12 @@ struct SerialTrsm<Side::Left, Uplo::Lower, Trans::NoTranspose, ArgDiag, Algo::Tr
     // Quick return if possible
     if (B.size() == 0) return 0;
 
-    size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
-    size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
+    size_t B_extent_1 = 1;
+    size_t B_stride_1 = 1;
+    if constexpr (B_rank == 2) {
+      B_extent_1 = B.extent(1);
+      B_stride_1 = B.stride(1);
+    }
 
     auto info = KokkosBatched::Impl::checkTrsmInput<Side::Left>(A, B);
     if (info) return info;
@@ -120,8 +132,12 @@ struct SerialTrsm<Side::Left, Uplo::Lower, Trans::NoTranspose, ArgDiag, Algo::Tr
     // Quick return if possible
     if (B.size() == 0) return 0;
 
-    size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
-    size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
+    size_t B_extent_1 = 1;
+    size_t B_stride_1 = 1;
+    if constexpr (B_rank == 2) {
+      B_extent_1 = B.extent(1);
+      B_stride_1 = B.stride(1);
+    }
 
     auto info = KokkosBatched::Impl::checkTrsmInput<Side::Left>(A, B);
     if (info) return info;
@@ -151,8 +167,12 @@ struct SerialTrsm<Side::Left, Uplo::Upper, Trans::NoTranspose, ArgDiag, Algo::Tr
     // Quick return if possible
     if (B.size() == 0) return 0;
 
-    size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
-    size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
+    size_t B_extent_1 = 1;
+    size_t B_stride_1 = 1;
+    if constexpr (B_rank == 2) {
+      B_extent_1 = B.extent(1);
+      B_stride_1 = B.stride(1);
+    }
 
     typedef typename BViewType::value_type vector_type;
     // typedef typename vector_type::value_type value_type;
@@ -194,8 +214,12 @@ struct SerialTrsm<Side::Left, Uplo::Upper, Trans::NoTranspose, ArgDiag, Algo::Tr
     // Quick return if possible
     if (B.size() == 0) return 0;
 
-    size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
-    size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
+    size_t B_extent_1 = 1;
+    size_t B_stride_1 = 1;
+    if constexpr (B_rank == 2) {
+      B_extent_1 = B.extent(1);
+      B_stride_1 = B.stride(1);
+    }
 
     auto info = KokkosBatched::Impl::checkTrsmInput<Side::Left>(A, B);
     if (info) return info;
@@ -217,8 +241,12 @@ struct SerialTrsm<Side::Left, Uplo::Upper, Trans::NoTranspose, ArgDiag, Algo::Tr
     // Quick return if possible
     if (B.size() == 0) return 0;
 
-    size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
-    size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
+    size_t B_extent_1 = 1;
+    size_t B_stride_1 = 1;
+    if constexpr (B_rank == 2) {
+      B_extent_1 = B.extent(1);
+      B_stride_1 = B.stride(1);
+    }
 
     auto info = KokkosBatched::Impl::checkTrsmInput<Side::Left>(A, B);
     if (info) return info;
@@ -248,8 +276,12 @@ struct SerialTrsm<Side::Left, Uplo::Lower, Trans::Transpose, ArgDiag, Algo::Trsm
     // Quick return if possible
     if (B.size() == 0) return 0;
 
-    size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
-    size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
+    size_t B_extent_1 = 1;
+    size_t B_stride_1 = 1;
+    if constexpr (B_rank == 2) {
+      B_extent_1 = B.extent(1);
+      B_stride_1 = B.stride(1);
+    }
 
     typedef typename BViewType::value_type vector_type;
     // typedef typename vector_type::value_type value_type;
@@ -290,8 +322,12 @@ struct SerialTrsm<Side::Left, Uplo::Lower, Trans::Transpose, ArgDiag, Algo::Trsm
     // Quick return if possible
     if (B.size() == 0) return 0;
 
-    size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
-    size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
+    size_t B_extent_1 = 1;
+    size_t B_stride_1 = 1;
+    if constexpr (B_rank == 2) {
+      B_extent_1 = B.extent(1);
+      B_stride_1 = B.stride(1);
+    }
 
     auto info = KokkosBatched::Impl::checkTrsmInput<Side::Left>(A, B);
     if (info) return info;
@@ -313,8 +349,12 @@ struct SerialTrsm<Side::Left, Uplo::Lower, Trans::Transpose, ArgDiag, Algo::Trsm
     // Quick return if possible
     if (B.size() == 0) return 0;
 
-    size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
-    size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
+    size_t B_extent_1 = 1;
+    size_t B_stride_1 = 1;
+    if constexpr (B_rank == 2) {
+      B_extent_1 = B.extent(1);
+      B_stride_1 = B.stride(1);
+    }
 
     auto info = KokkosBatched::Impl::checkTrsmInput<Side::Left>(A, B);
     if (info) return info;
@@ -343,8 +383,12 @@ struct SerialTrsm<Side::Left, Uplo::Upper, Trans::Transpose, ArgDiag, Algo::Trsm
     // Quick return if possible
     if (B.size() == 0) return 0;
 
-    size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
-    size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
+    size_t B_extent_1 = 1;
+    size_t B_stride_1 = 1;
+    if constexpr (B_rank == 2) {
+      B_extent_1 = B.extent(1);
+      B_stride_1 = B.stride(1);
+    }
 
     typedef typename BViewType::value_type vector_type;
     // typedef typename vector_type::value_type value_type;
@@ -385,8 +429,12 @@ struct SerialTrsm<Side::Left, Uplo::Upper, Trans::Transpose, ArgDiag, Algo::Trsm
     // Quick return if possible
     if (B.size() == 0) return 0;
 
-    size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
-    size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
+    size_t B_extent_1 = 1;
+    size_t B_stride_1 = 1;
+    if constexpr (B_rank == 2) {
+      B_extent_1 = B.extent(1);
+      B_stride_1 = B.stride(1);
+    }
 
     auto info = KokkosBatched::Impl::checkTrsmInput<Side::Left>(A, B);
     if (info) return info;
@@ -408,8 +456,12 @@ struct SerialTrsm<Side::Left, Uplo::Upper, Trans::Transpose, ArgDiag, Algo::Trsm
     // Quick return if possible
     if (B.size() == 0) return 0;
 
-    size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
-    size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
+    size_t B_extent_1 = 1;
+    size_t B_stride_1 = 1;
+    if constexpr (B_rank == 2) {
+      B_extent_1 = B.extent(1);
+      B_stride_1 = B.stride(1);
+    }
 
     auto info = KokkosBatched::Impl::checkTrsmInput<Side::Left>(A, B);
     if (info) return info;
@@ -439,8 +491,12 @@ struct SerialTrsm<Side::Left, Uplo::Lower, Trans::ConjTranspose, ArgDiag, Algo::
     // Quick return if possible
     if (B.size() == 0) return 0;
 
-    size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
-    size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
+    size_t B_extent_1 = 1;
+    size_t B_stride_1 = 1;
+    if constexpr (B_rank == 2) {
+      B_extent_1 = B.extent(1);
+      B_stride_1 = B.stride(1);
+    }
 
     typedef typename BViewType::value_type vector_type;
     // typedef typename vector_type::value_type value_type;
@@ -481,8 +537,12 @@ struct SerialTrsm<Side::Left, Uplo::Lower, Trans::ConjTranspose, ArgDiag, Algo::
     // Quick return if possible
     if (B.size() == 0) return 0;
 
-    size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
-    size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
+    size_t B_extent_1 = 1;
+    size_t B_stride_1 = 1;
+    if constexpr (B_rank == 2) {
+      B_extent_1 = B.extent(1);
+      B_stride_1 = B.stride(1);
+    }
 
     auto info = KokkosBatched::Impl::checkTrsmInput<Side::Left>(A, B);
     if (info) return info;
@@ -504,8 +564,12 @@ struct SerialTrsm<Side::Left, Uplo::Lower, Trans::ConjTranspose, ArgDiag, Algo::
     // Quick return if possible
     if (B.size() == 0) return 0;
 
-    size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
-    size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
+    size_t B_extent_1 = 1;
+    size_t B_stride_1 = 1;
+    if constexpr (B_rank == 2) {
+      B_extent_1 = B.extent(1);
+      B_stride_1 = B.stride(1);
+    }
 
     auto info = KokkosBatched::Impl::checkTrsmInput<Side::Left>(A, B);
     if (info) return info;
@@ -534,8 +598,12 @@ struct SerialTrsm<Side::Left, Uplo::Upper, Trans::ConjTranspose, ArgDiag, Algo::
     // Quick return if possible
     if (B.size() == 0) return 0;
 
-    size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
-    size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
+    size_t B_extent_1 = 1;
+    size_t B_stride_1 = 1;
+    if constexpr (B_rank == 2) {
+      B_extent_1 = B.extent(1);
+      B_stride_1 = B.stride(1);
+    }
 
     typedef typename BViewType::value_type vector_type;
     // typedef typename vector_type::value_type value_type;
@@ -576,8 +644,12 @@ struct SerialTrsm<Side::Left, Uplo::Upper, Trans::ConjTranspose, ArgDiag, Algo::
     // Quick return if possible
     if (B.size() == 0) return 0;
 
-    size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
-    size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
+    size_t B_extent_1 = 1;
+    size_t B_stride_1 = 1;
+    if constexpr (B_rank == 2) {
+      B_extent_1 = B.extent(1);
+      B_stride_1 = B.stride(1);
+    }
 
     auto info = KokkosBatched::Impl::checkTrsmInput<Side::Left>(A, B);
     if (info) return info;

--- a/batched/dense/impl/KokkosBatched_Trsm_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Trsm_Serial_Impl.hpp
@@ -20,7 +20,7 @@ KOKKOS_INLINE_FUNCTION static int checkTrsmInput([[maybe_unused]] const AViewTyp
   static_assert(BViewType::rank == 1 || BViewType::rank == 2, "KokkosBatched::trsm: BViewType must have rank 1 or 2.");
 #ifndef NDEBUG
   const int m = B.extent(0);
-  int n = 1;
+  int n       = 1;
   if constexpr (BViewType::rank == 2) {
     n = B.extent(1);
   }
@@ -59,8 +59,8 @@ struct SerialTrsm<Side::Left, Uplo::Lower, Trans::NoTranspose, ArgDiag, Algo::Tr
     // Quick return if possible
     if (B.size() == 0) return 0;
 
-    size_t B_extent_1 = 1; //B_rank == 1 ? 1 : B.extent(1);
-    size_t B_stride_1 = 1; //B_rank == 1 ? 1 : B.stride(1);
+    size_t B_extent_1 = 1;  // B_rank == 1 ? 1 : B.extent(1);
+    size_t B_stride_1 = 1;  // B_rank == 1 ? 1 : B.stride(1);
     if constexpr (B_rank == 2) {
       B_extent_1 = B.extent(1);
       B_stride_1 = B.stride(1);

--- a/batched/dense/unit_test/Test_Batched_VectorView.hpp
+++ b/batched/dense/unit_test/Test_Batched_VectorView.hpp
@@ -25,7 +25,7 @@ namespace Test {
 
 template <int extent_id, typename VectorViewType>
 inline int get_extent(const VectorViewType& v) {
-  if constexpr (VectorViewType::rank == extent_id + 1) {
+  if constexpr (extent_id < VectorViewType::rank) {
     return v.extent(extent_id);
   } else
     return 1;

--- a/batched/dense/unit_test/Test_Batched_VectorView.hpp
+++ b/batched/dense/unit_test/Test_Batched_VectorView.hpp
@@ -23,28 +23,37 @@ using namespace KokkosBatched;
 
 namespace Test {
 
+template <int rank, typename VectorViewType>
+inline int get_extent(const VectorViewType& v) {
+  if constexpr (VectorViewType::rank == rank+1) {
+    return v.extent(rank);
+  }
+  else
+    return 1;
+}
+
 template <typename VectorViewType>
 void impl_init_vector_view(const VectorViewType& a) {
   int cnt = 0;
-  for (int i0 = 0, i0end = a.extent(0); i0 < i0end; ++i0)
-    for (int i1 = 0, i1end = a.extent(1); i1 < i1end; ++i1)
-      for (int i2 = 0, i2end = a.extent(2); i2 < i2end; ++i2)
-        for (int i3 = 0, i3end = a.extent(3); i3 < i3end; ++i3)
-          for (int i4 = 0, i4end = a.extent(4); i4 < i4end; ++i4)
-            for (int i5 = 0, i5end = a.extent(5); i5 < i5end; ++i5)
-              for (int i6 = 0, i6end = a.extent(6); i6 < i6end; ++i6)
-                for (int i7 = 0, i7end = a.extent(7); i7 < i7end; ++i7)
+  for (int i0 = 0, i0end = get_extent<0>(a); i0 < i0end; ++i0)
+    for (int i1 = 0, i1end = get_extent<1>(a); i1 < i1end; ++i1)
+      for (int i2 = 0, i2end = get_extent<2>(a); i2 < i2end; ++i2)
+        for (int i3 = 0, i3end = get_extent<3>(a); i3 < i3end; ++i3)
+          for (int i4 = 0, i4end = get_extent<4>(a); i4 < i4end; ++i4)
+            for (int i5 = 0, i5end = get_extent<5>(a); i5 < i5end; ++i5)
+              for (int i6 = 0, i6end = get_extent<6>(a); i6 < i6end; ++i6)
+                for (int i7 = 0, i7end = get_extent<7>(a); i7 < i7end; ++i7)
                   a.access(i0, i1, i2, i3, i4, i5, i6, i7) = cnt++;
 }
 #define TEST_LOOP                                                     \
-  for (int i0 = 0, i0end = b.extent(0); i0 < i0end; ++i0)             \
-    for (int i1 = 0, i1end = b.extent(1); i1 < i1end; ++i1)           \
-      for (int i2 = 0, i2end = b.extent(2); i2 < i2end; ++i2)         \
-        for (int i3 = 0, i3end = b.extent(3); i3 < i3end; ++i3)       \
-          for (int i4 = 0, i4end = b.extent(4); i4 < i4end; ++i4)     \
-            for (int i5 = 0, i5end = b.extent(5); i5 < i5end; ++i5)   \
-              for (int i6 = 0, i6end = b.extent(6); i6 < i6end; ++i6) \
-                for (int i7 = 0, i7end = b.extent(7); i7 < i7end; ++i7)
+  for (int i0 = 0, i0end = get_extent<0>(b); i0 < i0end; ++i0)             \
+    for (int i1 = 0, i1end = get_extent<1>(b); i1 < i1end; ++i1)           \
+      for (int i2 = 0, i2end = get_extent<2>(b); i2 < i2end; ++i2)         \
+        for (int i3 = 0, i3end = get_extent<3>(b); i3 < i3end; ++i3)       \
+          for (int i4 = 0, i4end = get_extent<4>(b); i4 < i4end; ++i4)     \
+            for (int i5 = 0, i5end = get_extent<5>(b); i5 < i5end; ++i5)   \
+              for (int i6 = 0, i6end = get_extent<6>(b); i6 < i6end; ++i6) \
+                for (int i7 = 0, i7end = get_extent<7>(b); i7 < i7end; ++i7)
 
 template <typename VectorViewType>
 void impl_verify_vector_view(const VectorViewType& a, const SimdViewAccess<VectorViewType, PackDim<0> >& b) {

--- a/batched/dense/unit_test/Test_Batched_VectorView.hpp
+++ b/batched/dense/unit_test/Test_Batched_VectorView.hpp
@@ -23,10 +23,10 @@ using namespace KokkosBatched;
 
 namespace Test {
 
-template <int rank, typename VectorViewType>
+template <int extent_id, typename VectorViewType>
 inline int get_extent(const VectorViewType& v) {
-  if constexpr (VectorViewType::rank == rank + 1) {
-    return v.extent(rank);
+  if constexpr (VectorViewType::rank == extent_id + 1) {
+    return v.extent(extent_id);
   } else
     return 1;
 }

--- a/batched/dense/unit_test/Test_Batched_VectorView.hpp
+++ b/batched/dense/unit_test/Test_Batched_VectorView.hpp
@@ -25,10 +25,9 @@ namespace Test {
 
 template <int rank, typename VectorViewType>
 inline int get_extent(const VectorViewType& v) {
-  if constexpr (VectorViewType::rank == rank+1) {
+  if constexpr (VectorViewType::rank == rank + 1) {
     return v.extent(rank);
-  }
-  else
+  } else
     return 1;
 }
 
@@ -45,7 +44,7 @@ void impl_init_vector_view(const VectorViewType& a) {
                 for (int i7 = 0, i7end = get_extent<7>(a); i7 < i7end; ++i7)
                   a.access(i0, i1, i2, i3, i4, i5, i6, i7) = cnt++;
 }
-#define TEST_LOOP                                                     \
+#define TEST_LOOP                                                          \
   for (int i0 = 0, i0end = get_extent<0>(b); i0 < i0end; ++i0)             \
     for (int i1 = 0, i1end = get_extent<1>(b); i1 < i1end; ++i1)           \
       for (int i2 = 0, i2end = get_extent<2>(b); i2 < i2end; ++i2)         \

--- a/blas/impl/KokkosBlas1_update_impl.hpp
+++ b/blas/impl/KokkosBlas1_update_impl.hpp
@@ -202,7 +202,7 @@ struct V_Update_Functor {
   V_Update_Functor(const typename XV::non_const_value_type& alpha, const XV& X,
                    const typename YV::non_const_value_type& beta, const YV& Y,
                    const typename ZV::non_const_value_type& gamma, const ZV& Z)
-      : numCols(X.extent(1)), alpha_(alpha), X_(X), beta_(beta), Y_(Y), gamma_(gamma), Z_(Z) {
+      : numCols(1), alpha_(alpha), X_(X), beta_(beta), Y_(Y), gamma_(gamma), Z_(Z) {
     static_assert(Kokkos::is_view<XV>::value,
                   "KokkosBlas::Impl::"
                   "V_Update_Functor: X is not a Kokkos::View.");

--- a/blas/impl/KokkosBlas1_update_spec.hpp
+++ b/blas/impl/KokkosBlas1_update_spec.hpp
@@ -230,7 +230,7 @@ struct Update<execution_space, XV, YV, ZV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_
 #endif
 
     const size_type numRows = X.extent(0);
-    const size_type numCols = 1; //X.extent(1);
+    const size_type numCols = 1;  // X.extent(1);
     int a = 2, b = 2, c = 2;
 
     if (alpha == ATA::zero()) {

--- a/blas/impl/KokkosBlas1_update_spec.hpp
+++ b/blas/impl/KokkosBlas1_update_spec.hpp
@@ -230,7 +230,7 @@ struct Update<execution_space, XV, YV, ZV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_
 #endif
 
     const size_type numRows = X.extent(0);
-    const size_type numCols = X.extent(1);
+    const size_type numCols = 1; //X.extent(1);
     int a = 2, b = 2, c = 2;
 
     if (alpha == ATA::zero()) {

--- a/blas/impl/KokkosBlas1_update_spec.hpp
+++ b/blas/impl/KokkosBlas1_update_spec.hpp
@@ -230,7 +230,6 @@ struct Update<execution_space, XV, YV, ZV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_
 #endif
 
     const size_type numRows = X.extent(0);
-    const size_type numCols = 1;  // X.extent(1);
     int a = 2, b = 2, c = 2;
 
     if (alpha == ATA::zero()) {
@@ -249,7 +248,7 @@ struct Update<execution_space, XV, YV, ZV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_
       c = 2;
     }
 
-    if (numRows < static_cast<size_type>(INT_MAX) && numRows * numCols < static_cast<size_type>(INT_MAX)) {
+    if (numRows < static_cast<size_type>(INT_MAX)) {
       typedef int index_type;
       V_Update_Generic<execution_space, XV, YV, ZV, index_type>(space, alpha, X, beta, Y, gamma, Z, a, b, c);
     } else {

--- a/blas/src/KokkosBlas1_abs.hpp
+++ b/blas/src/KokkosBlas1_abs.hpp
@@ -52,11 +52,21 @@ void abs(const execution_space& space, const RMV& R, const XMV& X) {
                 "RMV and XMV must either have rank 1 or rank 2.");
 
   // Check compatibility of dimensions at run time.
-  if (X.extent(0) != R.extent(0) || X.extent(1) != R.extent(1)) {
-    std::ostringstream os;
-    os << "KokkosBlas::abs (MV): Dimensions of R and X do not match: "
-       << "R: " << R.extent(0) << " x " << R.extent(1) << ", X: " << X.extent(0) << " x " << X.extent(1);
-    KokkosKernels::Impl::throw_runtime_exception(os.str());
+  if constexpr (RMV::rank == 1) {
+    if (X.extent(0) != R.extent(0)) {
+      std::ostringstream os;
+      os << "KokkosBlas::abs (MV): Dimensions of R and X do not match: "
+         << "R: " << R.extent(0) << ", X: " << X.extent(0);
+      KokkosKernels::Impl::throw_runtime_exception(os.str());
+    }
+  }
+  else if constexpr (RMV::rank == 2) {
+    if (X.extent(0) != R.extent(0) || X.extent(1) != R.extent(1)) {
+      std::ostringstream os;
+      os << "KokkosBlas::abs (MV): Dimensions of R and X do not match: "
+         << "R: " << R.extent(0) << " x " << R.extent(1) << ", X: " << X.extent(0) << " x " << X.extent(1);
+      KokkosKernels::Impl::throw_runtime_exception(os.str());
+    }
   }
 
   // Create unmanaged versions of the input Views.  RMV and XMV may be

--- a/blas/src/KokkosBlas1_abs.hpp
+++ b/blas/src/KokkosBlas1_abs.hpp
@@ -59,8 +59,7 @@ void abs(const execution_space& space, const RMV& R, const XMV& X) {
          << "R: " << R.extent(0) << ", X: " << X.extent(0);
       KokkosKernels::Impl::throw_runtime_exception(os.str());
     }
-  }
-  else if constexpr (RMV::rank == 2) {
+  } else if constexpr (RMV::rank == 2) {
     if (X.extent(0) != R.extent(0) || X.extent(1) != R.extent(1)) {
       std::ostringstream os;
       os << "KokkosBlas::abs (MV): Dimensions of R and X do not match: "

--- a/blas/src/KokkosBlas1_axpby.hpp
+++ b/blas/src/KokkosBlas1_axpby.hpp
@@ -232,8 +232,7 @@ KOKKOS_FUNCTION void serial_axpy(const scalar_type alpha, const XMV X, YMV Y) {
     if (X.extent(0) != Y.extent(0)) {
       Kokkos::abort("KokkosBlas::serial_axpy: X and Y dimensions do not match");
     }
-  }
-  else if constexpr (XMV::rank == 2) {
+  } else if constexpr (XMV::rank == 2) {
     if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
       Kokkos::abort("KokkosBlas::serial_axpy: X and Y dimensions do not match");
     }

--- a/blas/src/KokkosBlas1_axpby.hpp
+++ b/blas/src/KokkosBlas1_axpby.hpp
@@ -228,8 +228,15 @@ KOKKOS_FUNCTION void serial_axpy(const scalar_type alpha, const XMV X, YMV Y) {
   static_assert(XMV::rank == YMV::rank, "KokkosBlas::serial_axpy: XMV and YMV must have the same rank.");
 
 #ifndef NDEBUG
-  if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
-    Kokkos::abort("KokkosBlas::serial_axpy: X and Y dimensions do not match");
+  if constexpr (XMV::rank == 1) {
+    if (X.extent(0) != Y.extent(0)) {
+      Kokkos::abort("KokkosBlas::serial_axpy: X and Y dimensions do not match");
+    }
+  }
+  else if constexpr (XMV::rank == 2) {
+    if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1)) {
+      Kokkos::abort("KokkosBlas::serial_axpy: X and Y dimensions do not match");
+    }
   }
 #endif  // NDEBUG
   if constexpr (XMV::rank() == 1)

--- a/blas/src/KokkosBlas1_iamax.hpp
+++ b/blas/src/KokkosBlas1_iamax.hpp
@@ -118,11 +118,13 @@ void iamax(const execution_space& space, const RV& R, const XMV& X,
                 "(we have to be able to write to its entries).");
 
   // Check compatibility of dimensions at run time.
-  if (X.extent(1) != R.extent(0)) {
-    std::ostringstream os;
-    os << "KokkosBlas::iamax (MV): Dimensions of R and X do not match: "
-       << "R: " << R.extent(0) << ", X: " << X.extent(0) << " x " << X.extent(1);
-    KokkosKernels::Impl::throw_runtime_exception(os.str());
+  if constexpr (XMV::rank == 2 && RV::rank == 1) {
+    if (X.extent(1) != R.extent(0)) {
+      std::ostringstream os;
+      os << "KokkosBlas::iamax (MV): Dimensions of R and X do not match: "
+         << "R: " << R.extent(0) << ", X: " << X.extent(0) << " x " << X.extent(1);
+      KokkosKernels::Impl::throw_runtime_exception(os.str());
+    }
   }
 
   using UnifiedXLayout  = typename KokkosKernels::Impl::GetUnifiedLayout<XMV>::array_layout;

--- a/blas/src/KokkosBlas1_mult.hpp
+++ b/blas/src/KokkosBlas1_mult.hpp
@@ -58,12 +58,23 @@ void mult(const execution_space& space, typename YMV::const_value_type& gamma, c
   static_assert(AV::rank == 1, "KokkosBlas::mult: A must have rank 1.");
 
   // Check compatibility of dimensions at run time.
-  if (Y.extent(0) != A.extent(0) || Y.extent(0) != X.extent(0) || Y.extent(1) != X.extent(1)) {
-    std::ostringstream os;
-    os << "KokkosBlas::mult: Dimensions do not match: "
-       << "Y: " << Y.extent(0) << " x " << Y.extent(1) << ", A: " << A.extent(0) << " x " << A.extent(0)
-       << ", X: " << X.extent(0) << " x " << X.extent(1);
-    KokkosKernels::Impl::throw_runtime_exception(os.str());
+  if constexpr (XMV::rank == 1 && YMV::rank == 1) {
+    if (Y.extent(0) != A.extent(0) || Y.extent(0) != X.extent(0)) {
+      std::ostringstream os;
+      os << "KokkosBlas::mult: Dimensions do not match: "
+         << "Y: " << Y.extent(0) << " x " << Y.extent(1) << ", A: " << A.extent(0)
+         << ", X: " << X.extent(0);
+      KokkosKernels::Impl::throw_runtime_exception(os.str());
+    }
+  }
+  else if constexpr (XMV::rank == 2 && YMV::rank == 2) {
+    if (Y.extent(0) != A.extent(0) || Y.extent(0) != X.extent(0) || Y.extent(1) != X.extent(1)) {
+      std::ostringstream os;
+      os << "KokkosBlas::mult: Dimensions do not match: "
+         << "Y: " << Y.extent(0) << " x " << Y.extent(1) << ", A: " << A.extent(0) << " x " << A.extent(0)
+         << ", X: " << X.extent(0) << " x " << X.extent(1);
+      KokkosKernels::Impl::throw_runtime_exception(os.str());
+    }
   }
 
   using YUnifiedLayout = typename KokkosKernels::Impl::GetUnifiedLayout<YMV>::array_layout;

--- a/blas/src/KokkosBlas1_mult.hpp
+++ b/blas/src/KokkosBlas1_mult.hpp
@@ -62,12 +62,10 @@ void mult(const execution_space& space, typename YMV::const_value_type& gamma, c
     if (Y.extent(0) != A.extent(0) || Y.extent(0) != X.extent(0)) {
       std::ostringstream os;
       os << "KokkosBlas::mult: Dimensions do not match: "
-         << "Y: " << Y.extent(0) << " x " << Y.extent(1) << ", A: " << A.extent(0)
-         << ", X: " << X.extent(0);
+         << "Y: " << Y.extent(0) << " x " << Y.extent(1) << ", A: " << A.extent(0) << ", X: " << X.extent(0);
       KokkosKernels::Impl::throw_runtime_exception(os.str());
     }
-  }
-  else if constexpr (XMV::rank == 2 && YMV::rank == 2) {
+  } else if constexpr (XMV::rank == 2 && YMV::rank == 2) {
     if (Y.extent(0) != A.extent(0) || Y.extent(0) != X.extent(0) || Y.extent(1) != X.extent(1)) {
       std::ostringstream os;
       os << "KokkosBlas::mult: Dimensions do not match: "

--- a/blas/src/KokkosBlas1_reciprocal.hpp
+++ b/blas/src/KokkosBlas1_reciprocal.hpp
@@ -60,8 +60,7 @@ void reciprocal(const execution_space& space, const RMV& R, const XMV& X) {
          << "R: " << R.extent(0) << ", X: " << X.extent(0);
       KokkosKernels::Impl::throw_runtime_exception(os.str());
     }
-  }
-  else if constexpr (RMV::rank == 2) {
+  } else if constexpr (RMV::rank == 2) {
     if (X.extent(0) != R.extent(0) || X.extent(1) != R.extent(1)) {
       std::ostringstream os;
       os << "KokkosBlas::reciprocal (MV): Dimensions of R and X do not match: "

--- a/blas/src/KokkosBlas1_reciprocal.hpp
+++ b/blas/src/KokkosBlas1_reciprocal.hpp
@@ -53,11 +53,21 @@ void reciprocal(const execution_space& space, const RMV& R, const XMV& X) {
                 "RMV and XMV must either have rank 1 or rank 2.");
 
   // Check compatibility of dimensions at run time.
-  if (X.extent(0) != R.extent(0) || X.extent(1) != R.extent(1)) {
-    std::ostringstream os;
-    os << "KokkosBlas::reciprocal (MV): Dimensions of R and X do not match: "
-       << "R: " << R.extent(0) << " x " << R.extent(1) << ", X: " << X.extent(0) << " x " << X.extent(1);
-    KokkosKernels::Impl::throw_runtime_exception(os.str());
+  if constexpr (RMV::rank == 1) {
+    if (X.extent(0) != R.extent(0)) {
+      std::ostringstream os;
+      os << "KokkosBlas::reciprocal (MV): Dimensions of R and X do not match: "
+         << "R: " << R.extent(0) << ", X: " << X.extent(0);
+      KokkosKernels::Impl::throw_runtime_exception(os.str());
+    }
+  }
+  else if constexpr (RMV::rank == 2) {
+    if (X.extent(0) != R.extent(0) || X.extent(1) != R.extent(1)) {
+      std::ostringstream os;
+      os << "KokkosBlas::reciprocal (MV): Dimensions of R and X do not match: "
+         << "R: " << R.extent(0) << " x " << R.extent(1) << ", X: " << X.extent(0) << " x " << X.extent(1);
+      KokkosKernels::Impl::throw_runtime_exception(os.str());
+    }
   }
 
   // Create unmanaged versions of the input Views.  RMV and XMV may be

--- a/blas/src/KokkosBlas1_scal.hpp
+++ b/blas/src/KokkosBlas1_scal.hpp
@@ -57,11 +57,21 @@ void scal(const execution_space& space, const RMV& R, const AV& a, const XMV& X)
                 "RMV and XMV must either have rank 1 or rank 2.");
 
   // Check compatibility of dimensions at run time.
-  if (X.extent(0) != R.extent(0) || X.extent(1) != R.extent(1)) {
-    std::ostringstream os;
-    os << "KokkosBlas::scal: Dimensions of R and X do not match: "
-       << "R: " << R.extent(0) << " x " << R.extent(1) << ", X: " << X.extent(0) << " x " << X.extent(1);
-    KokkosKernels::Impl::throw_runtime_exception(os.str());
+  if constexpr (RMV::rank == 1) {
+    if (X.extent(0) != R.extent(0)) {
+      std::ostringstream os;
+      os << "KokkosBlas::scal: Dimensions of R and X do not match: "
+         << "R: " << R.extent(0) << ", X: " << X.extent(0);
+      KokkosKernels::Impl::throw_runtime_exception(os.str());
+    }
+  }
+  else if constexpr (RMV::rank == 2) {
+    if (X.extent(0) != R.extent(0) || X.extent(1) != R.extent(1)) {
+      std::ostringstream os;
+      os << "KokkosBlas::scal: Dimensions of R and X do not match: "
+         << "R: " << R.extent(0) << " x " << R.extent(1) << ", X: " << X.extent(0) << " x " << X.extent(1);
+      KokkosKernels::Impl::throw_runtime_exception(os.str());
+    }
   }
 
   using UnifiedRLayout = typename KokkosKernels::Impl::GetUnifiedLayout<RMV>::array_layout;

--- a/blas/src/KokkosBlas1_scal.hpp
+++ b/blas/src/KokkosBlas1_scal.hpp
@@ -64,8 +64,7 @@ void scal(const execution_space& space, const RMV& R, const AV& a, const XMV& X)
          << "R: " << R.extent(0) << ", X: " << X.extent(0);
       KokkosKernels::Impl::throw_runtime_exception(os.str());
     }
-  }
-  else if constexpr (RMV::rank == 2) {
+  } else if constexpr (RMV::rank == 2) {
     if (X.extent(0) != R.extent(0) || X.extent(1) != R.extent(1)) {
       std::ostringstream os;
       os << "KokkosBlas::scal: Dimensions of R and X do not match: "

--- a/blas/src/KokkosBlas1_update.hpp
+++ b/blas/src/KokkosBlas1_update.hpp
@@ -74,8 +74,7 @@ void update(const execution_space& space, const typename XMV::non_const_value_ty
          << "Z: " << Z.extent(0) << ", X: " << X.extent(0) << ", Y: " << Y.extent(0);
       KokkosKernels::Impl::throw_runtime_exception(os.str());
     }
-  }
-  else if constexpr (ZMV::rank == 2) {
+  } else if constexpr (ZMV::rank == 2) {
     if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1) || X.extent(0) != Z.extent(0) ||
         X.extent(1) != Z.extent(1)) {
       std::ostringstream os;

--- a/blas/src/KokkosBlas1_update.hpp
+++ b/blas/src/KokkosBlas1_update.hpp
@@ -67,13 +67,23 @@ void update(const execution_space& space, const typename XMV::non_const_value_ty
                 "XMV, YMV, and ZMV must either have rank 1 or rank 2.");
 
   // Check compatibility of dimensions at run time.
-  if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1) || X.extent(0) != Z.extent(0) ||
-      X.extent(1) != Z.extent(1)) {
-    std::ostringstream os;
-    os << "KokkosBlas::update (MV): Dimensions of X, Y, and Z do not match: "
-       << "Z: " << Z.extent(0) << " x " << Z.extent(1) << ", X: " << X.extent(0) << " x " << X.extent(1)
-       << ", Y: " << Y.extent(0) << " x " << Y.extent(1);
-    KokkosKernels::Impl::throw_runtime_exception(os.str());
+  if constexpr (ZMV::rank == 1) {
+    if (X.extent(0) != Y.extent(0) || X.extent(0) != Z.extent(0)) {
+      std::ostringstream os;
+      os << "KokkosBlas::update (MV): Dimensions of X, Y, and Z do not match: "
+         << "Z: " << Z.extent(0) << ", X: " << X.extent(0) << ", Y: " << Y.extent(0);
+      KokkosKernels::Impl::throw_runtime_exception(os.str());
+    }
+  }
+  else if constexpr (ZMV::rank == 2) {
+    if (X.extent(0) != Y.extent(0) || X.extent(1) != Y.extent(1) || X.extent(0) != Z.extent(0) ||
+        X.extent(1) != Z.extent(1)) {
+      std::ostringstream os;
+      os << "KokkosBlas::update (MV): Dimensions of X, Y, and Z do not match: "
+         << "Z: " << Z.extent(0) << " x " << Z.extent(1) << ", X: " << X.extent(0) << " x " << X.extent(1)
+         << ", Y: " << Y.extent(0) << " x " << Y.extent(1);
+      KokkosKernels::Impl::throw_runtime_exception(os.str());
+    }
   }
 
   // Create unmanaged versions of the input Views.  XMV, YMV, and ZMV

--- a/common/src/KokkosKernels_PrintUtils.hpp
+++ b/common/src/KokkosKernels_PrintUtils.hpp
@@ -56,7 +56,6 @@ inline std::enable_if_t<idx_array_type::rank == 0> kk_print_1Dview(std::ostream&
                                                                    bool print_all = false, const char* sep = " ",
                                                                    size_t print_size = 1) {
   typedef typename idx_array_type::host_mirror_type host_type;
-  typedef typename idx_array_type::size_type idx;
   host_type host_view = Kokkos::create_mirror_view(view);
   Kokkos::deep_copy(host_view, view);
   if (print_all || print_size > 0) {

--- a/common/src/KokkosKernels_PrintUtils.hpp
+++ b/common/src/KokkosKernels_PrintUtils.hpp
@@ -40,8 +40,6 @@ inline void kk_get_histogram(typename in_lno_view_t::size_type in_elements, in_l
   MyExecSpace().fence();
 }
 
-// TODO add 0Dview printer or remove the test
-
 /**
  * \brief Prints the given 1D view.
  * \param os: Stream to print to. To print to stdout use std::cout, stderr,
@@ -61,12 +59,7 @@ inline std::enable_if_t<idx_array_type::rank == 0> kk_print_1Dview(std::ostream&
   typedef typename idx_array_type::size_type idx;
   host_type host_view = Kokkos::create_mirror_view(view);
   Kokkos::deep_copy(host_view, view);
-  // const auto print_range = [&](idx begin, idx end) {
-  //   for (idx i = begin; i < end; ++i) os << host_view.access(i) << sep;
-  // };
-  idx nr = 1;  // rank 0 view is just a scalar
-  if (print_all || nr <= print_size) {
-    // print_range(0, nr);
+  if (print_all || print_size > 0) {
     os << host_view() << sep;
   }
   os << std::endl;

--- a/common/src/KokkosKernels_PrintUtils.hpp
+++ b/common/src/KokkosKernels_PrintUtils.hpp
@@ -40,18 +40,40 @@ inline void kk_get_histogram(typename in_lno_view_t::size_type in_elements, in_l
   MyExecSpace().fence();
 }
 
+// TODO add 0Dview printer or remove the test
+
 /**
  * \brief Prints the given 1D view.
  * \param os: Stream to print to. To print to stdout use std::cout, stderr,
- * std::cerr, or a file use an ofstream object. \param view: input view to
- * print. \param print_all: whether to print all elements or not. If it is
- * false, print print_size/2 first and last elements. \param sep: Element
- * separator. Default is a single space: " " \param print_size: Total elements
- * to print if print_all is false print_size/2 first and last elements are
- * pritned. This parameter is not used if print_all is set to true.
+ * std::cerr, or a file use an ofstream object.
+ * \param view: input view to print.
+ * \param print_all: whether to print all elements or not. If it is
+ * false, print print_size/2 first and last elements.
+ * \param sep: Element separator. Default is a single space: " "
+ * \param print_size: Total elements to print if print_all is false print_size/2
+ * first and last elements are printed. This parameter is not used if print_all is set to true.
  */
 template <typename idx_array_type>
-inline std::enable_if_t<idx_array_type::rank <= 1> kk_print_1Dview(std::ostream& os, idx_array_type view,
+inline std::enable_if_t<idx_array_type::rank == 0> kk_print_1Dview(std::ostream& os, idx_array_type view,
+                                                                   bool print_all = false, const char* sep = " ",
+                                                                   size_t print_size = 1) {
+  typedef typename idx_array_type::host_mirror_type host_type;
+  typedef typename idx_array_type::size_type idx;
+  host_type host_view = Kokkos::create_mirror_view(view);
+  Kokkos::deep_copy(host_view, view);
+  //const auto print_range = [&](idx begin, idx end) {
+  //  for (idx i = begin; i < end; ++i) os << host_view.access(i) << sep;
+  //};
+  idx nr = 1; // rank 0 view is just a scalar
+  if (print_all || nr <= print_size) {
+    //print_range(0, nr);
+    os << host_view() << sep;
+  }
+  os << std::endl;
+}
+
+template <typename idx_array_type>
+inline std::enable_if_t<idx_array_type::rank == 1> kk_print_1Dview(std::ostream& os, idx_array_type view,
                                                                    bool print_all = false, const char* sep = " ",
                                                                    size_t print_size = 40) {
   typedef typename idx_array_type::host_mirror_type host_type;

--- a/common/src/KokkosKernels_PrintUtils.hpp
+++ b/common/src/KokkosKernels_PrintUtils.hpp
@@ -61,12 +61,12 @@ inline std::enable_if_t<idx_array_type::rank == 0> kk_print_1Dview(std::ostream&
   typedef typename idx_array_type::size_type idx;
   host_type host_view = Kokkos::create_mirror_view(view);
   Kokkos::deep_copy(host_view, view);
-  //const auto print_range = [&](idx begin, idx end) {
-  //  for (idx i = begin; i < end; ++i) os << host_view.access(i) << sep;
-  //};
-  idx nr = 1; // rank 0 view is just a scalar
+  // const auto print_range = [&](idx begin, idx end) {
+  //   for (idx i = begin; i < end; ++i) os << host_view.access(i) << sep;
+  // };
+  idx nr = 1;  // rank 0 view is just a scalar
   if (print_all || nr <= print_size) {
-    //print_range(0, nr);
+    // print_range(0, nr);
     os << host_view() << sep;
   }
   os << std::endl;

--- a/common/unit_test/Test_Common_IOUtils.hpp
+++ b/common/unit_test/Test_Common_IOUtils.hpp
@@ -29,8 +29,8 @@ class ViewPrintHelper {
 
 template <typename exec_space>
 void testPrintView() {
-  using scalar_t   = KokkosKernels::default_scalar;
-  using Unmanaged  = Kokkos::MemoryTraits<Kokkos::Unmanaged>;
+  using scalar_t  = KokkosKernels::default_scalar;
+  using Unmanaged = Kokkos::MemoryTraits<Kokkos::Unmanaged>;
   // TODO add 0Dview printer or remove the test
   using rank0_view = Kokkos::View<scalar_t, Kokkos::HostSpace, Unmanaged>;
   using rank1_view = Kokkos::View<scalar_t *, Kokkos::HostSpace, Unmanaged>;

--- a/common/unit_test/Test_Common_IOUtils.hpp
+++ b/common/unit_test/Test_Common_IOUtils.hpp
@@ -31,7 +31,6 @@ template <typename exec_space>
 void testPrintView() {
   using scalar_t  = KokkosKernels::default_scalar;
   using Unmanaged = Kokkos::MemoryTraits<Kokkos::Unmanaged>;
-  // TODO add 0Dview printer or remove the test
   using rank0_view = Kokkos::View<scalar_t, Kokkos::HostSpace, Unmanaged>;
   using rank1_view = Kokkos::View<scalar_t *, Kokkos::HostSpace, Unmanaged>;
   using rank2_view = Kokkos::View<scalar_t **, Kokkos::HostSpace, Unmanaged>;

--- a/common/unit_test/Test_Common_IOUtils.hpp
+++ b/common/unit_test/Test_Common_IOUtils.hpp
@@ -29,8 +29,8 @@ class ViewPrintHelper {
 
 template <typename exec_space>
 void testPrintView() {
-  using scalar_t  = KokkosKernels::default_scalar;
-  using Unmanaged = Kokkos::MemoryTraits<Kokkos::Unmanaged>;
+  using scalar_t   = KokkosKernels::default_scalar;
+  using Unmanaged  = Kokkos::MemoryTraits<Kokkos::Unmanaged>;
   using rank0_view = Kokkos::View<scalar_t, Kokkos::HostSpace, Unmanaged>;
   using rank1_view = Kokkos::View<scalar_t *, Kokkos::HostSpace, Unmanaged>;
   using rank2_view = Kokkos::View<scalar_t **, Kokkos::HostSpace, Unmanaged>;

--- a/common/unit_test/Test_Common_IOUtils.hpp
+++ b/common/unit_test/Test_Common_IOUtils.hpp
@@ -31,6 +31,7 @@ template <typename exec_space>
 void testPrintView() {
   using scalar_t   = KokkosKernels::default_scalar;
   using Unmanaged  = Kokkos::MemoryTraits<Kokkos::Unmanaged>;
+  // TODO add 0Dview printer or remove the test
   using rank0_view = Kokkos::View<scalar_t, Kokkos::HostSpace, Unmanaged>;
   using rank1_view = Kokkos::View<scalar_t *, Kokkos::HostSpace, Unmanaged>;
   using rank2_view = Kokkos::View<scalar_t **, Kokkos::HostSpace, Unmanaged>;

--- a/sparse/src/KokkosSparse_gauss_seidel.hpp
+++ b/sparse/src/KokkosSparse_gauss_seidel.hpp
@@ -644,12 +644,14 @@ void symmetric_block_gauss_seidel_apply(KernelHandle *handle, typename KernelHan
                                         bool init_zero_x_vector, bool update_y_vector,
                                         typename KernelHandle::nnz_scalar_t omega, int numIter) {
   // Check compatibility of dimensions at run time.
-  if (x_lhs_output_vec.extent(1) != y_rhs_input_vec.extent(1)) {
-    std::ostringstream os;
-    os << "KokkosSparse::symmetric_block_gauss_seidel_apply: Dimensions of X "
-          "and Y do not match: "
-       << "X has " << x_lhs_output_vec.extent(1) << "columns, Y has " << y_rhs_input_vec.extent(1) << " columns.";
-    KokkosKernels::Impl::throw_runtime_exception(os.str());
+  if constexpr (x_scalar_view_t::rank == 2) {
+    if (x_lhs_output_vec.extent(1) != y_rhs_input_vec.extent(1)) {
+      std::ostringstream os;
+      os << "KokkosSparse::symmetric_block_gauss_seidel_apply: Dimensions of X "
+            "and Y do not match: "
+         << "X has " << x_lhs_output_vec.extent(1) << "columns, Y has " << y_rhs_input_vec.extent(1) << " columns.";
+      KokkosKernels::Impl::throw_runtime_exception(os.str());
+    }
   }
   auto gsHandle = handle->get_point_gs_handle();
   if (gsHandle->get_algorithm_type() == GS_CLUSTER) {

--- a/sparse/src/KokkosSparse_gauss_seidel.hpp
+++ b/sparse/src/KokkosSparse_gauss_seidel.hpp
@@ -542,10 +542,9 @@ void symmetric_gauss_seidel_apply(const ExecutionSpace &space, KernelHandle *han
   size_t x_lhs_output_vec_r2{1}, y_rhs_input_vec_r2{1};
   if constexpr (x_scalar_view_t::rank == 2) {
     x_lhs_output_vec_r2 = x_lhs_output_vec.extent(1);
-    y_rhs_input_vec_r2 = y_rhs_input_vec.extent(1);
+    y_rhs_input_vec_r2  = y_rhs_input_vec.extent(1);
   }
-  Internal_xscalar_nnz_view_t_ nonconst_x_v(x_lhs_output_vec.data(), x_lhs_output_vec.extent(0),
-                                            x_lhs_output_vec_r2);
+  Internal_xscalar_nnz_view_t_ nonconst_x_v(x_lhs_output_vec.data(), x_lhs_output_vec.extent(0), x_lhs_output_vec_r2);
   Internal_yscalar_nnz_view_t_ const_y_v(y_rhs_input_vec.data(), y_rhs_input_vec.extent(0), y_rhs_input_vec_r2);
 
   using namespace KokkosSparse::Impl;
@@ -794,11 +793,10 @@ void forward_sweep_gauss_seidel_apply(const ExecutionSpace &space, KernelHandle 
   size_t x_lhs_output_vec_r2{1}, y_rhs_input_vec_r2{1};
   if constexpr (x_scalar_view_t::rank == 2) {
     x_lhs_output_vec_r2 = x_lhs_output_vec.extent(1);
-    y_rhs_input_vec_r2 = y_rhs_input_vec.extent(1);
+    y_rhs_input_vec_r2  = y_rhs_input_vec.extent(1);
   }
 
-  Internal_xscalar_nnz_view_t_ nonconst_x_v(x_lhs_output_vec.data(), x_lhs_output_vec.extent(0),
-                                            x_lhs_output_vec_r2);
+  Internal_xscalar_nnz_view_t_ nonconst_x_v(x_lhs_output_vec.data(), x_lhs_output_vec.extent(0), x_lhs_output_vec_r2);
   Internal_yscalar_nnz_view_t_ const_y_v(y_rhs_input_vec.data(), y_rhs_input_vec.extent(0), y_rhs_input_vec_r2);
 
   using namespace KokkosSparse::Impl;
@@ -1049,11 +1047,10 @@ void backward_sweep_gauss_seidel_apply(const ExecutionSpace &space, KernelHandle
   size_t x_lhs_output_vec_r2{1}, y_rhs_input_vec_r2{1};
   if constexpr (x_scalar_view_t::rank == 2) {
     x_lhs_output_vec_r2 = x_lhs_output_vec.extent(1);
-    y_rhs_input_vec_r2 = y_rhs_input_vec.extent(1);
+    y_rhs_input_vec_r2  = y_rhs_input_vec.extent(1);
   }
 
-  Internal_xscalar_nnz_view_t_ nonconst_x_v(x_lhs_output_vec.data(), x_lhs_output_vec.extent(0),
-                                            x_lhs_output_vec_r2);
+  Internal_xscalar_nnz_view_t_ nonconst_x_v(x_lhs_output_vec.data(), x_lhs_output_vec.extent(0), x_lhs_output_vec_r2);
   Internal_yscalar_nnz_view_t_ const_y_v(y_rhs_input_vec.data(), y_rhs_input_vec.extent(0), y_rhs_input_vec_r2);
 
   using namespace KokkosSparse::Impl;

--- a/sparse/src/KokkosSparse_gauss_seidel.hpp
+++ b/sparse/src/KokkosSparse_gauss_seidel.hpp
@@ -488,11 +488,13 @@ void symmetric_gauss_seidel_apply(const ExecutionSpace &space, KernelHandle *han
                 "a contiguous layout (Left or Right, not Stride)");
 
   // Check compatibility of #vectors
-  if (x_lhs_output_vec.extent(1) != y_rhs_input_vec.extent(1)) {
-    std::ostringstream os;
-    os << "KokkosSparse::symmetric_gauss_seidel_apply: "
-       << "X has " << x_lhs_output_vec.extent(1) << "columns, Y has " << y_rhs_input_vec.extent(1) << " columns.";
-    KokkosKernels::Impl::throw_runtime_exception(os.str());
+  if constexpr (x_scalar_view_t::rank == 2) {
+    if (x_lhs_output_vec.extent(1) != y_rhs_input_vec.extent(1)) {
+      std::ostringstream os;
+      os << "KokkosSparse::symmetric_gauss_seidel_apply: "
+         << "X has " << x_lhs_output_vec.extent(1) << "columns, Y has " << y_rhs_input_vec.extent(1) << " columns.";
+      KokkosKernels::Impl::throw_runtime_exception(os.str());
+    }
   }
 
   typedef typename KernelHandle::const_size_type c_size_t;
@@ -537,9 +539,14 @@ void symmetric_gauss_seidel_apply(const ExecutionSpace &space, KernelHandle *han
   Internal_alno_nnz_view_t_ const_a_l(entries.data(), entries.extent(0));
   Internal_ascalar_nnz_view_t_ const_a_v(values.data(), values.extent(0));
 
+  size_t x_lhs_output_vec_r2{1}, y_rhs_input_vec_r2{1};
+  if constexpr (x_scalar_view_t::rank == 2) {
+    x_lhs_output_vec_r2 = x_lhs_output_vec.extent(1);
+    y_rhs_input_vec_r2 = y_rhs_input_vec.extent(1);
+  }
   Internal_xscalar_nnz_view_t_ nonconst_x_v(x_lhs_output_vec.data(), x_lhs_output_vec.extent(0),
-                                            x_lhs_output_vec.extent(1));
-  Internal_yscalar_nnz_view_t_ const_y_v(y_rhs_input_vec.data(), y_rhs_input_vec.extent(0), y_rhs_input_vec.extent(1));
+                                            x_lhs_output_vec_r2);
+  Internal_yscalar_nnz_view_t_ const_y_v(y_rhs_input_vec.data(), y_rhs_input_vec.extent(0), y_rhs_input_vec_r2);
 
   using namespace KokkosSparse::Impl;
 
@@ -731,12 +738,14 @@ void forward_sweep_gauss_seidel_apply(const ExecutionSpace &space, KernelHandle 
                 "have a contiguous layout (Left or Right, not Stride)");
 
   // Check compatibility of dimensions at run time.
-  if (x_lhs_output_vec.extent(1) != y_rhs_input_vec.extent(1)) {
-    std::ostringstream os;
-    os << "KokkosSparse::forward_sweep_gauss_seidel_apply: Dimensions of X and "
-          "Y do not match: "
-       << "X has " << x_lhs_output_vec.extent(1) << "columns, Y has " << y_rhs_input_vec.extent(1) << " columns.";
-    KokkosKernels::Impl::throw_runtime_exception(os.str());
+  if constexpr (x_scalar_view_t::rank == 2) {
+    if (x_lhs_output_vec.extent(1) != y_rhs_input_vec.extent(1)) {
+      std::ostringstream os;
+      os << "KokkosSparse::forward_sweep_gauss_seidel_apply: Dimensions of X and "
+            "Y do not match: "
+         << "X has " << x_lhs_output_vec.extent(1) << "columns, Y has " << y_rhs_input_vec.extent(1) << " columns.";
+      KokkosKernels::Impl::throw_runtime_exception(os.str());
+    }
   }
 
   typedef typename KernelHandle::const_size_type c_size_t;
@@ -782,9 +791,15 @@ void forward_sweep_gauss_seidel_apply(const ExecutionSpace &space, KernelHandle 
   Internal_alno_nnz_view_t_ const_a_l(entries.data(), entries.extent(0));
   Internal_ascalar_nnz_view_t_ const_a_v(values.data(), values.extent(0));
 
+  size_t x_lhs_output_vec_r2{1}, y_rhs_input_vec_r2{1};
+  if constexpr (x_scalar_view_t::rank == 2) {
+    x_lhs_output_vec_r2 = x_lhs_output_vec.extent(1);
+    y_rhs_input_vec_r2 = y_rhs_input_vec.extent(1);
+  }
+
   Internal_xscalar_nnz_view_t_ nonconst_x_v(x_lhs_output_vec.data(), x_lhs_output_vec.extent(0),
-                                            x_lhs_output_vec.extent(1));
-  Internal_yscalar_nnz_view_t_ const_y_v(y_rhs_input_vec.data(), y_rhs_input_vec.extent(0), y_rhs_input_vec.extent(1));
+                                            x_lhs_output_vec_r2);
+  Internal_yscalar_nnz_view_t_ const_y_v(y_rhs_input_vec.data(), y_rhs_input_vec.extent(0), y_rhs_input_vec_r2);
 
   using namespace KokkosSparse::Impl;
 
@@ -882,12 +897,14 @@ void forward_sweep_block_gauss_seidel_apply(KernelHandle *handle, typename Kerne
                                             bool init_zero_x_vector, bool update_y_vector,
                                             typename KernelHandle::nnz_scalar_t omega, int numIter) {
   // Check compatibility of dimensions at run time.
-  if (x_lhs_output_vec.extent(1) != y_rhs_input_vec.extent(1)) {
-    std::ostringstream os;
-    os << "KokkosSparse::forward_sweep_block_gauss_seidel_apply: Dimensions of "
-          "X and Y do not match: "
-       << "X has " << x_lhs_output_vec.extent(1) << "columns, Y has " << y_rhs_input_vec.extent(1) << " columns.";
-    KokkosKernels::Impl::throw_runtime_exception(os.str());
+  if constexpr (x_scalar_view_t::rank == 2) {
+    if (x_lhs_output_vec.extent(1) != y_rhs_input_vec.extent(1)) {
+      std::ostringstream os;
+      os << "KokkosSparse::forward_sweep_block_gauss_seidel_apply: Dimensions of "
+            "X and Y do not match: "
+         << "X has " << x_lhs_output_vec.extent(1) << "columns, Y has " << y_rhs_input_vec.extent(1) << " columns.";
+      KokkosKernels::Impl::throw_runtime_exception(os.str());
+    }
   }
 
   auto gsHandle = handle->get_point_gs_handle();
@@ -976,12 +993,14 @@ void backward_sweep_gauss_seidel_apply(const ExecutionSpace &space, KernelHandle
                 "have a contiguous layout (Left or Right, not Stride)");
 
   // Check compatibility of dimensions at run time.
-  if (x_lhs_output_vec.extent(1) != y_rhs_input_vec.extent(1)) {
-    std::ostringstream os;
-    os << "KokkosSparse::backward_sweep_gauss_seidel_apply: Dimensions of X "
-          "and Y do not match: "
-       << "X has " << x_lhs_output_vec.extent(1) << "columns, Y has " << y_rhs_input_vec.extent(1) << " columns.";
-    KokkosKernels::Impl::throw_runtime_exception(os.str());
+  if constexpr (x_scalar_view_t::rank == 2) {
+    if (x_lhs_output_vec.extent(1) != y_rhs_input_vec.extent(1)) {
+      std::ostringstream os;
+      os << "KokkosSparse::backward_sweep_gauss_seidel_apply: Dimensions of X "
+            "and Y do not match: "
+         << "X has " << x_lhs_output_vec.extent(1) << "columns, Y has " << y_rhs_input_vec.extent(1) << " columns.";
+      KokkosKernels::Impl::throw_runtime_exception(os.str());
+    }
   }
 
   typedef typename KernelHandle::const_size_type c_size_t;
@@ -1027,9 +1046,15 @@ void backward_sweep_gauss_seidel_apply(const ExecutionSpace &space, KernelHandle
   Internal_alno_nnz_view_t_ const_a_l(entries.data(), entries.extent(0));
   Internal_ascalar_nnz_view_t_ const_a_v(values.data(), values.extent(0));
 
+  size_t x_lhs_output_vec_r2{1}, y_rhs_input_vec_r2{1};
+  if constexpr (x_scalar_view_t::rank == 2) {
+    x_lhs_output_vec_r2 = x_lhs_output_vec.extent(1);
+    y_rhs_input_vec_r2 = y_rhs_input_vec.extent(1);
+  }
+
   Internal_xscalar_nnz_view_t_ nonconst_x_v(x_lhs_output_vec.data(), x_lhs_output_vec.extent(0),
-                                            x_lhs_output_vec.extent(1));
-  Internal_yscalar_nnz_view_t_ const_y_v(y_rhs_input_vec.data(), y_rhs_input_vec.extent(0), y_rhs_input_vec.extent(1));
+                                            x_lhs_output_vec_r2);
+  Internal_yscalar_nnz_view_t_ const_y_v(y_rhs_input_vec.data(), y_rhs_input_vec.extent(0), y_rhs_input_vec_r2);
 
   using namespace KokkosSparse::Impl;
 
@@ -1128,12 +1153,14 @@ void backward_sweep_block_gauss_seidel_apply(KernelHandle *handle, typename Kern
                                              bool update_y_vector, typename KernelHandle::nnz_scalar_t omega,
                                              int numIter) {
   // Check compatibility of dimensions at run time.
-  if (x_lhs_output_vec.extent(1) != y_rhs_input_vec.extent(1)) {
-    std::ostringstream os;
-    os << "KokkosSparse::backward_sweep_block_gauss_seidel_apply: Dimensions "
-          "of X and Y do not match: "
-       << "X has " << x_lhs_output_vec.extent(1) << "columns, Y has " << y_rhs_input_vec.extent(1) << " columns.";
-    KokkosKernels::Impl::throw_runtime_exception(os.str());
+  if constexpr (x_scalar_view_t::rank == 2) {
+    if (x_lhs_output_vec.extent(1) != y_rhs_input_vec.extent(1)) {
+      std::ostringstream os;
+      os << "KokkosSparse::backward_sweep_block_gauss_seidel_apply: Dimensions "
+            "of X and Y do not match: "
+         << "X has " << x_lhs_output_vec.extent(1) << "columns, Y has " << y_rhs_input_vec.extent(1) << " columns.";
+      KokkosKernels::Impl::throw_runtime_exception(os.str());
+    }
   }
   auto gsHandle = handle->get_point_gs_handle();
   if (gsHandle->get_algorithm_type() == GS_CLUSTER) {

--- a/sparse/src/KokkosSparse_spmv.hpp
+++ b/sparse/src/KokkosSparse_spmv.hpp
@@ -113,20 +113,40 @@ void spmv(const ExecutionSpace& space, Handle* handle, const char mode[], const 
   }
 
   if ((mode[0] == NoTranspose[0]) || (mode[0] == Conjugate[0])) {
-    if ((x.extent(1) != y.extent(1)) || (n != x.extent(0)) || (m != y.extent(0))) {
-      std::ostringstream os;
-      os << "KokkosSparse::spmv: Dimensions do not match: "
-         << ", A: " << m << " x " << n << ", x: " << x.extent(0) << " x " << x.extent(1) << ", y: " << y.extent(0)
-         << " x " << y.extent(1);
-      KokkosKernels::Impl::throw_runtime_exception(os.str());
+    if constexpr (XVector::rank() == 1) {
+      if ((n != x.extent(0)) || (m != y.extent(0))) {
+        std::ostringstream os;
+        os << "KokkosSparse::spmv: Dimensions do not match: "
+           << ", A: " << m << " x " << n << ", x: " << x.extent(0) << ", y: " << y.extent(0);
+        KokkosKernels::Impl::throw_runtime_exception(os.str());
+      }
+    }
+    else if constexpr (XVector::rank() == 2) {
+      if ((x.extent(1) != y.extent(1)) || (n != x.extent(0)) || (m != y.extent(0))) {
+        std::ostringstream os;
+        os << "KokkosSparse::spmv: Dimensions do not match: "
+           << ", A: " << m << " x " << n << ", x: " << x.extent(0) << " x " << x.extent(1) << ", y: " << y.extent(0)
+           << " x " << y.extent(1);
+        KokkosKernels::Impl::throw_runtime_exception(os.str());
+      }
     }
   } else {
-    if ((x.extent(1) != y.extent(1)) || (m != x.extent(0)) || (n != y.extent(0))) {
-      std::ostringstream os;
-      os << "KokkosSparse::spmv: Dimensions do not match (transpose): "
-         << ", A: " << A.numRows() << " x " << A.numCols() << ", x: " << x.extent(0) << " x " << x.extent(1)
-         << ", y: " << y.extent(0) << " x " << y.extent(1);
-      KokkosKernels::Impl::throw_runtime_exception(os.str());
+    if constexpr (XVector::rank() == 1) {
+      if ((m != x.extent(0)) || (n != y.extent(0))) {
+        std::ostringstream os;
+        os << "KokkosSparse::spmv: Dimensions do not match (transpose): "
+           << ", A: " << A.numRows() << " x " << A.numCols() << ", x: " << x.extent(0) << ", y: " << y.extent(0);
+        KokkosKernels::Impl::throw_runtime_exception(os.str());
+      }
+    }
+    else if constexpr (XVector::rank() == 2) {
+      if ((x.extent(1) != y.extent(1)) || (m != x.extent(0)) || (n != y.extent(0))) {
+        std::ostringstream os;
+        os << "KokkosSparse::spmv: Dimensions do not match (transpose): "
+           << ", A: " << A.numRows() << " x " << A.numCols() << ", x: " << x.extent(0) << " x " << x.extent(1)
+           << ", y: " << y.extent(0) << " x " << y.extent(1);
+        KokkosKernels::Impl::throw_runtime_exception(os.str());
+      }
     }
   }
 
@@ -560,24 +580,58 @@ void spmv_struct(const ExecutionSpace& space, const char mode[], const int stenc
 
   // Check compatibility of dimensions at run time.
   if ((mode[0] == NoTranspose[0]) || (mode[0] == Conjugate[0])) {
-    if ((x.extent(1) != y.extent(1)) || (static_cast<size_t>(A.numCols()) > static_cast<size_t>(x.extent(0))) ||
-        (static_cast<size_t>(A.numRows()) > static_cast<size_t>(y.extent(0)))) {
-      std::ostringstream os;
-      os << "KokkosSparse::spmv_struct: Dimensions do not match: "
-         << ", A: " << A.numRows() << " x " << A.numCols() << ", x: " << x.extent(0) << " x " << x.extent(1)
-         << ", y: " << y.extent(0) << " x " << y.extent(1);
+    if constexpr (XVector::rank == 1) {
+      if ((static_cast<size_t>(A.numCols()) > static_cast<size_t>(x.extent(0))) ||
+          (static_cast<size_t>(A.numRows()) > static_cast<size_t>(y.extent(0)))) {
+        std::ostringstream os;
+        os << "KokkosSparse::spmv_struct: Dimensions do not match: "
+           << ", A: " << A.numRows() << " x " << A.numCols() << ", x: " << x.extent(0) << ", y: " << y.extent(0);
 
-      KokkosKernels::Impl::throw_runtime_exception(os.str());
+        KokkosKernels::Impl::throw_runtime_exception(os.str());
+      }
+    }
+    if constexpr (XVector::rank == 1) {
+      if ((static_cast<size_t>(A.numCols()) > static_cast<size_t>(x.extent(0))) ||
+          (static_cast<size_t>(A.numRows()) > static_cast<size_t>(y.extent(0)))) {
+        std::ostringstream os;
+        os << "KokkosSparse::spmv_struct: Dimensions do not match: "
+           << ", A: " << A.numRows() << " x " << A.numCols() << ", x: " << x.extent(0) << ", y: " << y.extent(0);
+
+        KokkosKernels::Impl::throw_runtime_exception(os.str());
+      }
+    }
+    else if constexpr (XVector::rank == 2) {
+      if ((x.extent(1) != y.extent(1)) || (static_cast<size_t>(A.numCols()) > static_cast<size_t>(x.extent(0))) ||
+          (static_cast<size_t>(A.numRows()) > static_cast<size_t>(y.extent(0)))) {
+        std::ostringstream os;
+        os << "KokkosSparse::spmv_struct: Dimensions do not match: "
+           << ", A: " << A.numRows() << " x " << A.numCols() << ", x: " << x.extent(0) << " x " << x.extent(1)
+           << ", y: " << y.extent(0) << " x " << y.extent(1);
+
+        KokkosKernels::Impl::throw_runtime_exception(os.str());
+      }
     }
   } else {
-    if ((x.extent(1) != y.extent(1)) || (static_cast<size_t>(A.numCols()) > static_cast<size_t>(y.extent(0))) ||
-        (static_cast<size_t>(A.numRows()) > static_cast<size_t>(x.extent(0)))) {
-      std::ostringstream os;
-      os << "KokkosSparse::spmv_struct: Dimensions do not match (transpose): "
-         << ", A: " << A.numRows() << " x " << A.numCols() << ", x: " << x.extent(0) << " x " << x.extent(1)
-         << ", y: " << y.extent(0) << " x " << y.extent(1);
+    if constexpr (XVector::rank == 1) {
+      if ((static_cast<size_t>(A.numCols()) > static_cast<size_t>(y.extent(0))) ||
+          (static_cast<size_t>(A.numRows()) > static_cast<size_t>(x.extent(0)))) {
+        std::ostringstream os;
+        os << "KokkosSparse::spmv_struct: Dimensions do not match (transpose): "
+           << ", A: " << A.numRows() << " x " << A.numCols() << ", x: " << x.extent(0) << ", y: " << y.extent(0);
 
-      KokkosKernels::Impl::throw_runtime_exception(os.str());
+        KokkosKernels::Impl::throw_runtime_exception(os.str());
+      }
+    }
+    else if constexpr (XVector::rank == 2) {
+      if ((x.extent(1) != y.extent(1)) || (static_cast<size_t>(A.numCols()) > static_cast<size_t>(y.extent(0))) ||
+          (static_cast<size_t>(A.numRows()) > static_cast<size_t>(x.extent(0)))) {
+        std::ostringstream os;
+        os << "KokkosSparse::spmv_struct: Dimensions do not match (transpose): "
+           << ", A: " << A.numRows() << " x " << A.numCols() << ", x: " << x.extent(0) << " x " << x.extent(1)
+           << ", y: " << y.extent(0) << " x " << y.extent(1);
+
+        KokkosKernels::Impl::throw_runtime_exception(os.str());
+      }
     }
   }
 

--- a/sparse/src/KokkosSparse_spmv.hpp
+++ b/sparse/src/KokkosSparse_spmv.hpp
@@ -120,8 +120,7 @@ void spmv(const ExecutionSpace& space, Handle* handle, const char mode[], const 
            << ", A: " << m << " x " << n << ", x: " << x.extent(0) << ", y: " << y.extent(0);
         KokkosKernels::Impl::throw_runtime_exception(os.str());
       }
-    }
-    else if constexpr (XVector::rank() == 2) {
+    } else if constexpr (XVector::rank() == 2) {
       if ((x.extent(1) != y.extent(1)) || (n != x.extent(0)) || (m != y.extent(0))) {
         std::ostringstream os;
         os << "KokkosSparse::spmv: Dimensions do not match: "
@@ -138,8 +137,7 @@ void spmv(const ExecutionSpace& space, Handle* handle, const char mode[], const 
            << ", A: " << A.numRows() << " x " << A.numCols() << ", x: " << x.extent(0) << ", y: " << y.extent(0);
         KokkosKernels::Impl::throw_runtime_exception(os.str());
       }
-    }
-    else if constexpr (XVector::rank() == 2) {
+    } else if constexpr (XVector::rank() == 2) {
       if ((x.extent(1) != y.extent(1)) || (m != x.extent(0)) || (n != y.extent(0))) {
         std::ostringstream os;
         os << "KokkosSparse::spmv: Dimensions do not match (transpose): "
@@ -599,8 +597,7 @@ void spmv_struct(const ExecutionSpace& space, const char mode[], const int stenc
 
         KokkosKernels::Impl::throw_runtime_exception(os.str());
       }
-    }
-    else if constexpr (XVector::rank == 2) {
+    } else if constexpr (XVector::rank == 2) {
       if ((x.extent(1) != y.extent(1)) || (static_cast<size_t>(A.numCols()) > static_cast<size_t>(x.extent(0))) ||
           (static_cast<size_t>(A.numRows()) > static_cast<size_t>(y.extent(0)))) {
         std::ostringstream os;
@@ -621,8 +618,7 @@ void spmv_struct(const ExecutionSpace& space, const char mode[], const int stenc
 
         KokkosKernels::Impl::throw_runtime_exception(os.str());
       }
-    }
-    else if constexpr (XVector::rank == 2) {
+    } else if constexpr (XVector::rank == 2) {
       if ((x.extent(1) != y.extent(1)) || (static_cast<size_t>(A.numCols()) > static_cast<size_t>(y.extent(0))) ||
           (static_cast<size_t>(A.numRows()) > static_cast<size_t>(x.extent(0)))) {
         std::ostringstream os;

--- a/test_common/KokkosKernels_TestUtils.hpp
+++ b/test_common/KokkosKernels_TestUtils.hpp
@@ -241,11 +241,23 @@ template <typename vec_t>
 vec_t create_random_x_vector(vec_t& kok_x, double max_value = 10.0) {
   typedef typename vec_t::value_type scalar_t;
   auto h_x = Kokkos::create_mirror_view(kok_x);
-  for (size_t j = 0; j < h_x.extent(1); ++j) {
+  if constexpr (vec_t::rank == 2) {
+    for (size_t j = 0; j < h_x.extent(1); ++j) {
+      for (size_t i = 0; i < h_x.extent(0); ++i) {
+        scalar_t r       = static_cast<scalar_t>(rand()) / static_cast<scalar_t>(RAND_MAX / max_value);
+        h_x.access(i, j) = r;
+      }
+    }
+  }
+  else if constexpr (vec_t::rank == 1) {
     for (size_t i = 0; i < h_x.extent(0); ++i) {
       scalar_t r       = static_cast<scalar_t>(rand()) / static_cast<scalar_t>(RAND_MAX / max_value);
-      h_x.access(i, j) = r;
+      h_x.access(i) = r;
     }
+  }
+  else if constexpr (vec_t::rank == 0) {
+    scalar_t r       = static_cast<scalar_t>(rand()) / static_cast<scalar_t>(RAND_MAX / max_value);
+    h_x() = r;
   }
   Kokkos::deep_copy(kok_x, h_x);
   return kok_x;

--- a/test_common/KokkosKernels_TestUtils.hpp
+++ b/test_common/KokkosKernels_TestUtils.hpp
@@ -248,16 +248,14 @@ vec_t create_random_x_vector(vec_t& kok_x, double max_value = 10.0) {
         h_x.access(i, j) = r;
       }
     }
-  }
-  else if constexpr (vec_t::rank == 1) {
+  } else if constexpr (vec_t::rank == 1) {
     for (size_t i = 0; i < h_x.extent(0); ++i) {
-      scalar_t r       = static_cast<scalar_t>(rand()) / static_cast<scalar_t>(RAND_MAX / max_value);
+      scalar_t r    = static_cast<scalar_t>(rand()) / static_cast<scalar_t>(RAND_MAX / max_value);
       h_x.access(i) = r;
     }
-  }
-  else if constexpr (vec_t::rank == 0) {
-    scalar_t r       = static_cast<scalar_t>(rand()) / static_cast<scalar_t>(RAND_MAX / max_value);
-    h_x() = r;
+  } else if constexpr (vec_t::rank == 0) {
+    scalar_t r = static_cast<scalar_t>(rand()) / static_cast<scalar_t>(RAND_MAX / max_value);
+    h_x()      = r;
   }
   Kokkos::deep_copy(kok_x, h_x);
   return kok_x;


### PR DESCRIPTION
This PR includes work toward addressing https://github.com/kokkos/kokkos-kernels/issues/3161

Compatibility update when building with `Kokkos_ENABLE_DEPRECATED_CODE_5=OFF` following https://github.com/kokkos/kokkos/pull/9076
