### PR TITLE
BLAS ETI/TPL refactor: core changes

### DIFF
--- a/blas/CMakeLists.txt
+++ b/blas/CMakeLists.txt
@@ -53,6 +53,13 @@ endif()
 #Generate @X@ variables in the template X.hpp.in and X.cpp.in
 #files containing the list of all needed macros
 
+macro(gen_blas_eti_new FUNC_NAME SUBDIR)
+  kokkoskernels_generate_eti(${FUNC_NAME} ${SUBDIR}
+    COMPONENTS  blas
+    HEADER_LIST ETI_HEADERS
+    SOURCE_LIST SOURCES
+    TYPE_LISTS  FLOATS LAYOUTS EXEC_SPACES)
+endmacro()
 macro(gen_blas_eti FUNC_NAME SUBDIR)
   kokkoskernels_generate_eti(${FUNC_NAME} ${SUBDIR}
     COMPONENTS  blas
@@ -67,8 +74,8 @@ gen_blas_eti(Blas1_scal           scal)
 gen_blas_eti(Blas1_scal_mv        scal)
 gen_blas_eti(Blas1_dot            dot)
 gen_blas_eti(Blas1_dot_mv         dot)
-gen_blas_eti(Blas1_axpby          axpby)
-gen_blas_eti(Blas1_axpby_mv       axpby)
+gen_blas_eti_new(Blas1_axpby          axpby)
+gen_blas_eti_new(Blas1_axpby_mv       axpby)
 gen_blas_eti(Blas1_update         update)
 gen_blas_eti(Blas1_update_mv      update)
 gen_blas_eti(Blas1_sum            sum)

--- a/blas/impl/KokkosBlas1_axpby_spec.hpp
+++ b/blas/impl/KokkosBlas1_axpby_spec.hpp
@@ -29,29 +29,20 @@ struct axpby_eti_spec_avail {
 // We may spread out definitions (see _INST macro below) across one or
 // more .cpp files.
 //
-#define KOKKOSBLAS1_AXPBY_ETI_SPEC_AVAIL(SCALAR, LAYOUT, EXEC_SPACE, MEM_SPACE)                                       \
-  template <>                                                                                                         \
-  struct axpby_eti_spec_avail<                                                                                        \
-      EXEC_SPACE, SCALAR,                                                                                             \
-      Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                                      \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                         \
-      SCALAR,                                                                                                         \
-      Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-      1> {                                                                                                            \
-    enum : bool { value = true };                                                                                     \
-  };                                                                                                                  \
-  template <>                                                                                                         \
-  struct axpby_eti_spec_avail<                                                                                        \
-      EXEC_SPACE,                                                                                                     \
-      Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                                      \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                         \
-      Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                                      \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                         \
-      Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                                      \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                         \
-      Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-      1> {                                                                                                            \
-    enum : bool { value = true };                                                                                     \
+#define KOKKOSBLAS1_AXPBY_ETI_SPEC_AVAIL(SCALAR, LAYOUT, EXEC_SPACE)                                                 \
+  template <>                                                                                                        \
+  struct axpby_eti_spec_avail<                                                                                       \
+      EXEC_SPACE, SCALAR, Kokkos::View<const SCALAR*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+      SCALAR, Kokkos::View<SCALAR*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, 1> {              \
+    enum : bool { value = true };                                                                                    \
+  };                                                                                                                 \
+  template <>                                                                                                        \
+  struct axpby_eti_spec_avail<                                                                                       \
+      EXEC_SPACE, Kokkos::View<const SCALAR*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,         \
+      Kokkos::View<const SCALAR*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                     \
+      Kokkos::View<const SCALAR*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                     \
+      Kokkos::View<SCALAR*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, 1> {                      \
+    enum : bool { value = true };                                                                                    \
   };
 
 //
@@ -61,29 +52,20 @@ struct axpby_eti_spec_avail {
 // We may spread out definitions (see _INST macro below) across one or
 // more .cpp files.
 //
-#define KOKKOSBLAS1_AXPBY_MV_ETI_SPEC_AVAIL(SCALAR, LAYOUT, EXEC_SPACE, MEM_SPACE)                                     \
-  template <>                                                                                                          \
-  struct axpby_eti_spec_avail<                                                                                         \
-      EXEC_SPACE, SCALAR,                                                                                              \
-      Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                                      \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                          \
-      SCALAR,                                                                                                          \
-      Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-      2> {                                                                                                             \
-    enum : bool { value = true };                                                                                      \
-  };                                                                                                                   \
-  template <>                                                                                                          \
-  struct axpby_eti_spec_avail<                                                                                         \
-      EXEC_SPACE,                                                                                                      \
-      Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                                       \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                          \
-      Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                                      \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                          \
-      Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                                       \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                          \
-      Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-      2> {                                                                                                             \
-    enum : bool { value = true };                                                                                      \
+#define KOKKOSBLAS1_AXPBY_MV_ETI_SPEC_AVAIL(SCALAR, LAYOUT, EXEC_SPACE)                                               \
+  template <>                                                                                                         \
+  struct axpby_eti_spec_avail<                                                                                        \
+      EXEC_SPACE, SCALAR, Kokkos::View<const SCALAR**, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+      SCALAR, Kokkos::View<SCALAR**, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, 2> {              \
+    enum : bool { value = true };                                                                                     \
+  };                                                                                                                  \
+  template <>                                                                                                         \
+  struct axpby_eti_spec_avail<                                                                                        \
+      EXEC_SPACE, Kokkos::View<const SCALAR*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,          \
+      Kokkos::View<const SCALAR**, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                     \
+      Kokkos::View<const SCALAR*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                      \
+      Kokkos::View<SCALAR**, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, 2> {                      \
+    enum : bool { value = true };                                                                                     \
   };
 
 // Include the actual specialization declarations
@@ -489,45 +471,27 @@ struct Axpby<execution_space, typename XV::non_const_value_type, XV, typename YV
 // one or more .cpp files.
 //
 
-#define KOKKOSBLAS1_AXPBY_ETI_SPEC_DECL(SCALAR, LAYOUT, EXEC_SPACE, MEM_SPACE)                                        \
-  extern template struct Axpby<                                                                                       \
-      EXEC_SPACE, SCALAR,                                                                                             \
-      Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                                      \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                         \
-      SCALAR,                                                                                                         \
-      Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-      1, false, true>;                                                                                                \
-  extern template struct Axpby<                                                                                       \
-      EXEC_SPACE,                                                                                                     \
-      Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                                      \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                         \
-      Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                                      \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                         \
-      Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                                      \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                         \
-      Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-      1, false, true>;
+#define KOKKOSBLAS1_AXPBY_ETI_SPEC_DECL(SCALAR, LAYOUT, EXEC_SPACE)                                                  \
+  extern template struct Axpby<                                                                                      \
+      EXEC_SPACE, SCALAR, Kokkos::View<const SCALAR*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+      SCALAR, Kokkos::View<SCALAR*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, 1, false, true>;  \
+  extern template struct Axpby<                                                                                      \
+      EXEC_SPACE, Kokkos::View<const SCALAR*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,         \
+      Kokkos::View<const SCALAR*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                     \
+      Kokkos::View<const SCALAR*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                     \
+      Kokkos::View<SCALAR*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, 1, false, true>;
 
 #include <generated_specializations_hpp/KokkosBlas1_axpby_eti_spec_decl.hpp>
 
-#define KOKKOSBLAS1_AXPBY_ETI_SPEC_INST(SCALAR, LAYOUT, EXEC_SPACE, MEM_SPACE)                                        \
-  template struct Axpby<                                                                                              \
-      EXEC_SPACE, SCALAR,                                                                                             \
-      Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                                      \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                         \
-      SCALAR,                                                                                                         \
-      Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-      1, false, true>;                                                                                                \
-  template struct Axpby<                                                                                              \
-      EXEC_SPACE,                                                                                                     \
-      Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                                      \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                         \
-      Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                                      \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                         \
-      Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                                      \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                         \
-      Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-      1, false, true>;
+#define KOKKOSBLAS1_AXPBY_ETI_SPEC_INST(SCALAR, LAYOUT, EXEC_SPACE)                                                  \
+  template struct Axpby<                                                                                             \
+      EXEC_SPACE, SCALAR, Kokkos::View<const SCALAR*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+      SCALAR, Kokkos::View<SCALAR*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, 1, false, true>;  \
+  template struct Axpby<                                                                                             \
+      EXEC_SPACE, Kokkos::View<const SCALAR*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,         \
+      Kokkos::View<const SCALAR*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                     \
+      Kokkos::View<const SCALAR*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                     \
+      Kokkos::View<SCALAR*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, 1, false, true>;
 
 //
 // Macro for declaration of full specialization of
@@ -537,45 +501,27 @@ struct Axpby<execution_space, typename XV::non_const_value_type, XV, typename YV
 // one or more .cpp files.
 //
 
-#define KOKKOSBLAS1_AXPBY_MV_ETI_SPEC_DECL(SCALAR, LAYOUT, EXEC_SPACE, MEM_SPACE)                                      \
-  extern template struct Axpby<                                                                                        \
-      EXEC_SPACE, SCALAR,                                                                                              \
-      Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                                      \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                          \
-      SCALAR,                                                                                                          \
-      Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-      2, false, true>;                                                                                                 \
-  extern template struct Axpby<                                                                                        \
-      EXEC_SPACE,                                                                                                      \
-      Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                                       \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                          \
-      Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                                      \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                          \
-      Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                                       \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                          \
-      Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-      2, false, true>;
+#define KOKKOSBLAS1_AXPBY_MV_ETI_SPEC_DECL(SCALAR, LAYOUT, EXEC_SPACE)                                                \
+  extern template struct Axpby<                                                                                       \
+      EXEC_SPACE, SCALAR, Kokkos::View<const SCALAR**, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+      SCALAR, Kokkos::View<SCALAR**, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, 2, false, true>;  \
+  extern template struct Axpby<                                                                                       \
+      EXEC_SPACE, Kokkos::View<const SCALAR*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,          \
+      Kokkos::View<const SCALAR**, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                     \
+      Kokkos::View<const SCALAR*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                      \
+      Kokkos::View<SCALAR**, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, 2, false, true>;
 
 #include <generated_specializations_hpp/KokkosBlas1_axpby_mv_eti_spec_decl.hpp>
 
-#define KOKKOSBLAS1_AXPBY_MV_ETI_SPEC_INST(SCALAR, LAYOUT, EXEC_SPACE, MEM_SPACE)                                      \
-  template struct Axpby<                                                                                               \
-      EXEC_SPACE, SCALAR,                                                                                              \
-      Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                                      \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                          \
-      SCALAR,                                                                                                          \
-      Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-      2, false, true>;                                                                                                 \
-  template struct Axpby<                                                                                               \
-      EXEC_SPACE,                                                                                                      \
-      Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                                       \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                          \
-      Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                                      \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                          \
-      Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                                       \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                          \
-      Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-      2, false, true>;
+#define KOKKOSBLAS1_AXPBY_MV_ETI_SPEC_INST(SCALAR, LAYOUT, EXEC_SPACE)                                                \
+  template struct Axpby<                                                                                              \
+      EXEC_SPACE, SCALAR, Kokkos::View<const SCALAR**, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+      SCALAR, Kokkos::View<SCALAR**, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, 2, false, true>;  \
+  template struct Axpby<                                                                                              \
+      EXEC_SPACE, Kokkos::View<const SCALAR*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,          \
+      Kokkos::View<const SCALAR**, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                     \
+      Kokkos::View<const SCALAR*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                      \
+      Kokkos::View<SCALAR**, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, 2, false, true>;
 
 #include <KokkosBlas1_axpby_tpl_spec_decl.hpp>
 

--- a/blas/impl/KokkosBlas1_axpby_unification.hpp
+++ b/blas/impl/KokkosBlas1_axpby_unification.hpp
@@ -62,7 +62,7 @@ UnifiedCoeff unifyAxpbyCoeff(const Coeff& coeff) {
     return coeff();
   } else if constexpr (isRank1View<Coeff>()) {
     // Directly convert to unified type
-    return coeff;
+    return KokkosKernels::Impl::unificationCast<UnifiedCoeff>(coeff);
   } else if constexpr (isRank1View<UnifiedCoeff>()) {
     // UnifiedCoeff is a rank-1 View but Coeff is rank-0.
     // Convert rank-0 Coeff to rank-1 UnifiedCoeff
@@ -105,7 +105,7 @@ UnifiedCoeff unifyAxpbyMvCoeff(const Coeff& coeff) {
         "unifyAxpbyCoeff: in this case Coeff needs to be a host accessible View");
     return coeff();
   } else {
-    return coeff;
+    return KokkosKernels::Impl::unificationCast<UnifiedCoeff>(coeff);
   }
 }
 

--- a/blas/src/KokkosBlas1_axpby.hpp
+++ b/blas/src/KokkosBlas1_axpby.hpp
@@ -108,14 +108,14 @@ void axpby(const execution_space& exec_space, const AV& a, const XMV& X, const B
   }
   // Get unified types (all preferring the layout of the InternalTypeX)
   using PreferredLayout = typename KokkosKernels::Impl::GetUnifiedLayout<XMV>::array_layout;
-  using InternalTypeX   = Kokkos::View<typename XMV::const_data_type, PreferredLayout, typename XMV::device_type,
+  using InternalTypeX   = Kokkos::View<typename XMV::const_data_type, PreferredLayout, execution_space,
                                      Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
   using InternalTypeY =
       Kokkos::View<typename YMV::non_const_data_type,
                    typename KokkosKernels::Impl::GetUnifiedLayoutPreferring<YMV, PreferredLayout>::array_layout,
-                   typename YMV::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
-  InternalTypeX internal_X = X;
-  InternalTypeY internal_Y = Y;
+                   execution_space, Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
+  InternalTypeX internal_X = KokkosKernels::Impl::unificationCast<InternalTypeX>(X);
+  InternalTypeY internal_Y = KokkosKernels::Impl::unificationCast<InternalTypeY>(Y);
   // Run the rank-1 or rank-2 cases, with the appropriate coefficient unification
   if constexpr ((int)XMV::rank == 1) {
     using InternalTypeA =

--- a/blas/tpls/KokkosBlas1_axpby_tpl_spec_avail.hpp
+++ b/blas/tpls/KokkosBlas1_axpby_tpl_spec_avail.hpp
@@ -20,44 +20,51 @@ namespace Impl {
 // Generic Host side BLAS (could be MKL or whatever)
 #ifdef KOKKOSKERNELS_ENABLE_TPL_BLAS
 
-#define KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_BLAS(SCALAR, LAYOUT, MEMSPACE)                                             \
-  template <class ExecSpace>                                                                                        \
-  struct axpby_tpl_spec_avail<                                                                                      \
-      ExecSpace, SCALAR,                                                                                            \
-      Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>,                                      \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                       \
-      SCALAR,                                                                                                       \
-      Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-      1> {                                                                                                          \
-    enum : bool { value = true };                                                                                   \
+#define KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_BLAS(EXEC_SPACE, SCALAR, LAYOUT)                                            \
+  template <>                                                                                                        \
+  struct axpby_tpl_spec_avail<                                                                                       \
+      EXEC_SPACE, SCALAR, Kokkos::View<const SCALAR*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+      SCALAR, Kokkos::View<SCALAR*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, 1> {              \
+    enum : bool { value = true };                                                                                    \
   };
 
-KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_BLAS(double, Kokkos::LayoutLeft, Kokkos::HostSpace)
-KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_BLAS(float, Kokkos::LayoutLeft, Kokkos::HostSpace)
-KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_BLAS(Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::HostSpace)
-KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_BLAS(Kokkos::complex<float>, Kokkos::LayoutLeft, Kokkos::HostSpace)
+#ifdef KOKKOS_ENABLE_SERIAL
+KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_BLAS(Kokkos::Serial, double, Kokkos::LayoutLeft)
+KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_BLAS(Kokkos::Serial, float, Kokkos::LayoutLeft)
+KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_BLAS(Kokkos::Serial, Kokkos::complex<double>, Kokkos::LayoutLeft)
+KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_BLAS(Kokkos::Serial, Kokkos::complex<float>, Kokkos::LayoutLeft)
+#endif
+#ifdef KOKKOS_ENABLE_OPENMP
+KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_BLAS(Kokkos::OpenMP, double, Kokkos::LayoutLeft)
+KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_BLAS(Kokkos::OpenMP, float, Kokkos::LayoutLeft)
+KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_BLAS(Kokkos::OpenMP, Kokkos::complex<double>, Kokkos::LayoutLeft)
+KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_BLAS(Kokkos::OpenMP, Kokkos::complex<float>, Kokkos::LayoutLeft)
+#endif
+#ifdef KOKKOS_ENABLE_THREADS
+KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_BLAS(Kokkos::Threads, double, Kokkos::LayoutLeft)
+KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_BLAS(Kokkos::Threads, float, Kokkos::LayoutLeft)
+KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_BLAS(Kokkos::Threads, Kokkos::complex<double>, Kokkos::LayoutLeft)
+KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_BLAS(Kokkos::Threads, Kokkos::complex<float>, Kokkos::LayoutLeft)
+#endif
 
 #endif
 
 // cuBLAS
 #ifdef KOKKOSKERNELS_ENABLE_TPL_CUBLAS
 
-#define KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_CUBLAS(SCALAR, LAYOUT, MEMSPACE)                                           \
-  template <class ExecSpace>                                                                                        \
-  struct axpby_tpl_spec_avail<                                                                                      \
-      ExecSpace, SCALAR,                                                                                            \
-      Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>,                                      \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                       \
-      SCALAR,                                                                                                       \
-      Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-      1> {                                                                                                          \
-    enum : bool { value = true };                                                                                   \
+#define KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_CUBLAS(SCALAR, LAYOUT)                                            \
+  template <>                                                                                              \
+  struct axpby_tpl_spec_avail<                                                                             \
+      Kokkos::Cuda, SCALAR,                                                                                \
+      Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, SCALAR, \
+      Kokkos::View<SCALAR*, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, 1> {          \
+    enum : bool { value = true };                                                                          \
   };
 
-KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_CUBLAS(double, Kokkos::LayoutLeft, Kokkos::CudaSpace)
-KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_CUBLAS(float, Kokkos::LayoutLeft, Kokkos::CudaSpace)
-KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_CUBLAS(Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::CudaSpace)
-KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_CUBLAS(Kokkos::complex<float>, Kokkos::LayoutLeft, Kokkos::CudaSpace)
+KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_CUBLAS(double, Kokkos::LayoutLeft)
+KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_CUBLAS(float, Kokkos::LayoutLeft)
+KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_CUBLAS(Kokkos::complex<double>, Kokkos::LayoutLeft)
+KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_CUBLAS(Kokkos::complex<float>, Kokkos::LayoutLeft)
 
 #endif
 }  // namespace Impl

--- a/blas/tpls/KokkosBlas1_axpby_tpl_spec_avail.hpp
+++ b/blas/tpls/KokkosBlas1_axpby_tpl_spec_avail.hpp
@@ -20,51 +20,39 @@ namespace Impl {
 // Generic Host side BLAS (could be MKL or whatever)
 #ifdef KOKKOSKERNELS_ENABLE_TPL_BLAS
 
-#define KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_BLAS(EXEC_SPACE, SCALAR, LAYOUT)                                            \
-  template <>                                                                                                        \
-  struct axpby_tpl_spec_avail<                                                                                       \
-      EXEC_SPACE, SCALAR, Kokkos::View<const SCALAR*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-      SCALAR, Kokkos::View<SCALAR*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, 1> {              \
-    enum : bool { value = true };                                                                                    \
+#define KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_BLAS(SCALAR)                                                               \
+  template <typename ExecSpace>                                                                                     \
+    requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)                                   \
+  struct axpby_tpl_spec_avail<                                                                                      \
+      ExecSpace, SCALAR,                                                                                            \
+      Kokkos::View<const SCALAR*, Kokkos::LayoutLeft, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, SCALAR, \
+      Kokkos::View<SCALAR*, Kokkos::LayoutLeft, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, 1> {          \
+    enum : bool { value = true };                                                                                   \
   };
 
-#ifdef KOKKOS_ENABLE_SERIAL
-KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_BLAS(Kokkos::Serial, double, Kokkos::LayoutLeft)
-KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_BLAS(Kokkos::Serial, float, Kokkos::LayoutLeft)
-KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_BLAS(Kokkos::Serial, Kokkos::complex<double>, Kokkos::LayoutLeft)
-KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_BLAS(Kokkos::Serial, Kokkos::complex<float>, Kokkos::LayoutLeft)
-#endif
-#ifdef KOKKOS_ENABLE_OPENMP
-KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_BLAS(Kokkos::OpenMP, double, Kokkos::LayoutLeft)
-KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_BLAS(Kokkos::OpenMP, float, Kokkos::LayoutLeft)
-KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_BLAS(Kokkos::OpenMP, Kokkos::complex<double>, Kokkos::LayoutLeft)
-KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_BLAS(Kokkos::OpenMP, Kokkos::complex<float>, Kokkos::LayoutLeft)
-#endif
-#ifdef KOKKOS_ENABLE_THREADS
-KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_BLAS(Kokkos::Threads, double, Kokkos::LayoutLeft)
-KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_BLAS(Kokkos::Threads, float, Kokkos::LayoutLeft)
-KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_BLAS(Kokkos::Threads, Kokkos::complex<double>, Kokkos::LayoutLeft)
-KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_BLAS(Kokkos::Threads, Kokkos::complex<float>, Kokkos::LayoutLeft)
-#endif
+KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_BLAS(double)
+KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_BLAS(float)
+KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_BLAS(Kokkos::complex<double>)
+KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_BLAS(Kokkos::complex<float>)
 
 #endif
 
 // cuBLAS
 #ifdef KOKKOSKERNELS_ENABLE_TPL_CUBLAS
 
-#define KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_CUBLAS(SCALAR, LAYOUT)                                            \
-  template <>                                                                                              \
-  struct axpby_tpl_spec_avail<                                                                             \
-      Kokkos::Cuda, SCALAR,                                                                                \
-      Kokkos::View<const SCALAR*, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, SCALAR, \
-      Kokkos::View<SCALAR*, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, 1> {          \
-    enum : bool { value = true };                                                                          \
+#define KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_CUBLAS(SCALAR)                                                                \
+  template <>                                                                                                          \
+  struct axpby_tpl_spec_avail<                                                                                         \
+      Kokkos::Cuda, SCALAR,                                                                                            \
+      Kokkos::View<const SCALAR*, Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, SCALAR, \
+      Kokkos::View<SCALAR*, Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, 1> {          \
+    enum : bool { value = true };                                                                                      \
   };
 
-KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_CUBLAS(double, Kokkos::LayoutLeft)
-KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_CUBLAS(float, Kokkos::LayoutLeft)
-KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_CUBLAS(Kokkos::complex<double>, Kokkos::LayoutLeft)
-KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_CUBLAS(Kokkos::complex<float>, Kokkos::LayoutLeft)
+KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_CUBLAS(double)
+KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_CUBLAS(float)
+KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_CUBLAS(Kokkos::complex<double>)
+KOKKOSBLAS1_AXPBY_TPL_SPEC_AVAIL_CUBLAS(Kokkos::complex<float>)
 
 #endif
 }  // namespace Impl

--- a/blas/tpls/KokkosBlas1_axpby_tpl_spec_decl.hpp
+++ b/blas/tpls/KokkosBlas1_axpby_tpl_spec_decl.hpp
@@ -26,145 +26,142 @@ inline void axpby_print_specialization() {
 namespace KokkosBlas {
 namespace Impl {
 
-#define KOKKOSBLAS1_DAXPBY_BLAS(LAYOUT, MEMSPACE, ETI_SPEC_AVAIL)                                                      \
-  template <class ExecSpace>                                                                                           \
+#define KOKKOSBLAS1_DAXPBY_BLAS(EXEC_SPACE, LAYOUT, ETI_SPEC_AVAIL)                                               \
+  template <>                                                                                                     \
+  struct Axpby<EXEC_SPACE, double,                                                                                \
+               Kokkos::View<const double*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, double, \
+               Kokkos::View<double*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, 1, true,      \
+               ETI_SPEC_AVAIL> {                                                                                  \
+    typedef double AV;                                                                                            \
+    typedef double BV;                                                                                            \
+    typedef Kokkos::View<const double*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> > XV;         \
+    typedef Kokkos::View<double*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> > YV;               \
+                                                                                                                  \
+    static void axpby(const EXEC_SPACE& space, const AV& alpha, const XV& X, const BV& beta, const YV& Y) {       \
+      Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_BLAS,double]");                                        \
+      if ((X.extent(0) < INT_MAX) && (beta == 1.0)) {                                                             \
+        axpby_print_specialization<AV, XV, BV, YV>();                                                             \
+        int N   = X.extent(0);                                                                                    \
+        int one = 1;                                                                                              \
+        HostBlas<double>::axpy(N, alpha, X.data(), one, Y.data(), one);                                           \
+      } else                                                                                                      \
+        Axpby<EXEC_SPACE, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(space, alpha, X, beta, Y);      \
+      Kokkos::Profiling::popRegion();                                                                             \
+    }                                                                                                             \
+  };
+
+#define KOKKOSBLAS1_SAXPBY_BLAS(EXEC_SPACE, LAYOUT, ETI_SPEC_AVAIL)                                             \
+  template <>                                                                                                   \
+  struct Axpby<EXEC_SPACE, float,                                                                               \
+               Kokkos::View<const float*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, float, \
+               Kokkos::View<float*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, 1, true,     \
+               ETI_SPEC_AVAIL> {                                                                                \
+    typedef float AV;                                                                                           \
+    typedef float BV;                                                                                           \
+    typedef Kokkos::View<const float*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> > XV;        \
+    typedef Kokkos::View<float*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> > YV;              \
+                                                                                                                \
+    static void axpby(const EXEC_SPACE& space, const AV& alpha, const XV& X, const BV& beta, const YV& Y) {     \
+      Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_BLAS,float]");                                       \
+      if ((X.extent(0) < INT_MAX) && (beta == 1.0f)) {                                                          \
+        axpby_print_specialization<AV, XV, BV, YV>();                                                           \
+        int N   = X.extent(0);                                                                                  \
+        int one = 1;                                                                                            \
+        HostBlas<float>::axpy(N, alpha, X.data(), one, Y.data(), one);                                          \
+      } else                                                                                                    \
+        Axpby<EXEC_SPACE, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(space, alpha, X, beta, Y);    \
+      Kokkos::Profiling::popRegion();                                                                           \
+    }                                                                                                           \
+  };
+
+#define KOKKOSBLAS1_ZAXPBY_BLAS(EXEC_SPACE, LAYOUT, ETI_SPEC_AVAIL)                                                    \
+  template <>                                                                                                          \
   struct Axpby<                                                                                                        \
-      ExecSpace, double,                                                                                               \
-      Kokkos::View<const double*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>,                                         \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                          \
-      double,                                                                                                          \
-      Kokkos::View<double*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, 1, \
-      true, ETI_SPEC_AVAIL> {                                                                                          \
-    typedef double AV;                                                                                                 \
-    typedef double BV;                                                                                                 \
-    typedef Kokkos::View<const double*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>,                                   \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >                                                     \
+      EXEC_SPACE, Kokkos::complex<double>,                                                                             \
+      Kokkos::View<const Kokkos::complex<double>*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,      \
+      Kokkos::complex<double>,                                                                                         \
+      Kokkos::View<Kokkos::complex<double>*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, 1, true,   \
+      ETI_SPEC_AVAIL> {                                                                                                \
+    typedef Kokkos::complex<double> AV;                                                                                \
+    typedef Kokkos::complex<double> BV;                                                                                \
+    typedef Kokkos::View<const Kokkos::complex<double>*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> > \
         XV;                                                                                                            \
-    typedef Kokkos::View<double*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>,                                         \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >                                                     \
-        YV;                                                                                                            \
+    typedef Kokkos::View<Kokkos::complex<double>*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> > YV;   \
                                                                                                                        \
-    static void axpby(const ExecSpace& space, const AV& alpha, const XV& X, const BV& beta, const YV& Y) {             \
-      Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_BLAS,double]");                                             \
-      if ((X.extent(0) < INT_MAX) && (beta == 1.0)) {                                                                  \
+    static void axpby(const EXEC_SPACE& space, const AV& alpha, const XV& X, const BV& beta, const YV& Y) {            \
+      Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_BLAS,complex<double>]");                                    \
+      if ((X.extent(0) < INT_MAX) && (beta == 1.0f)) {                                                                 \
         axpby_print_specialization<AV, XV, BV, YV>();                                                                  \
-        int N   = X.extent(0);                                                                                         \
-        int one = 1;                                                                                                   \
-        HostBlas<double>::axpy(N, alpha, X.data(), one, Y.data(), one);                                                \
+        int N                                = X.extent(0);                                                            \
+        int one                              = 1;                                                                      \
+        const std::complex<double> alpha_val = alpha;                                                                  \
+        HostBlas<std::complex<double> >::axpy(N, alpha_val, reinterpret_cast<const std::complex<double>*>(X.data()),   \
+                                              one, reinterpret_cast<std::complex<double>*>(Y.data()), one);            \
       } else                                                                                                           \
-        Axpby<ExecSpace, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(space, alpha, X, beta, Y);            \
+        Axpby<EXEC_SPACE, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(space, alpha, X, beta, Y);           \
       Kokkos::Profiling::popRegion();                                                                                  \
     }                                                                                                                  \
   };
 
-#define KOKKOSBLAS1_SAXPBY_BLAS(LAYOUT, MEMSPACE, ETI_SPEC_AVAIL)                                                     \
-  template <class ExecSpace>                                                                                          \
+#define KOKKOSBLAS1_CAXPBY_BLAS(EXEC_SPACE, LAYOUT, ETI_SPEC_AVAIL)                                                   \
+  template <>                                                                                                         \
   struct Axpby<                                                                                                       \
-      ExecSpace, float,                                                                                               \
-      Kokkos::View<const float*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>,                                         \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                         \
-      float,                                                                                                          \
-      Kokkos::View<float*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, 1, \
-      true, ETI_SPEC_AVAIL> {                                                                                         \
-    typedef float AV;                                                                                                 \
-    typedef float BV;                                                                                                 \
-    typedef Kokkos::View<const float*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>,                                   \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >                                                    \
+      EXEC_SPACE, Kokkos::complex<float>,                                                                             \
+      Kokkos::View<const Kokkos::complex<float>*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,      \
+      Kokkos::complex<float>,                                                                                         \
+      Kokkos::View<Kokkos::complex<float>*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, 1, true,   \
+      ETI_SPEC_AVAIL> {                                                                                               \
+    typedef Kokkos::complex<float> AV;                                                                                \
+    typedef Kokkos::complex<float> BV;                                                                                \
+    typedef Kokkos::View<const Kokkos::complex<float>*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> > \
         XV;                                                                                                           \
-    typedef Kokkos::View<float*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>,                                         \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >                                                    \
-        YV;                                                                                                           \
+    typedef Kokkos::View<Kokkos::complex<float>*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> > YV;   \
                                                                                                                       \
-    static void axpby(const ExecSpace& space, const AV& alpha, const XV& X, const BV& beta, const YV& Y) {            \
-      Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_BLAS,float]");                                             \
+    static void axpby(const EXEC_SPACE& space, const AV& alpha, const XV& X, const BV& beta, const YV& Y) {           \
+      Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_BLAS,complex<float>]");                                    \
       if ((X.extent(0) < INT_MAX) && (beta == 1.0f)) {                                                                \
         axpby_print_specialization<AV, XV, BV, YV>();                                                                 \
-        int N   = X.extent(0);                                                                                        \
-        int one = 1;                                                                                                  \
-        HostBlas<float>::axpy(N, alpha, X.data(), one, Y.data(), one);                                                \
+        int N                               = X.extent(0);                                                            \
+        int one                             = 1;                                                                      \
+        const std::complex<float> alpha_val = alpha;                                                                  \
+        HostBlas<std::complex<float> >::axpy(N, alpha_val, reinterpret_cast<const std::complex<float>*>(X.data()),    \
+                                             one, reinterpret_cast<std::complex<float>*>(Y.data()), one);             \
       } else                                                                                                          \
-        Axpby<ExecSpace, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(space, alpha, X, beta, Y);           \
+        Axpby<EXEC_SPACE, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(space, alpha, X, beta, Y);          \
       Kokkos::Profiling::popRegion();                                                                                 \
     }                                                                                                                 \
   };
 
-#define KOKKOSBLAS1_ZAXPBY_BLAS(LAYOUT, MEMSPACE, ETI_SPEC_AVAIL)                                                    \
-  template <class ExecSpace>                                                                                         \
-  struct Axpby<ExecSpace, Kokkos::complex<double>,                                                                   \
-               Kokkos::View<const Kokkos::complex<double>*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>,             \
-                            Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                               \
-               Kokkos::complex<double>,                                                                              \
-               Kokkos::View<Kokkos::complex<double>*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>,                   \
-                            Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                               \
-               1, true, ETI_SPEC_AVAIL> {                                                                            \
-    typedef Kokkos::complex<double> AV;                                                                              \
-    typedef Kokkos::complex<double> BV;                                                                              \
-    typedef Kokkos::View<const Kokkos::complex<double>*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>,                \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >                                                   \
-        XV;                                                                                                          \
-    typedef Kokkos::View<Kokkos::complex<double>*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>,                      \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >                                                   \
-        YV;                                                                                                          \
-                                                                                                                     \
-    static void axpby(const ExecSpace& space, const AV& alpha, const XV& X, const BV& beta, const YV& Y) {           \
-      Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_BLAS,complex<double>]");                                  \
-      if ((X.extent(0) < INT_MAX) && (beta == 1.0f)) {                                                               \
-        axpby_print_specialization<AV, XV, BV, YV>();                                                                \
-        int N                                = X.extent(0);                                                          \
-        int one                              = 1;                                                                    \
-        const std::complex<double> alpha_val = alpha;                                                                \
-        HostBlas<std::complex<double> >::axpy(N, alpha_val, reinterpret_cast<const std::complex<double>*>(X.data()), \
-                                              one, reinterpret_cast<std::complex<double>*>(Y.data()), one);          \
-      } else                                                                                                         \
-        Axpby<ExecSpace, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(space, alpha, X, beta, Y);          \
-      Kokkos::Profiling::popRegion();                                                                                \
-    }                                                                                                                \
-  };
-
-#define KOKKOSBLAS1_CAXPBY_BLAS(LAYOUT, MEMSPACE, ETI_SPEC_AVAIL)                                                  \
-  template <class ExecSpace>                                                                                       \
-  struct Axpby<ExecSpace, Kokkos::complex<float>,                                                                  \
-               Kokkos::View<const Kokkos::complex<float>*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>,            \
-                            Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                             \
-               Kokkos::complex<float>,                                                                             \
-               Kokkos::View<Kokkos::complex<float>*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>,                  \
-                            Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                             \
-               1, true, ETI_SPEC_AVAIL> {                                                                          \
-    typedef Kokkos::complex<float> AV;                                                                             \
-    typedef Kokkos::complex<float> BV;                                                                             \
-    typedef Kokkos::View<const Kokkos::complex<float>*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>,               \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >                                                 \
-        XV;                                                                                                        \
-    typedef Kokkos::View<Kokkos::complex<float>*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>,                     \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >                                                 \
-        YV;                                                                                                        \
-                                                                                                                   \
-    static void axpby(const ExecSpace& space, const AV& alpha, const XV& X, const BV& beta, const YV& Y) {         \
-      Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_BLAS,complex<float>]");                                 \
-      if ((X.extent(0) < INT_MAX) && (beta == 1.0f)) {                                                             \
-        axpby_print_specialization<AV, XV, BV, YV>();                                                              \
-        int N                               = X.extent(0);                                                         \
-        int one                             = 1;                                                                   \
-        const std::complex<float> alpha_val = alpha;                                                               \
-        HostBlas<std::complex<float> >::axpy(N, alpha_val, reinterpret_cast<const std::complex<float>*>(X.data()), \
-                                             one, reinterpret_cast<std::complex<float>*>(Y.data()), one);          \
-      } else                                                                                                       \
-        Axpby<ExecSpace, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(space, alpha, X, beta, Y);        \
-      Kokkos::Profiling::popRegion();                                                                              \
-    }                                                                                                              \
-  };
-
-KOKKOSBLAS1_DAXPBY_BLAS(Kokkos::LayoutLeft, Kokkos::HostSpace, true)
-KOKKOSBLAS1_DAXPBY_BLAS(Kokkos::LayoutLeft, Kokkos::HostSpace, false)
-
-KOKKOSBLAS1_SAXPBY_BLAS(Kokkos::LayoutLeft, Kokkos::HostSpace, true)
-KOKKOSBLAS1_SAXPBY_BLAS(Kokkos::LayoutLeft, Kokkos::HostSpace, false)
-
-KOKKOSBLAS1_ZAXPBY_BLAS(Kokkos::LayoutLeft, Kokkos::HostSpace, true)
-KOKKOSBLAS1_ZAXPBY_BLAS(Kokkos::LayoutLeft, Kokkos::HostSpace, false)
-
-KOKKOSBLAS1_CAXPBY_BLAS(Kokkos::LayoutLeft, Kokkos::HostSpace, true)
-KOKKOSBLAS1_CAXPBY_BLAS(Kokkos::LayoutLeft, Kokkos::HostSpace, false)
+#ifdef KOKKOS_ENABLE_SERIAL
+KOKKOSBLAS1_DAXPBY_BLAS(Kokkos::Serial, Kokkos::LayoutLeft, true)
+KOKKOSBLAS1_DAXPBY_BLAS(Kokkos::Serial, Kokkos::LayoutLeft, false)
+KOKKOSBLAS1_SAXPBY_BLAS(Kokkos::Serial, Kokkos::LayoutLeft, true)
+KOKKOSBLAS1_SAXPBY_BLAS(Kokkos::Serial, Kokkos::LayoutLeft, false)
+KOKKOSBLAS1_ZAXPBY_BLAS(Kokkos::Serial, Kokkos::LayoutLeft, true)
+KOKKOSBLAS1_ZAXPBY_BLAS(Kokkos::Serial, Kokkos::LayoutLeft, false)
+KOKKOSBLAS1_CAXPBY_BLAS(Kokkos::Serial, Kokkos::LayoutLeft, true)
+KOKKOSBLAS1_CAXPBY_BLAS(Kokkos::Serial, Kokkos::LayoutLeft, false)
+#endif
+#ifdef KOKKOS_ENABLE_OPENMP
+KOKKOSBLAS1_DAXPBY_BLAS(Kokkos::OpenMP, Kokkos::LayoutLeft, true)
+KOKKOSBLAS1_DAXPBY_BLAS(Kokkos::OpenMP, Kokkos::LayoutLeft, false)
+KOKKOSBLAS1_SAXPBY_BLAS(Kokkos::OpenMP, Kokkos::LayoutLeft, true)
+KOKKOSBLAS1_SAXPBY_BLAS(Kokkos::OpenMP, Kokkos::LayoutLeft, false)
+KOKKOSBLAS1_ZAXPBY_BLAS(Kokkos::OpenMP, Kokkos::LayoutLeft, true)
+KOKKOSBLAS1_ZAXPBY_BLAS(Kokkos::OpenMP, Kokkos::LayoutLeft, false)
+KOKKOSBLAS1_CAXPBY_BLAS(Kokkos::OpenMP, Kokkos::LayoutLeft, true)
+KOKKOSBLAS1_CAXPBY_BLAS(Kokkos::OpenMP, Kokkos::LayoutLeft, false)
+#endif
+#ifdef KOKKOS_ENABLE_THREADS
+KOKKOSBLAS1_DAXPBY_BLAS(Kokkos::Threads, Kokkos::LayoutLeft, true)
+KOKKOSBLAS1_DAXPBY_BLAS(Kokkos::Threads, Kokkos::LayoutLeft, false)
+KOKKOSBLAS1_SAXPBY_BLAS(Kokkos::Threads, Kokkos::LayoutLeft, true)
+KOKKOSBLAS1_SAXPBY_BLAS(Kokkos::Threads, Kokkos::LayoutLeft, false)
+KOKKOSBLAS1_ZAXPBY_BLAS(Kokkos::Threads, Kokkos::LayoutLeft, true)
+KOKKOSBLAS1_ZAXPBY_BLAS(Kokkos::Threads, Kokkos::LayoutLeft, false)
+KOKKOSBLAS1_CAXPBY_BLAS(Kokkos::Threads, Kokkos::LayoutLeft, true)
+KOKKOSBLAS1_CAXPBY_BLAS(Kokkos::Threads, Kokkos::LayoutLeft, false)
+#endif
 
 #undef KOKKOSBLAS1_DAXPBY_BLAS
 #undef KOKKOSBLAS1_SAXPBY_BLAS
@@ -182,63 +179,117 @@ KOKKOSBLAS1_CAXPBY_BLAS(Kokkos::LayoutLeft, Kokkos::HostSpace, false)
 namespace KokkosBlas {
 namespace Impl {
 
-#define KOKKOSBLAS1_DAXPBY_CUBLAS(LAYOUT, MEMSPACE, ETI_SPEC_AVAIL)                                                    \
-  template <class ExecSpace>                                                                                           \
+#define KOKKOSBLAS1_DAXPBY_CUBLAS(LAYOUT, ETI_SPEC_AVAIL)                                                           \
+  template <>                                                                                                       \
+  struct Axpby<Kokkos::Cuda, double,                                                                                \
+               Kokkos::View<const double*, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, double, \
+               Kokkos::View<double*, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, 1, true,      \
+               ETI_SPEC_AVAIL> {                                                                                    \
+    typedef double AV;                                                                                              \
+    typedef double BV;                                                                                              \
+    typedef Kokkos::View<const double*, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> > XV;         \
+    typedef Kokkos::View<double*, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> > YV;               \
+    typedef typename XV::size_type size_type;                                                                       \
+                                                                                                                    \
+    static void axpby(const Kokkos::Cuda& space, const AV& alpha, const XV& X, const BV& beta, const YV& Y) {       \
+      Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_CUBLAS,double]");                                        \
+      const size_type numElems = X.extent(0);                                                                       \
+      if ((numElems < static_cast<size_type>(INT_MAX)) && (beta == 1.0)) {                                          \
+        axpby_print_specialization<AV, XV, BV, YV>();                                                               \
+        const int N                            = static_cast<int>(numElems);                                        \
+        constexpr int one                      = 1;                                                                 \
+        KokkosBlas::Impl::CudaBlasSingleton& s = KokkosBlas::Impl::CudaBlasSingleton::singleton();                  \
+        KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasSetStream(s.handle, space.cuda_stream()));                           \
+        KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasDaxpy(s.handle, N, &alpha, X.data(), one, Y.data(), one));           \
+        KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasSetStream(s.handle, NULL));                                          \
+      } else                                                                                                        \
+        Axpby<Kokkos::Cuda, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(space, alpha, X, beta, Y);      \
+      Kokkos::Profiling::popRegion();                                                                               \
+    }                                                                                                               \
+  };
+
+#define KOKKOSBLAS1_SAXPBY_CUBLAS(LAYOUT, ETI_SPEC_AVAIL)                                                         \
+  template <>                                                                                                     \
+  struct Axpby<Kokkos::Cuda, float,                                                                               \
+               Kokkos::View<const float*, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, float, \
+               Kokkos::View<float*, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, 1, true,     \
+               ETI_SPEC_AVAIL> {                                                                                  \
+    typedef float AV;                                                                                             \
+    typedef float BV;                                                                                             \
+    typedef Kokkos::View<const float*, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> > XV;        \
+    typedef Kokkos::View<float*, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> > YV;              \
+    typedef typename XV::size_type size_type;                                                                     \
+                                                                                                                  \
+    static void axpby(const Kokkos::Cuda& space, const AV& alpha, const XV& X, const BV& beta, const YV& Y) {     \
+      Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_CUBLAS,float]");                                       \
+      const size_type numElems = X.extent(0);                                                                     \
+      if ((numElems < static_cast<size_type>(INT_MAX)) && (beta == 1.0f)) {                                       \
+        axpby_print_specialization<AV, XV, BV, YV>();                                                             \
+        const int N                            = static_cast<int>(numElems);                                      \
+        constexpr int one                      = 1;                                                               \
+        KokkosBlas::Impl::CudaBlasSingleton& s = KokkosBlas::Impl::CudaBlasSingleton::singleton();                \
+        KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasSetStream(s.handle, space.cuda_stream()));                         \
+        KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasSaxpy(s.handle, N, &alpha, X.data(), one, Y.data(), one));         \
+        KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasSetStream(s.handle, NULL));                                        \
+      } else                                                                                                      \
+        Axpby<Kokkos::Cuda, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(space, alpha, X, beta, Y);    \
+      Kokkos::Profiling::popRegion();                                                                             \
+    }                                                                                                             \
+  };
+
+#define KOKKOSBLAS1_ZAXPBY_CUBLAS(LAYOUT, ETI_SPEC_AVAIL)                                                              \
+  template <>                                                                                                          \
   struct Axpby<                                                                                                        \
-      ExecSpace, double,                                                                                               \
-      Kokkos::View<const double*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>,                                         \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                          \
-      double,                                                                                                          \
-      Kokkos::View<double*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, 1, \
-      true, ETI_SPEC_AVAIL> {                                                                                          \
-    typedef double AV;                                                                                                 \
-    typedef double BV;                                                                                                 \
-    typedef Kokkos::View<const double*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>,                                   \
+      Kokkos::Cuda, Kokkos::complex<double>,                                                                           \
+      Kokkos::View<const Kokkos::complex<double>*, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,    \
+      Kokkos::complex<double>,                                                                                         \
+      Kokkos::View<Kokkos::complex<double>*, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, 1, true, \
+      ETI_SPEC_AVAIL> {                                                                                                \
+    typedef Kokkos::complex<double> AV;                                                                                \
+    typedef Kokkos::complex<double> BV;                                                                                \
+    typedef Kokkos::View<const Kokkos::complex<double>*, LAYOUT, Kokkos::Cuda,                                         \
                          Kokkos::MemoryTraits<Kokkos::Unmanaged> >                                                     \
         XV;                                                                                                            \
-    typedef Kokkos::View<double*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>,                                         \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >                                                     \
-        YV;                                                                                                            \
+    typedef Kokkos::View<Kokkos::complex<double>*, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> > YV; \
     typedef typename XV::size_type size_type;                                                                          \
                                                                                                                        \
-    static void axpby(const ExecSpace& space, const AV& alpha, const XV& X, const BV& beta, const YV& Y) {             \
-      Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_CUBLAS,double]");                                           \
+    static void axpby(const Kokkos::Cuda& space, const AV& alpha, const XV& X, const BV& beta, const YV& Y) {          \
+      Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_CUBLAS,complex<double>]");                                  \
       const size_type numElems = X.extent(0);                                                                          \
-      if ((numElems < static_cast<size_type>(INT_MAX)) && (beta == 1.0)) {                                             \
+      if ((numElems < static_cast<size_type>(INT_MAX)) && (beta == 1.0f)) {                                            \
         axpby_print_specialization<AV, XV, BV, YV>();                                                                  \
         const int N                            = static_cast<int>(numElems);                                           \
         constexpr int one                      = 1;                                                                    \
         KokkosBlas::Impl::CudaBlasSingleton& s = KokkosBlas::Impl::CudaBlasSingleton::singleton();                     \
         KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasSetStream(s.handle, space.cuda_stream()));                              \
-        KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasDaxpy(s.handle, N, &alpha, X.data(), one, Y.data(), one));              \
+        KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasZaxpy(s.handle, N, reinterpret_cast<const cuDoubleComplex*>(&alpha),    \
+                                                     reinterpret_cast<const cuDoubleComplex*>(X.data()), one,          \
+                                                     reinterpret_cast<cuDoubleComplex*>(Y.data()), one));              \
         KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasSetStream(s.handle, NULL));                                             \
       } else                                                                                                           \
-        Axpby<ExecSpace, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(space, alpha, X, beta, Y);            \
+        Axpby<Kokkos::Cuda, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(space, alpha, X, beta, Y);         \
       Kokkos::Profiling::popRegion();                                                                                  \
     }                                                                                                                  \
   };
 
-#define KOKKOSBLAS1_SAXPBY_CUBLAS(LAYOUT, MEMSPACE, ETI_SPEC_AVAIL)                                                   \
-  template <class ExecSpace>                                                                                          \
+#define KOKKOSBLAS1_CAXPBY_CUBLAS(LAYOUT, ETI_SPEC_AVAIL)                                                             \
+  template <>                                                                                                         \
   struct Axpby<                                                                                                       \
-      ExecSpace, float,                                                                                               \
-      Kokkos::View<const float*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>,                                         \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                         \
-      float,                                                                                                          \
-      Kokkos::View<float*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, 1, \
-      true, ETI_SPEC_AVAIL> {                                                                                         \
-    typedef float AV;                                                                                                 \
-    typedef float BV;                                                                                                 \
-    typedef Kokkos::View<const float*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>,                                   \
+      Kokkos::Cuda, Kokkos::complex<float>,                                                                           \
+      Kokkos::View<const Kokkos::complex<float>*, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,    \
+      Kokkos::complex<float>,                                                                                         \
+      Kokkos::View<Kokkos::complex<float>*, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, 1, true, \
+      ETI_SPEC_AVAIL> {                                                                                               \
+    typedef Kokkos::complex<float> AV;                                                                                \
+    typedef Kokkos::complex<float> BV;                                                                                \
+    typedef Kokkos::View<const Kokkos::complex<float>*, LAYOUT, Kokkos::Cuda,                                         \
                          Kokkos::MemoryTraits<Kokkos::Unmanaged> >                                                    \
         XV;                                                                                                           \
-    typedef Kokkos::View<float*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>,                                         \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >                                                    \
-        YV;                                                                                                           \
+    typedef Kokkos::View<Kokkos::complex<float>*, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> > YV; \
     typedef typename XV::size_type size_type;                                                                         \
                                                                                                                       \
-    static void axpby(const ExecSpace& space, const AV& alpha, const XV& X, const BV& beta, const YV& Y) {            \
-      Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_CUBLAS,float]");                                           \
+    static void axpby(const Kokkos::Cuda& space, const AV& alpha, const XV& X, const BV& beta, const YV& Y) {         \
+      Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_CUBLAS,complex<float>]");                                  \
       const size_type numElems = X.extent(0);                                                                         \
       if ((numElems < static_cast<size_type>(INT_MAX)) && (beta == 1.0f)) {                                           \
         axpby_print_specialization<AV, XV, BV, YV>();                                                                 \
@@ -246,101 +297,27 @@ namespace Impl {
         constexpr int one                      = 1;                                                                   \
         KokkosBlas::Impl::CudaBlasSingleton& s = KokkosBlas::Impl::CudaBlasSingleton::singleton();                    \
         KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasSetStream(s.handle, space.cuda_stream()));                             \
-        KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasSaxpy(s.handle, N, &alpha, X.data(), one, Y.data(), one));             \
+        KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasCaxpy(s.handle, N, reinterpret_cast<const cuComplex*>(&alpha),         \
+                                                     reinterpret_cast<const cuComplex*>(X.data()), one,               \
+                                                     reinterpret_cast<cuComplex*>(Y.data()), one));                   \
         KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasSetStream(s.handle, NULL));                                            \
       } else                                                                                                          \
-        Axpby<ExecSpace, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(space, alpha, X, beta, Y);           \
+        Axpby<Kokkos::Cuda, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(space, alpha, X, beta, Y);        \
       Kokkos::Profiling::popRegion();                                                                                 \
     }                                                                                                                 \
   };
 
-#define KOKKOSBLAS1_ZAXPBY_CUBLAS(LAYOUT, MEMSPACE, ETI_SPEC_AVAIL)                                                 \
-  template <class ExecSpace>                                                                                        \
-  struct Axpby<ExecSpace, Kokkos::complex<double>,                                                                  \
-               Kokkos::View<const Kokkos::complex<double>*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>,            \
-                            Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                              \
-               Kokkos::complex<double>,                                                                             \
-               Kokkos::View<Kokkos::complex<double>*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>,                  \
-                            Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                              \
-               1, true, ETI_SPEC_AVAIL> {                                                                           \
-    typedef Kokkos::complex<double> AV;                                                                             \
-    typedef Kokkos::complex<double> BV;                                                                             \
-    typedef Kokkos::View<const Kokkos::complex<double>*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>,               \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >                                                  \
-        XV;                                                                                                         \
-    typedef Kokkos::View<Kokkos::complex<double>*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>,                     \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >                                                  \
-        YV;                                                                                                         \
-    typedef typename XV::size_type size_type;                                                                       \
-                                                                                                                    \
-    static void axpby(const ExecSpace& space, const AV& alpha, const XV& X, const BV& beta, const YV& Y) {          \
-      Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_CUBLAS,complex<double>]");                               \
-      const size_type numElems = X.extent(0);                                                                       \
-      if ((numElems < static_cast<size_type>(INT_MAX)) && (beta == 1.0f)) {                                         \
-        axpby_print_specialization<AV, XV, BV, YV>();                                                               \
-        const int N                            = static_cast<int>(numElems);                                        \
-        constexpr int one                      = 1;                                                                 \
-        KokkosBlas::Impl::CudaBlasSingleton& s = KokkosBlas::Impl::CudaBlasSingleton::singleton();                  \
-        KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasSetStream(s.handle, space.cuda_stream()));                           \
-        KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasZaxpy(s.handle, N, reinterpret_cast<const cuDoubleComplex*>(&alpha), \
-                                                     reinterpret_cast<const cuDoubleComplex*>(X.data()), one,       \
-                                                     reinterpret_cast<cuDoubleComplex*>(Y.data()), one));           \
-        KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasSetStream(s.handle, NULL));                                          \
-      } else                                                                                                        \
-        Axpby<ExecSpace, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(space, alpha, X, beta, Y);         \
-      Kokkos::Profiling::popRegion();                                                                               \
-    }                                                                                                               \
-  };
+KOKKOSBLAS1_DAXPBY_CUBLAS(Kokkos::LayoutLeft, true)
+KOKKOSBLAS1_DAXPBY_CUBLAS(Kokkos::LayoutLeft, false)
 
-#define KOKKOSBLAS1_CAXPBY_CUBLAS(LAYOUT, MEMSPACE, ETI_SPEC_AVAIL)                                           \
-  template <class ExecSpace>                                                                                  \
-  struct Axpby<ExecSpace, Kokkos::complex<float>,                                                             \
-               Kokkos::View<const Kokkos::complex<float>*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>,       \
-                            Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                        \
-               Kokkos::complex<float>,                                                                        \
-               Kokkos::View<Kokkos::complex<float>*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>,             \
-                            Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                        \
-               1, true, ETI_SPEC_AVAIL> {                                                                     \
-    typedef Kokkos::complex<float> AV;                                                                        \
-    typedef Kokkos::complex<float> BV;                                                                        \
-    typedef Kokkos::View<const Kokkos::complex<float>*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>,          \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >                                            \
-        XV;                                                                                                   \
-    typedef Kokkos::View<Kokkos::complex<float>*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>,                \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >                                            \
-        YV;                                                                                                   \
-    typedef typename XV::size_type size_type;                                                                 \
-                                                                                                              \
-    static void axpby(const ExecSpace& space, const AV& alpha, const XV& X, const BV& beta, const YV& Y) {    \
-      Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_CUBLAS,complex<float>]");                          \
-      const size_type numElems = X.extent(0);                                                                 \
-      if ((numElems < static_cast<size_type>(INT_MAX)) && (beta == 1.0f)) {                                   \
-        axpby_print_specialization<AV, XV, BV, YV>();                                                         \
-        const int N                            = static_cast<int>(numElems);                                  \
-        constexpr int one                      = 1;                                                           \
-        KokkosBlas::Impl::CudaBlasSingleton& s = KokkosBlas::Impl::CudaBlasSingleton::singleton();            \
-        KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasSetStream(s.handle, space.cuda_stream()));                     \
-        KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasCaxpy(s.handle, N, reinterpret_cast<const cuComplex*>(&alpha), \
-                                                     reinterpret_cast<const cuComplex*>(X.data()), one,       \
-                                                     reinterpret_cast<cuComplex*>(Y.data()), one));           \
-        KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasSetStream(s.handle, NULL));                                    \
-      } else                                                                                                  \
-        Axpby<ExecSpace, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(space, alpha, X, beta, Y);   \
-      Kokkos::Profiling::popRegion();                                                                         \
-    }                                                                                                         \
-  };
+KOKKOSBLAS1_SAXPBY_CUBLAS(Kokkos::LayoutLeft, true)
+KOKKOSBLAS1_SAXPBY_CUBLAS(Kokkos::LayoutLeft, false)
 
-KOKKOSBLAS1_DAXPBY_CUBLAS(Kokkos::LayoutLeft, Kokkos::CudaSpace, true)
-KOKKOSBLAS1_DAXPBY_CUBLAS(Kokkos::LayoutLeft, Kokkos::CudaSpace, false)
+KOKKOSBLAS1_ZAXPBY_CUBLAS(Kokkos::LayoutLeft, true)
+KOKKOSBLAS1_ZAXPBY_CUBLAS(Kokkos::LayoutLeft, false)
 
-KOKKOSBLAS1_SAXPBY_CUBLAS(Kokkos::LayoutLeft, Kokkos::CudaSpace, true)
-KOKKOSBLAS1_SAXPBY_CUBLAS(Kokkos::LayoutLeft, Kokkos::CudaSpace, false)
-
-KOKKOSBLAS1_ZAXPBY_CUBLAS(Kokkos::LayoutLeft, Kokkos::CudaSpace, true)
-KOKKOSBLAS1_ZAXPBY_CUBLAS(Kokkos::LayoutLeft, Kokkos::CudaSpace, false)
-
-KOKKOSBLAS1_CAXPBY_CUBLAS(Kokkos::LayoutLeft, Kokkos::CudaSpace, true)
-KOKKOSBLAS1_CAXPBY_CUBLAS(Kokkos::LayoutLeft, Kokkos::CudaSpace, false)
+KOKKOSBLAS1_CAXPBY_CUBLAS(Kokkos::LayoutLeft, true)
+KOKKOSBLAS1_CAXPBY_CUBLAS(Kokkos::LayoutLeft, false)
 
 #undef KOKKOSBLAS1_DAXPBY_CUBLAS
 #undef KOKKOSBLAS1_SAXPBY_CUBLAS

--- a/blas/tpls/KokkosBlas1_axpby_tpl_spec_decl.hpp
+++ b/blas/tpls/KokkosBlas1_axpby_tpl_spec_decl.hpp
@@ -26,69 +26,76 @@ inline void axpby_print_specialization() {
 namespace KokkosBlas {
 namespace Impl {
 
-#define KOKKOSBLAS1_DAXPBY_BLAS(EXEC_SPACE, LAYOUT, ETI_SPEC_AVAIL)                                               \
-  template <>                                                                                                     \
-  struct Axpby<EXEC_SPACE, double,                                                                                \
-               Kokkos::View<const double*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, double, \
-               Kokkos::View<double*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, 1, true,      \
-               ETI_SPEC_AVAIL> {                                                                                  \
-    typedef double AV;                                                                                            \
-    typedef double BV;                                                                                            \
-    typedef Kokkos::View<const double*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> > XV;         \
-    typedef Kokkos::View<double*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> > YV;               \
-                                                                                                                  \
-    static void axpby(const EXEC_SPACE& space, const AV& alpha, const XV& X, const BV& beta, const YV& Y) {       \
-      Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_BLAS,double]");                                        \
-      if ((X.extent(0) < INT_MAX) && (beta == 1.0)) {                                                             \
-        axpby_print_specialization<AV, XV, BV, YV>();                                                             \
-        int N   = X.extent(0);                                                                                    \
-        int one = 1;                                                                                              \
-        HostBlas<double>::axpy(N, alpha, X.data(), one, Y.data(), one);                                           \
-      } else                                                                                                      \
-        Axpby<EXEC_SPACE, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(space, alpha, X, beta, Y);      \
-      Kokkos::Profiling::popRegion();                                                                             \
-    }                                                                                                             \
+#define KOKKOSBLAS1_DAXPBY_BLAS(ETI_SPEC_AVAIL)                                                                        \
+  template <typename ExecSpace>                                                                                        \
+    requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)                                      \
+  struct Axpby<ExecSpace, double,                                                                                      \
+               Kokkos::View<const double*, Kokkos::LayoutLeft, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,   \
+               double, Kokkos::View<double*, Kokkos::LayoutLeft, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+               1, true, ETI_SPEC_AVAIL> {                                                                              \
+    typedef double AV;                                                                                                 \
+    typedef double BV;                                                                                                 \
+    typedef Kokkos::View<const double*, Kokkos::LayoutLeft, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> > XV;   \
+    typedef Kokkos::View<double*, Kokkos::LayoutLeft, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> > YV;         \
+                                                                                                                       \
+    static void axpby(const ExecSpace& space, const AV& alpha, const XV& X, const BV& beta, const YV& Y) {             \
+      Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_BLAS,double]");                                             \
+      if ((X.extent(0) < INT_MAX) && (beta == 1.0)) {                                                                  \
+        axpby_print_specialization<AV, XV, BV, YV>();                                                                  \
+        int N   = X.extent(0);                                                                                         \
+        int one = 1;                                                                                                   \
+        HostBlas<double>::axpy(N, alpha, X.data(), one, Y.data(), one);                                                \
+      } else                                                                                                           \
+        Axpby<ExecSpace, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(space, alpha, X, beta, Y);            \
+      Kokkos::Profiling::popRegion();                                                                                  \
+    }                                                                                                                  \
   };
 
-#define KOKKOSBLAS1_SAXPBY_BLAS(EXEC_SPACE, LAYOUT, ETI_SPEC_AVAIL)                                             \
-  template <>                                                                                                   \
-  struct Axpby<EXEC_SPACE, float,                                                                               \
-               Kokkos::View<const float*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, float, \
-               Kokkos::View<float*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, 1, true,     \
-               ETI_SPEC_AVAIL> {                                                                                \
-    typedef float AV;                                                                                           \
-    typedef float BV;                                                                                           \
-    typedef Kokkos::View<const float*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> > XV;        \
-    typedef Kokkos::View<float*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> > YV;              \
-                                                                                                                \
-    static void axpby(const EXEC_SPACE& space, const AV& alpha, const XV& X, const BV& beta, const YV& Y) {     \
-      Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_BLAS,float]");                                       \
-      if ((X.extent(0) < INT_MAX) && (beta == 1.0f)) {                                                          \
-        axpby_print_specialization<AV, XV, BV, YV>();                                                           \
-        int N   = X.extent(0);                                                                                  \
-        int one = 1;                                                                                            \
-        HostBlas<float>::axpy(N, alpha, X.data(), one, Y.data(), one);                                          \
-      } else                                                                                                    \
-        Axpby<EXEC_SPACE, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(space, alpha, X, beta, Y);    \
-      Kokkos::Profiling::popRegion();                                                                           \
-    }                                                                                                           \
+#define KOKKOSBLAS1_SAXPBY_BLAS(ETI_SPEC_AVAIL)                                                                      \
+  template <typename ExecSpace>                                                                                      \
+    requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)                                    \
+  struct Axpby<ExecSpace, float,                                                                                     \
+               Kokkos::View<const float*, Kokkos::LayoutLeft, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,  \
+               float, Kokkos::View<float*, Kokkos::LayoutLeft, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+               1, true, ETI_SPEC_AVAIL> {                                                                            \
+    typedef float AV;                                                                                                \
+    typedef float BV;                                                                                                \
+    typedef Kokkos::View<const float*, Kokkos::LayoutLeft, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> > XV;  \
+    typedef Kokkos::View<float*, Kokkos::LayoutLeft, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> > YV;        \
+                                                                                                                     \
+    static void axpby(const ExecSpace& space, const AV& alpha, const XV& X, const BV& beta, const YV& Y) {           \
+      Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_BLAS,float]");                                            \
+      if ((X.extent(0) < INT_MAX) && (beta == 1.0f)) {                                                               \
+        axpby_print_specialization<AV, XV, BV, YV>();                                                                \
+        int N   = X.extent(0);                                                                                       \
+        int one = 1;                                                                                                 \
+        HostBlas<float>::axpy(N, alpha, X.data(), one, Y.data(), one);                                               \
+      } else                                                                                                         \
+        Axpby<ExecSpace, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(space, alpha, X, beta, Y);          \
+      Kokkos::Profiling::popRegion();                                                                                \
+    }                                                                                                                \
   };
 
-#define KOKKOSBLAS1_ZAXPBY_BLAS(EXEC_SPACE, LAYOUT, ETI_SPEC_AVAIL)                                                    \
-  template <>                                                                                                          \
+#define KOKKOSBLAS1_ZAXPBY_BLAS(ETI_SPEC_AVAIL)                                                                        \
+  template <typename ExecSpace>                                                                                        \
+    requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)                                      \
   struct Axpby<                                                                                                        \
-      EXEC_SPACE, Kokkos::complex<double>,                                                                             \
-      Kokkos::View<const Kokkos::complex<double>*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,      \
+      ExecSpace, Kokkos::complex<double>,                                                                              \
+      Kokkos::View<const Kokkos::complex<double>*, Kokkos::LayoutLeft, ExecSpace,                                      \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                          \
       Kokkos::complex<double>,                                                                                         \
-      Kokkos::View<Kokkos::complex<double>*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, 1, true,   \
-      ETI_SPEC_AVAIL> {                                                                                                \
+      Kokkos::View<Kokkos::complex<double>*, Kokkos::LayoutLeft, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+      1, true, ETI_SPEC_AVAIL> {                                                                                       \
     typedef Kokkos::complex<double> AV;                                                                                \
     typedef Kokkos::complex<double> BV;                                                                                \
-    typedef Kokkos::View<const Kokkos::complex<double>*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> > \
+    typedef Kokkos::View<const Kokkos::complex<double>*, Kokkos::LayoutLeft, ExecSpace,                                \
+                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >                                                     \
         XV;                                                                                                            \
-    typedef Kokkos::View<Kokkos::complex<double>*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> > YV;   \
+    typedef Kokkos::View<Kokkos::complex<double>*, Kokkos::LayoutLeft, ExecSpace,                                      \
+                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >                                                     \
+        YV;                                                                                                            \
                                                                                                                        \
-    static void axpby(const EXEC_SPACE& space, const AV& alpha, const XV& X, const BV& beta, const YV& Y) {            \
+    static void axpby(const ExecSpace& space, const AV& alpha, const XV& X, const BV& beta, const YV& Y) {             \
       Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_BLAS,complex<double>]");                                    \
       if ((X.extent(0) < INT_MAX) && (beta == 1.0f)) {                                                                 \
         axpby_print_specialization<AV, XV, BV, YV>();                                                                  \
@@ -98,26 +105,31 @@ namespace Impl {
         HostBlas<std::complex<double> >::axpy(N, alpha_val, reinterpret_cast<const std::complex<double>*>(X.data()),   \
                                               one, reinterpret_cast<std::complex<double>*>(Y.data()), one);            \
       } else                                                                                                           \
-        Axpby<EXEC_SPACE, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(space, alpha, X, beta, Y);           \
+        Axpby<ExecSpace, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(space, alpha, X, beta, Y);            \
       Kokkos::Profiling::popRegion();                                                                                  \
     }                                                                                                                  \
   };
 
-#define KOKKOSBLAS1_CAXPBY_BLAS(EXEC_SPACE, LAYOUT, ETI_SPEC_AVAIL)                                                   \
-  template <>                                                                                                         \
+#define KOKKOSBLAS1_CAXPBY_BLAS(ETI_SPEC_AVAIL)                                                                       \
+  template <typename ExecSpace>                                                                                       \
+    requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)                                     \
   struct Axpby<                                                                                                       \
-      EXEC_SPACE, Kokkos::complex<float>,                                                                             \
-      Kokkos::View<const Kokkos::complex<float>*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,      \
+      ExecSpace, Kokkos::complex<float>,                                                                              \
+      Kokkos::View<const Kokkos::complex<float>*, Kokkos::LayoutLeft, ExecSpace,                                      \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                         \
       Kokkos::complex<float>,                                                                                         \
-      Kokkos::View<Kokkos::complex<float>*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, 1, true,   \
-      ETI_SPEC_AVAIL> {                                                                                               \
+      Kokkos::View<Kokkos::complex<float>*, Kokkos::LayoutLeft, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+      1, true, ETI_SPEC_AVAIL> {                                                                                      \
     typedef Kokkos::complex<float> AV;                                                                                \
     typedef Kokkos::complex<float> BV;                                                                                \
-    typedef Kokkos::View<const Kokkos::complex<float>*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> > \
+    typedef Kokkos::View<const Kokkos::complex<float>*, Kokkos::LayoutLeft, ExecSpace,                                \
+                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >                                                    \
         XV;                                                                                                           \
-    typedef Kokkos::View<Kokkos::complex<float>*, LAYOUT, EXEC_SPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged> > YV;   \
+    typedef Kokkos::View<Kokkos::complex<float>*, Kokkos::LayoutLeft, ExecSpace,                                      \
+                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >                                                    \
+        YV;                                                                                                           \
                                                                                                                       \
-    static void axpby(const EXEC_SPACE& space, const AV& alpha, const XV& X, const BV& beta, const YV& Y) {           \
+    static void axpby(const ExecSpace& space, const AV& alpha, const XV& X, const BV& beta, const YV& Y) {            \
       Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_BLAS,complex<float>]");                                    \
       if ((X.extent(0) < INT_MAX) && (beta == 1.0f)) {                                                                \
         axpby_print_specialization<AV, XV, BV, YV>();                                                                 \
@@ -127,41 +139,19 @@ namespace Impl {
         HostBlas<std::complex<float> >::axpy(N, alpha_val, reinterpret_cast<const std::complex<float>*>(X.data()),    \
                                              one, reinterpret_cast<std::complex<float>*>(Y.data()), one);             \
       } else                                                                                                          \
-        Axpby<EXEC_SPACE, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(space, alpha, X, beta, Y);          \
+        Axpby<ExecSpace, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(space, alpha, X, beta, Y);           \
       Kokkos::Profiling::popRegion();                                                                                 \
     }                                                                                                                 \
   };
 
-#ifdef KOKKOS_ENABLE_SERIAL
-KOKKOSBLAS1_DAXPBY_BLAS(Kokkos::Serial, Kokkos::LayoutLeft, true)
-KOKKOSBLAS1_DAXPBY_BLAS(Kokkos::Serial, Kokkos::LayoutLeft, false)
-KOKKOSBLAS1_SAXPBY_BLAS(Kokkos::Serial, Kokkos::LayoutLeft, true)
-KOKKOSBLAS1_SAXPBY_BLAS(Kokkos::Serial, Kokkos::LayoutLeft, false)
-KOKKOSBLAS1_ZAXPBY_BLAS(Kokkos::Serial, Kokkos::LayoutLeft, true)
-KOKKOSBLAS1_ZAXPBY_BLAS(Kokkos::Serial, Kokkos::LayoutLeft, false)
-KOKKOSBLAS1_CAXPBY_BLAS(Kokkos::Serial, Kokkos::LayoutLeft, true)
-KOKKOSBLAS1_CAXPBY_BLAS(Kokkos::Serial, Kokkos::LayoutLeft, false)
-#endif
-#ifdef KOKKOS_ENABLE_OPENMP
-KOKKOSBLAS1_DAXPBY_BLAS(Kokkos::OpenMP, Kokkos::LayoutLeft, true)
-KOKKOSBLAS1_DAXPBY_BLAS(Kokkos::OpenMP, Kokkos::LayoutLeft, false)
-KOKKOSBLAS1_SAXPBY_BLAS(Kokkos::OpenMP, Kokkos::LayoutLeft, true)
-KOKKOSBLAS1_SAXPBY_BLAS(Kokkos::OpenMP, Kokkos::LayoutLeft, false)
-KOKKOSBLAS1_ZAXPBY_BLAS(Kokkos::OpenMP, Kokkos::LayoutLeft, true)
-KOKKOSBLAS1_ZAXPBY_BLAS(Kokkos::OpenMP, Kokkos::LayoutLeft, false)
-KOKKOSBLAS1_CAXPBY_BLAS(Kokkos::OpenMP, Kokkos::LayoutLeft, true)
-KOKKOSBLAS1_CAXPBY_BLAS(Kokkos::OpenMP, Kokkos::LayoutLeft, false)
-#endif
-#ifdef KOKKOS_ENABLE_THREADS
-KOKKOSBLAS1_DAXPBY_BLAS(Kokkos::Threads, Kokkos::LayoutLeft, true)
-KOKKOSBLAS1_DAXPBY_BLAS(Kokkos::Threads, Kokkos::LayoutLeft, false)
-KOKKOSBLAS1_SAXPBY_BLAS(Kokkos::Threads, Kokkos::LayoutLeft, true)
-KOKKOSBLAS1_SAXPBY_BLAS(Kokkos::Threads, Kokkos::LayoutLeft, false)
-KOKKOSBLAS1_ZAXPBY_BLAS(Kokkos::Threads, Kokkos::LayoutLeft, true)
-KOKKOSBLAS1_ZAXPBY_BLAS(Kokkos::Threads, Kokkos::LayoutLeft, false)
-KOKKOSBLAS1_CAXPBY_BLAS(Kokkos::Threads, Kokkos::LayoutLeft, true)
-KOKKOSBLAS1_CAXPBY_BLAS(Kokkos::Threads, Kokkos::LayoutLeft, false)
-#endif
+KOKKOSBLAS1_DAXPBY_BLAS(true)
+KOKKOSBLAS1_DAXPBY_BLAS(false)
+KOKKOSBLAS1_SAXPBY_BLAS(true)
+KOKKOSBLAS1_SAXPBY_BLAS(false)
+KOKKOSBLAS1_ZAXPBY_BLAS(true)
+KOKKOSBLAS1_ZAXPBY_BLAS(false)
+KOKKOSBLAS1_CAXPBY_BLAS(true)
+KOKKOSBLAS1_CAXPBY_BLAS(false)
 
 #undef KOKKOSBLAS1_DAXPBY_BLAS
 #undef KOKKOSBLAS1_SAXPBY_BLAS
@@ -179,92 +169,30 @@ KOKKOSBLAS1_CAXPBY_BLAS(Kokkos::Threads, Kokkos::LayoutLeft, false)
 namespace KokkosBlas {
 namespace Impl {
 
-#define KOKKOSBLAS1_DAXPBY_CUBLAS(LAYOUT, ETI_SPEC_AVAIL)                                                           \
-  template <>                                                                                                       \
-  struct Axpby<Kokkos::Cuda, double,                                                                                \
-               Kokkos::View<const double*, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, double, \
-               Kokkos::View<double*, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, 1, true,      \
-               ETI_SPEC_AVAIL> {                                                                                    \
-    typedef double AV;                                                                                              \
-    typedef double BV;                                                                                              \
-    typedef Kokkos::View<const double*, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> > XV;         \
-    typedef Kokkos::View<double*, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> > YV;               \
-    typedef typename XV::size_type size_type;                                                                       \
-                                                                                                                    \
-    static void axpby(const Kokkos::Cuda& space, const AV& alpha, const XV& X, const BV& beta, const YV& Y) {       \
-      Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_CUBLAS,double]");                                        \
-      const size_type numElems = X.extent(0);                                                                       \
-      if ((numElems < static_cast<size_type>(INT_MAX)) && (beta == 1.0)) {                                          \
-        axpby_print_specialization<AV, XV, BV, YV>();                                                               \
-        const int N                            = static_cast<int>(numElems);                                        \
-        constexpr int one                      = 1;                                                                 \
-        KokkosBlas::Impl::CudaBlasSingleton& s = KokkosBlas::Impl::CudaBlasSingleton::singleton();                  \
-        KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasSetStream(s.handle, space.cuda_stream()));                           \
-        KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasDaxpy(s.handle, N, &alpha, X.data(), one, Y.data(), one));           \
-        KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasSetStream(s.handle, NULL));                                          \
-      } else                                                                                                        \
-        Axpby<Kokkos::Cuda, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(space, alpha, X, beta, Y);      \
-      Kokkos::Profiling::popRegion();                                                                               \
-    }                                                                                                               \
-  };
-
-#define KOKKOSBLAS1_SAXPBY_CUBLAS(LAYOUT, ETI_SPEC_AVAIL)                                                         \
-  template <>                                                                                                     \
-  struct Axpby<Kokkos::Cuda, float,                                                                               \
-               Kokkos::View<const float*, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, float, \
-               Kokkos::View<float*, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, 1, true,     \
-               ETI_SPEC_AVAIL> {                                                                                  \
-    typedef float AV;                                                                                             \
-    typedef float BV;                                                                                             \
-    typedef Kokkos::View<const float*, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> > XV;        \
-    typedef Kokkos::View<float*, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> > YV;              \
-    typedef typename XV::size_type size_type;                                                                     \
-                                                                                                                  \
-    static void axpby(const Kokkos::Cuda& space, const AV& alpha, const XV& X, const BV& beta, const YV& Y) {     \
-      Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_CUBLAS,float]");                                       \
-      const size_type numElems = X.extent(0);                                                                     \
-      if ((numElems < static_cast<size_type>(INT_MAX)) && (beta == 1.0f)) {                                       \
-        axpby_print_specialization<AV, XV, BV, YV>();                                                             \
-        const int N                            = static_cast<int>(numElems);                                      \
-        constexpr int one                      = 1;                                                               \
-        KokkosBlas::Impl::CudaBlasSingleton& s = KokkosBlas::Impl::CudaBlasSingleton::singleton();                \
-        KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasSetStream(s.handle, space.cuda_stream()));                         \
-        KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasSaxpy(s.handle, N, &alpha, X.data(), one, Y.data(), one));         \
-        KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasSetStream(s.handle, NULL));                                        \
-      } else                                                                                                      \
-        Axpby<Kokkos::Cuda, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(space, alpha, X, beta, Y);    \
-      Kokkos::Profiling::popRegion();                                                                             \
-    }                                                                                                             \
-  };
-
-#define KOKKOSBLAS1_ZAXPBY_CUBLAS(LAYOUT, ETI_SPEC_AVAIL)                                                              \
+#define KOKKOSBLAS1_DAXPBY_CUBLAS(ETI_SPEC_AVAIL)                                                                      \
   template <>                                                                                                          \
   struct Axpby<                                                                                                        \
-      Kokkos::Cuda, Kokkos::complex<double>,                                                                           \
-      Kokkos::View<const Kokkos::complex<double>*, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,    \
-      Kokkos::complex<double>,                                                                                         \
-      Kokkos::View<Kokkos::complex<double>*, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, 1, true, \
+      Kokkos::Cuda, double,                                                                                            \
+      Kokkos::View<const double*, Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, double, \
+      Kokkos::View<double*, Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, 1, true,      \
       ETI_SPEC_AVAIL> {                                                                                                \
-    typedef Kokkos::complex<double> AV;                                                                                \
-    typedef Kokkos::complex<double> BV;                                                                                \
-    typedef Kokkos::View<const Kokkos::complex<double>*, LAYOUT, Kokkos::Cuda,                                         \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >                                                     \
+    typedef double AV;                                                                                                 \
+    typedef double BV;                                                                                                 \
+    typedef Kokkos::View<const double*, Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> >    \
         XV;                                                                                                            \
-    typedef Kokkos::View<Kokkos::complex<double>*, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> > YV; \
+    typedef Kokkos::View<double*, Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> > YV;      \
     typedef typename XV::size_type size_type;                                                                          \
                                                                                                                        \
     static void axpby(const Kokkos::Cuda& space, const AV& alpha, const XV& X, const BV& beta, const YV& Y) {          \
-      Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_CUBLAS,complex<double>]");                                  \
+      Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_CUBLAS,double]");                                           \
       const size_type numElems = X.extent(0);                                                                          \
-      if ((numElems < static_cast<size_type>(INT_MAX)) && (beta == 1.0f)) {                                            \
+      if ((numElems < static_cast<size_type>(INT_MAX)) && (beta == 1.0)) {                                             \
         axpby_print_specialization<AV, XV, BV, YV>();                                                                  \
         const int N                            = static_cast<int>(numElems);                                           \
         constexpr int one                      = 1;                                                                    \
         KokkosBlas::Impl::CudaBlasSingleton& s = KokkosBlas::Impl::CudaBlasSingleton::singleton();                     \
         KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasSetStream(s.handle, space.cuda_stream()));                              \
-        KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasZaxpy(s.handle, N, reinterpret_cast<const cuDoubleComplex*>(&alpha),    \
-                                                     reinterpret_cast<const cuDoubleComplex*>(X.data()), one,          \
-                                                     reinterpret_cast<cuDoubleComplex*>(Y.data()), one));              \
+        KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasDaxpy(s.handle, N, &alpha, X.data(), one, Y.data(), one));              \
         KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasSetStream(s.handle, NULL));                                             \
       } else                                                                                                           \
         Axpby<Kokkos::Cuda, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(space, alpha, X, beta, Y);         \
@@ -272,52 +200,123 @@ namespace Impl {
     }                                                                                                                  \
   };
 
-#define KOKKOSBLAS1_CAXPBY_CUBLAS(LAYOUT, ETI_SPEC_AVAIL)                                                             \
-  template <>                                                                                                         \
-  struct Axpby<                                                                                                       \
-      Kokkos::Cuda, Kokkos::complex<float>,                                                                           \
-      Kokkos::View<const Kokkos::complex<float>*, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,    \
-      Kokkos::complex<float>,                                                                                         \
-      Kokkos::View<Kokkos::complex<float>*, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, 1, true, \
-      ETI_SPEC_AVAIL> {                                                                                               \
-    typedef Kokkos::complex<float> AV;                                                                                \
-    typedef Kokkos::complex<float> BV;                                                                                \
-    typedef Kokkos::View<const Kokkos::complex<float>*, LAYOUT, Kokkos::Cuda,                                         \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >                                                    \
-        XV;                                                                                                           \
-    typedef Kokkos::View<Kokkos::complex<float>*, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> > YV; \
-    typedef typename XV::size_type size_type;                                                                         \
-                                                                                                                      \
-    static void axpby(const Kokkos::Cuda& space, const AV& alpha, const XV& X, const BV& beta, const YV& Y) {         \
-      Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_CUBLAS,complex<float>]");                                  \
-      const size_type numElems = X.extent(0);                                                                         \
-      if ((numElems < static_cast<size_type>(INT_MAX)) && (beta == 1.0f)) {                                           \
-        axpby_print_specialization<AV, XV, BV, YV>();                                                                 \
-        const int N                            = static_cast<int>(numElems);                                          \
-        constexpr int one                      = 1;                                                                   \
-        KokkosBlas::Impl::CudaBlasSingleton& s = KokkosBlas::Impl::CudaBlasSingleton::singleton();                    \
-        KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasSetStream(s.handle, space.cuda_stream()));                             \
-        KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasCaxpy(s.handle, N, reinterpret_cast<const cuComplex*>(&alpha),         \
-                                                     reinterpret_cast<const cuComplex*>(X.data()), one,               \
-                                                     reinterpret_cast<cuComplex*>(Y.data()), one));                   \
-        KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasSetStream(s.handle, NULL));                                            \
-      } else                                                                                                          \
-        Axpby<Kokkos::Cuda, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(space, alpha, X, beta, Y);        \
-      Kokkos::Profiling::popRegion();                                                                                 \
-    }                                                                                                                 \
+#define KOKKOSBLAS1_SAXPBY_CUBLAS(ETI_SPEC_AVAIL)                                                                      \
+  template <>                                                                                                          \
+  struct Axpby<Kokkos::Cuda, float,                                                                                    \
+               Kokkos::View<const float*, Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+               float,                                                                                                  \
+               Kokkos::View<float*, Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, 1,    \
+               true, ETI_SPEC_AVAIL> {                                                                                 \
+    typedef float AV;                                                                                                  \
+    typedef float BV;                                                                                                  \
+    typedef Kokkos::View<const float*, Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> > XV; \
+    typedef Kokkos::View<float*, Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> > YV;       \
+    typedef typename XV::size_type size_type;                                                                          \
+                                                                                                                       \
+    static void axpby(const Kokkos::Cuda& space, const AV& alpha, const XV& X, const BV& beta, const YV& Y) {          \
+      Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_CUBLAS,float]");                                            \
+      const size_type numElems = X.extent(0);                                                                          \
+      if ((numElems < static_cast<size_type>(INT_MAX)) && (beta == 1.0f)) {                                            \
+        axpby_print_specialization<AV, XV, BV, YV>();                                                                  \
+        const int N                            = static_cast<int>(numElems);                                           \
+        constexpr int one                      = 1;                                                                    \
+        KokkosBlas::Impl::CudaBlasSingleton& s = KokkosBlas::Impl::CudaBlasSingleton::singleton();                     \
+        KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasSetStream(s.handle, space.cuda_stream()));                              \
+        KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasSaxpy(s.handle, N, &alpha, X.data(), one, Y.data(), one));              \
+        KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasSetStream(s.handle, NULL));                                             \
+      } else                                                                                                           \
+        Axpby<Kokkos::Cuda, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(space, alpha, X, beta, Y);         \
+      Kokkos::Profiling::popRegion();                                                                                  \
+    }                                                                                                                  \
   };
 
-KOKKOSBLAS1_DAXPBY_CUBLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS1_DAXPBY_CUBLAS(Kokkos::LayoutLeft, false)
+#define KOKKOSBLAS1_ZAXPBY_CUBLAS(ETI_SPEC_AVAIL)                                                                   \
+  template <>                                                                                                       \
+  struct Axpby<Kokkos::Cuda, Kokkos::complex<double>,                                                               \
+               Kokkos::View<const Kokkos::complex<double>*, Kokkos::LayoutLeft, Kokkos::Cuda,                       \
+                            Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                              \
+               Kokkos::complex<double>,                                                                             \
+               Kokkos::View<Kokkos::complex<double>*, Kokkos::LayoutLeft, Kokkos::Cuda,                             \
+                            Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                              \
+               1, true, ETI_SPEC_AVAIL> {                                                                           \
+    typedef Kokkos::complex<double> AV;                                                                             \
+    typedef Kokkos::complex<double> BV;                                                                             \
+    typedef Kokkos::View<const Kokkos::complex<double>*, Kokkos::LayoutLeft, Kokkos::Cuda,                          \
+                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >                                                  \
+        XV;                                                                                                         \
+    typedef Kokkos::View<Kokkos::complex<double>*, Kokkos::LayoutLeft, Kokkos::Cuda,                                \
+                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >                                                  \
+        YV;                                                                                                         \
+    typedef typename XV::size_type size_type;                                                                       \
+                                                                                                                    \
+    static void axpby(const Kokkos::Cuda& space, const AV& alpha, const XV& X, const BV& beta, const YV& Y) {       \
+      Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_CUBLAS,complex<double>]");                               \
+      const size_type numElems = X.extent(0);                                                                       \
+      if ((numElems < static_cast<size_type>(INT_MAX)) && (beta == 1.0f)) {                                         \
+        axpby_print_specialization<AV, XV, BV, YV>();                                                               \
+        const int N                            = static_cast<int>(numElems);                                        \
+        constexpr int one                      = 1;                                                                 \
+        KokkosBlas::Impl::CudaBlasSingleton& s = KokkosBlas::Impl::CudaBlasSingleton::singleton();                  \
+        KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasSetStream(s.handle, space.cuda_stream()));                           \
+        KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasZaxpy(s.handle, N, reinterpret_cast<const cuDoubleComplex*>(&alpha), \
+                                                     reinterpret_cast<const cuDoubleComplex*>(X.data()), one,       \
+                                                     reinterpret_cast<cuDoubleComplex*>(Y.data()), one));           \
+        KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasSetStream(s.handle, NULL));                                          \
+      } else                                                                                                        \
+        Axpby<Kokkos::Cuda, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(space, alpha, X, beta, Y);      \
+      Kokkos::Profiling::popRegion();                                                                               \
+    }                                                                                                               \
+  };
 
-KOKKOSBLAS1_SAXPBY_CUBLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS1_SAXPBY_CUBLAS(Kokkos::LayoutLeft, false)
+#define KOKKOSBLAS1_CAXPBY_CUBLAS(ETI_SPEC_AVAIL)                                                              \
+  template <>                                                                                                  \
+  struct Axpby<Kokkos::Cuda, Kokkos::complex<float>,                                                           \
+               Kokkos::View<const Kokkos::complex<float>*, Kokkos::LayoutLeft, Kokkos::Cuda,                   \
+                            Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                         \
+               Kokkos::complex<float>,                                                                         \
+               Kokkos::View<Kokkos::complex<float>*, Kokkos::LayoutLeft, Kokkos::Cuda,                         \
+                            Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                         \
+               1, true, ETI_SPEC_AVAIL> {                                                                      \
+    typedef Kokkos::complex<float> AV;                                                                         \
+    typedef Kokkos::complex<float> BV;                                                                         \
+    typedef Kokkos::View<const Kokkos::complex<float>*, Kokkos::LayoutLeft, Kokkos::Cuda,                      \
+                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >                                             \
+        XV;                                                                                                    \
+    typedef Kokkos::View<Kokkos::complex<float>*, Kokkos::LayoutLeft, Kokkos::Cuda,                            \
+                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >                                             \
+        YV;                                                                                                    \
+    typedef typename XV::size_type size_type;                                                                  \
+                                                                                                               \
+    static void axpby(const Kokkos::Cuda& space, const AV& alpha, const XV& X, const BV& beta, const YV& Y) {  \
+      Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_CUBLAS,complex<float>]");                           \
+      const size_type numElems = X.extent(0);                                                                  \
+      if ((numElems < static_cast<size_type>(INT_MAX)) && (beta == 1.0f)) {                                    \
+        axpby_print_specialization<AV, XV, BV, YV>();                                                          \
+        const int N                            = static_cast<int>(numElems);                                   \
+        constexpr int one                      = 1;                                                            \
+        KokkosBlas::Impl::CudaBlasSingleton& s = KokkosBlas::Impl::CudaBlasSingleton::singleton();             \
+        KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasSetStream(s.handle, space.cuda_stream()));                      \
+        KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasCaxpy(s.handle, N, reinterpret_cast<const cuComplex*>(&alpha),  \
+                                                     reinterpret_cast<const cuComplex*>(X.data()), one,        \
+                                                     reinterpret_cast<cuComplex*>(Y.data()), one));            \
+        KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasSetStream(s.handle, NULL));                                     \
+      } else                                                                                                   \
+        Axpby<Kokkos::Cuda, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(space, alpha, X, beta, Y); \
+      Kokkos::Profiling::popRegion();                                                                          \
+    }                                                                                                          \
+  };
 
-KOKKOSBLAS1_ZAXPBY_CUBLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS1_ZAXPBY_CUBLAS(Kokkos::LayoutLeft, false)
+KOKKOSBLAS1_DAXPBY_CUBLAS(true)
+KOKKOSBLAS1_DAXPBY_CUBLAS(false)
 
-KOKKOSBLAS1_CAXPBY_CUBLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS1_CAXPBY_CUBLAS(Kokkos::LayoutLeft, false)
+KOKKOSBLAS1_SAXPBY_CUBLAS(true)
+KOKKOSBLAS1_SAXPBY_CUBLAS(false)
+
+KOKKOSBLAS1_ZAXPBY_CUBLAS(true)
+KOKKOSBLAS1_ZAXPBY_CUBLAS(false)
+
+KOKKOSBLAS1_CAXPBY_CUBLAS(true)
+KOKKOSBLAS1_CAXPBY_CUBLAS(false)
 
 #undef KOKKOSBLAS1_DAXPBY_CUBLAS
 #undef KOKKOSBLAS1_SAXPBY_CUBLAS

--- a/cmake/kokkoskernels_eti_devices.cmake
+++ b/cmake/kokkoskernels_eti_devices.cmake
@@ -2,7 +2,7 @@
 # KokkosKernels may enable fewer execution spaces than
 # Kokkos enables.  This can reduce build and test times.
 
-set(EXEC_SPACES
+set(ALL_EXEC_SPACES
     EXECSPACE_CUDA
     EXECSPACE_HIP
     EXECSPACE_SYCL
@@ -149,9 +149,13 @@ set(EXECSPACE_SYCL_VALID_MEM_SPACES          SYCLSPACE SYCLSHAREDSPACE)
 set(EXECSPACE_SERIAL_VALID_MEM_SPACES        HOSTSPACE)
 set(EXECSPACE_OPENMP_VALID_MEM_SPACES        HOSTSPACE)
 set(EXECSPACE_THREADS_VALID_MEM_SPACES       HOSTSPACE)
+
+# Make lists of instantiated execution spaces and devices (exec/mem space combinations)
+set(EXEC_SPACES)
 set(DEVICES)
-foreach(EXEC ${EXEC_SPACES})
+foreach(EXEC ${ALL_EXEC_SPACES})
   if(KOKKOSKERNELS_INST_${EXEC})
+    list(APPEND EXEC_SPACES ${EXEC})
     foreach(MEM ${${EXEC}_VALID_MEM_SPACES})
       if(KOKKOSKERNELS_INST_MEMSPACE_${MEM})
         list(APPEND DEVICES ${EXEC}_MEMSPACE_${MEM})

--- a/common/src/KokkosKernels_helpers.hpp
+++ b/common/src/KokkosKernels_helpers.hpp
@@ -38,7 +38,7 @@ struct GetUnifiedScalarViewType<T, TX, false, true> {
   typedef Kokkos::View<
       typename T::non_const_value_type*,
       typename KokkosKernels::Impl::GetUnifiedLayoutPreferring<T, typename TX::array_layout>::array_layout,
-      typename T::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >
+      typename T::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged>>
       type;
 };
 
@@ -47,9 +47,60 @@ struct GetUnifiedScalarViewType<T, TX, true, true> {
   typedef Kokkos::View<
       typename T::const_value_type*,
       typename KokkosKernels::Impl::GetUnifiedLayoutPreferring<T, typename TX::array_layout>::array_layout,
-      typename T::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >
+      typename T::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged>>
       type;
 };
+
+// GetUnifiedScalarExecSpaceViewType: like the above, unifies a parameter type T that could be either a scalar or View.
+// But if it's a View, we use ExecSpace as the unified device type (instead of T::device_type as with
+// GetUnifiedScalarViewType above)
+template <class ExecSpace, class T, class TX, bool do_const, bool isView = Kokkos::is_view<T>::value>
+struct GetUnifiedScalarExecSpaceViewType {
+  typedef typename TX::non_const_value_type type;
+};
+
+template <class ExecSpace, class T, class TX>
+struct GetUnifiedScalarExecSpaceViewType<ExecSpace, T, TX, false, true> {
+  typedef Kokkos::View<
+      typename T::non_const_value_type*,
+      typename KokkosKernels::Impl::GetUnifiedLayoutPreferring<T, typename TX::array_layout>::array_layout, ExecSpace,
+      Kokkos::MemoryTraits<Kokkos::Unmanaged>>
+      type;
+};
+
+template <class ExecSpace, class T, class TX>
+struct GetUnifiedScalarExecSpaceViewType<ExecSpace, T, TX, true, true> {
+  typedef Kokkos::View<
+      typename T::const_value_type*,
+      typename KokkosKernels::Impl::GetUnifiedLayoutPreferring<T, typename TX::array_layout>::array_layout, ExecSpace,
+      Kokkos::MemoryTraits<Kokkos::Unmanaged>>
+      type;
+};
+
+// Utility for shallow-copying a view v to a different type, where
+// direct assignment may or may not be allowed by Kokkos.
+//
+// Some situations where direct assignment is not allowed (and this helper is needed):
+// - V1 is HostSpace, and V2 is any shared space.
+// - V1 is Serial and V2 is Device<Serial, CudaUVMSpace>
+//
+// In some kernels, unified parameters can be scalars so this also works with V1 and V2 being convertible scalar types.
+template <typename V1, typename V2>
+V1 unificationCast(const V2& v) {
+  if constexpr (!Kokkos::is_view_v<V1>) {
+    return v;
+  } else {
+    if constexpr (std::is_same_v<typename V1::array_layout, typename V2::array_layout>) {
+      return V1(v.data(), v.layout());
+    }
+    // If layout types aren't the same, first convert to an intermediate type with the target layout
+    Kokkos::View<typename V2::data_type, typename V1::array_layout, typename V2::device_type,
+                 Kokkos::MemoryTraits<Kokkos::Unmanaged>>
+        temp = v;
+    // Then we can we use View assignment to change to V1's device type and traits
+    return V1(temp.data(), temp.layout());
+  }
+}
 
 template <class... Ts>
 struct are_integral : std::bool_constant<((std::is_integral_v<Ts> || std::is_enum_v<Ts>)&&...)> {};

--- a/lapack/unit_test/Test_Lapack_gesv.hpp
+++ b/lapack/unit_test/Test_Lapack_gesv.hpp
@@ -66,7 +66,7 @@ void impl_test_gesv(const char* mode, const char* padding, int N) {
 
   // Allocate IPIV view on host
   using ViewTypeP = typename std::conditional<MAGMA, Kokkos::View<int*, Kokkos::LayoutLeft, Kokkos::HostSpace>,
-                                              Kokkos::View<int*, Kokkos::LayoutLeft, execution_space>>::type;
+                                              Kokkos::View<int*, Kokkos::LayoutLeft, Device>>::type;
   ViewTypeP ipiv;
   int Nt = 0;
   if (mode[0] == 'Y') {
@@ -86,10 +86,10 @@ void impl_test_gesv(const char* mode, const char* padding, int N) {
 #ifdef KOKKOSKERNELS_ENABLE_TPL_MAGMA   // have MAGMA TPL
 #ifdef KOKKOSKERNELS_ENABLE_TPL_LAPACK  // and have LAPACK TPL
 #if defined(KOKKOS_ENABLE_CUDA)
-    nopivot_runtime_err = (!std::is_same<typename Device::memory_space, Kokkos::CudaSpace>::value) &&
+    nopivot_runtime_err = (!std::is_same<typename Device::execution_space, Kokkos::Cuda>::value) &&
                           (ipiv.extent(0) == 0) && (ipiv.data() == nullptr);
 #elif defined(KOKKOS_ENABLE_HIP)
-    nopivot_runtime_err = (!std::is_same<typename Device::memory_space, Kokkos::HIPSpace>::value) &&
+    nopivot_runtime_err = (!std::is_same<typename Device::execution_space, Kokkos::HIP>::value) &&
                           (ipiv.extent(0) == 0) && (ipiv.data() == nullptr);
 #endif
     notpl_runtime_err = false;
@@ -174,7 +174,7 @@ void impl_test_gesv_mrhs(const char* mode, const char* padding, int N, int nrhs)
 
   // Allocate IPIV view on host
   using ViewTypeP = typename std::conditional<MAGMA, Kokkos::View<int*, Kokkos::LayoutLeft, Kokkos::HostSpace>,
-                                              Kokkos::View<int*, Kokkos::LayoutLeft, execution_space>>::type;
+                                              Kokkos::View<int*, Kokkos::LayoutLeft, Device>>::type;
   ViewTypeP ipiv;
   int Nt = 0;
   if (mode[0] == 'Y') {
@@ -194,10 +194,10 @@ void impl_test_gesv_mrhs(const char* mode, const char* padding, int N, int nrhs)
 #ifdef KOKKOSKERNELS_ENABLE_TPL_MAGMA   // have MAGMA TPL
 #ifdef KOKKOSKERNELS_ENABLE_TPL_LAPACK  // and have LAPACK TPL
 #if defined(KOKKOS_ENABLE_CUDA)
-    nopivot_runtime_err = (!std::is_same<typename Device::memory_space, Kokkos::CudaSpace>::value) &&
+    nopivot_runtime_err = (!std::is_same<typename Device::execution_space, Kokkos::Cuda>::value) &&
                           (ipiv.extent(0) == 0) && (ipiv.data() == nullptr);
 #elif defined(KOKKOS_ENABLE_HIP)
-    nopivot_runtime_err = (!std::is_same<typename Device::memory_space, Kokkos::HIPSpace>::value) &&
+    nopivot_runtime_err = (!std::is_same<typename Device::execution_space, Kokkos::HIP>::value) &&
                           (ipiv.extent(0) == 0) && (ipiv.data() == nullptr);
 #endif
     notpl_runtime_err = false;


### PR DESCRIPTION
This is the PR 1 in a refactor of the BLAS unification layer (splitting up the large draft PR #3168 for easier review).

The main change is to instantiate on ExecSpace instead of Device. This way, Views with ``<Cuda, CudaSpace>``, ``<Cuda, CudaUVMSpace>`` and ``<Cuda, CudaHostPinnedSpace>`` are all unified to the same implementation or TPL. This works towards resolving #775 and #1465.

This PR does:
- Add ``EXEC_SPACES`` as an ETI type list in cmake
- Add new helper which casts an unmanaged View to desired layout and device type
  - because we now can't always assign user's input views to the "_Internal" view types directly
- Refactor axpby to by ETI'd on ExecSpace only instead of Device. Similar changes coming for all other kernels.
- Fix LAPACK gesv test when instantiating UVM/HIPManaged only