### PR TITLE
Fix sell testmtx gen

### DIFF
--- a/sparse/unit_test/Test_Sparse_spmv_sell.hpp
+++ b/sparse/unit_test/Test_Sparse_spmv_sell.hpp
@@ -160,7 +160,7 @@ void test_spmv_sell_analytic() {
 }
 
 template <typename scalar_t, typename ordinal_t, typename size_type, typename Device>
-void test_spmv_sell(ordinal_t num_rows, ordinal_t num_cols, ordinal_t row_length, ordinal_t variance,
+void test_spmv_sell(ordinal_t num_rows, ordinal_t num_cols, ordinal_t row_length, const double variance,
                     ordinal_t bandwidth, scalar_t alpha, scalar_t beta) {
   using sellMat_t     = KokkosSparse::Experimental::SellMatrix<scalar_t, ordinal_t, Device, void, size_type>;
   using scalar_view_t = typename sellMat_t::values_type::non_const_type;
@@ -218,7 +218,7 @@ void test_spmv_sell(ordinal_t num_rows, ordinal_t num_cols, ordinal_t row_length
 #define KOKKOSKERNELS_EXECUTE_TEST(SCALAR, ORDINAL, OFFSET, DEVICE)                         \
   TEST_F(TestCategory, sparse##_##spmv_sell##_##SCALAR##_##ORDINAL##_##OFFSET##_##DEVICE) { \
     ::Test::test_spmv_sell_analytic<SCALAR, ORDINAL, OFFSET, DEVICE>();                     \
-    ::Test::test_spmv_sell<SCALAR, ORDINAL, OFFSET, DEVICE>(5, 5, 3, 0, 2, 2.0, 1.0);       \
+    ::Test::test_spmv_sell<SCALAR, ORDINAL, OFFSET, DEVICE>(5, 5, 3, std::numeric_limits<double>::epsilon(), 2, 2.0, 1.0);       \
     ::Test::test_spmv_sell<SCALAR, ORDINAL, OFFSET, DEVICE>(20, 20, 5, 2, 2, 2.0, 1.0);     \
     ::Test::test_spmv_sell<SCALAR, ORDINAL, OFFSET, DEVICE>(100, 100, 7, 3, 10, 2.0, 1.0);  \
     ::Test::test_spmv_sell<SCALAR, ORDINAL, OFFSET, DEVICE>(100, 50, 7, 2, 3, 2.0, 1.0);    \

--- a/sparse/unit_test/Test_Sparse_spmv_sell.hpp
+++ b/sparse/unit_test/Test_Sparse_spmv_sell.hpp
@@ -215,14 +215,15 @@ void test_spmv_sell(ordinal_t num_rows, ordinal_t num_cols, ordinal_t row_length
 
 }  // namespace Test
 
-#define KOKKOSKERNELS_EXECUTE_TEST(SCALAR, ORDINAL, OFFSET, DEVICE)                         \
-  TEST_F(TestCategory, sparse##_##spmv_sell##_##SCALAR##_##ORDINAL##_##OFFSET##_##DEVICE) { \
-    ::Test::test_spmv_sell_analytic<SCALAR, ORDINAL, OFFSET, DEVICE>();                     \
-    ::Test::test_spmv_sell<SCALAR, ORDINAL, OFFSET, DEVICE>(5, 5, 3, std::numeric_limits<double>::epsilon(), 2, 2.0, 1.0);       \
-    ::Test::test_spmv_sell<SCALAR, ORDINAL, OFFSET, DEVICE>(20, 20, 5, 2, 2, 2.0, 1.0);     \
-    ::Test::test_spmv_sell<SCALAR, ORDINAL, OFFSET, DEVICE>(100, 100, 7, 3, 10, 2.0, 1.0);  \
-    ::Test::test_spmv_sell<SCALAR, ORDINAL, OFFSET, DEVICE>(100, 50, 7, 2, 3, 2.0, 1.0);    \
-    ::Test::test_spmv_sell<SCALAR, ORDINAL, OFFSET, DEVICE>(80, 100, 7, 2, 3, 2.0, 1.0);    \
+#define KOKKOSKERNELS_EXECUTE_TEST(SCALAR, ORDINAL, OFFSET, DEVICE)                                                  \
+  TEST_F(TestCategory, sparse##_##spmv_sell##_##SCALAR##_##ORDINAL##_##OFFSET##_##DEVICE) {                          \
+    ::Test::test_spmv_sell_analytic<SCALAR, ORDINAL, OFFSET, DEVICE>();                                              \
+    ::Test::test_spmv_sell<SCALAR, ORDINAL, OFFSET, DEVICE>(5, 5, 3, std::numeric_limits<double>::epsilon(), 2, 2.0, \
+                                                            1.0);                                                    \
+    ::Test::test_spmv_sell<SCALAR, ORDINAL, OFFSET, DEVICE>(20, 20, 5, 2, 2, 2.0, 1.0);                              \
+    ::Test::test_spmv_sell<SCALAR, ORDINAL, OFFSET, DEVICE>(100, 100, 7, 3, 10, 2.0, 1.0);                           \
+    ::Test::test_spmv_sell<SCALAR, ORDINAL, OFFSET, DEVICE>(100, 50, 7, 2, 3, 2.0, 1.0);                             \
+    ::Test::test_spmv_sell<SCALAR, ORDINAL, OFFSET, DEVICE>(80, 100, 7, 2, 3, 2.0, 1.0);                             \
   }
 
 #include <Test_Common_Test_All_Type_Combos.hpp>


### PR DESCRIPTION
Resolves failures with g++-15 and c++23 of type:

```
    serial.sparse_spmv_sell_double_int_int_TestDevice
    /usr/include/c++/15/bits/random.h:2138: std::normal_distribution<_RealType>::param_type::param_type(_RealType, _RealType) [with _RealType = double]: Assertion '_M_stddev > _RealType(0)' failed
```

std::normal_distribution requires a stddev > 0