### PR TITLE
Fix maybe-uninitialized warnings

### DIFF
--- a/graph/impl/KokkosGraph_MergePath_impl.hpp
+++ b/graph/impl/KokkosGraph_MergePath_impl.hpp
@@ -19,7 +19,7 @@ namespace Impl {
  */
 template <typename a_index_type, typename b_index_type>
 struct DiagonalSearchResult {
-  DiagonalSearchResult() : ai(0), bi(0) {}
+  KOKKOS_INLINE_FUNCTION DiagonalSearchResult() : ai(0), bi(0) {}
   a_index_type ai;
   b_index_type bi;
 };

--- a/graph/impl/KokkosGraph_MergePath_impl.hpp
+++ b/graph/impl/KokkosGraph_MergePath_impl.hpp
@@ -19,6 +19,7 @@ namespace Impl {
  */
 template <typename a_index_type, typename b_index_type>
 struct DiagonalSearchResult {
+  DiagonalSearchResult() : ai(0), bi(0) {}
   a_index_type ai;
   b_index_type bi;
 };


### PR DESCRIPTION
Fix the following ``-Wmaybe-uninitialized`` warnings by gcc:

```
In file included from .../kokkos-kernels/sparse/impl/KokkosSparse_spmv_spec.hpp:14,
                 from .../kokkos-kernels/sparse/src/KokkosSparse_spmv.hpp:13,
                 from .../kokkos-kernels/perf_test/sparse/KokkosSparse_kk_spmv_merge.cpp:23:
.../kokkos-kernels/sparse/impl/KokkosSparse_spmv_impl.hpp: In member function ‘void KokkosSparse::Impl::SpmvMvMergeHierarchical<AMatrix, XVector, YVector>::Functor<CONJ>::operator()(const team_member&) const [with bool CONJ = false; AMatrix = KokkosSparse::CrsMatrix<double, int, Kokkos::OpenMP, void, int>; XVector = Kokkos::View<double**, Kokkos::LayoutLeft, Kokkos::HostSpace>; YVector = Kokkos::View<double**, Kokkos::LayoutLeft, Kokkos::HostSpace>]’:
.../kokkos-kernels/sparse/impl/KokkosSparse_spmv_impl.hpp:1422:11: error: ‘ub.KokkosGraph::Impl::DiagonalSearchResult<long unsigned int, int>::bi’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
 1422 |       DSR ub;
      |           ^~
.../kokkos-kernels/sparse/impl/KokkosSparse_spmv_impl.hpp:1440:26: error: ‘ub.KokkosGraph::Impl::DiagonalSearchResult<long unsigned int, int>::ai’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
 1440 |       const ordinal_type teamRowEnd   = ub.ai;  // >= the row than the last nnz is in
      |                          ^~~~~~~~~~
.../kokkos-kernels/sparse/impl/KokkosSparse_spmv_impl.hpp:1421:11: error: ‘lb.KokkosGraph::Impl::DiagonalSearchResult<long unsigned int, int>::bi’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
 1421 |       DSR lb;
      |           ^~
.../kokkos-kernels/sparse/impl/KokkosSparse_spmv_impl.hpp:1478:61: error: ‘lb.KokkosGraph::Impl::DiagonalSearchResult<long unsigned int, int>::ai’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
 1478 |       const ordinal_type threadRowBegin = threadChunk.lb.ai + teamRowBegin;
      |                                           ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
```