### PR TITLE
[Batched][Refactor] Replaced `view_rank()` on `Kokkos::rank()`

### DIFF
--- a/batched/KokkosBatched_Util.hpp
+++ b/batched/KokkosBatched_Util.hpp
@@ -58,17 +58,6 @@ namespace KokkosBatched {
 #define Int2String(A) Int2StringHelper(A)
 #define StringCat(A, B) A B
 
-// nvcc+MSVC device code cannot resolve Kokkos::View::rank via instance call;
-// use ViewType::rank() (compile-time) for fixed-rank View, v.rank() for DynRankView.
-template <typename ViewType>
-KOKKOS_INLINE_FUNCTION size_t view_rank(const ViewType &v) {
-  if constexpr (Kokkos::is_view_v<ViewType>) {
-    return ViewType::rank();
-  } else {
-    return v.rank();
-  }
-}
-
 void print_compiler_info();
 
 template <typename T>
@@ -725,7 +714,7 @@ KOKKOS_INLINE_FUNCTION int get_extent_int(const ViewType &v, const int r) {
                   "KokkosBatched: ViewType must be a Kokkos::View or a Kokkos::DynRankView");
   }
 
-  const std::size_t V_rank = view_rank(v);
+  const std::size_t V_rank = Kokkos::rank(v);
 
   if (r == 0) {
     int V_extent_0 = V_rank < 1 ? 1 : v.extent_int(0);
@@ -750,7 +739,7 @@ KOKKOS_INLINE_FUNCTION std::size_t get_stride(const ViewType &v, const int r) {
                   "KokkosBatched: ViewType must be a Kokkos::View or a Kokkos::DynRankView");
   }
 
-  const std::size_t V_rank = view_rank(v);
+  const std::size_t V_rank = Kokkos::rank(v);
 
   if (r == 0) {
     std::size_t V_stride_0 = V_rank < 1 ? 1 : v.stride(0);

--- a/batched/dense/impl/KokkosBatched_Trsm_Team_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Trsm_Team_Impl.hpp
@@ -46,7 +46,7 @@ struct TeamTrsm<MemberType, Side::Left, Uplo::Lower, Trans::NoTranspose, ArgDiag
     // Quick return if possible
     if (B.size() == 0) return 0;
 
-    const size_t B_rank     = view_rank(B);
+    const size_t B_rank     = Kokkos::rank(B);
     const size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
     const size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
 
@@ -80,7 +80,7 @@ struct TeamTrsm<MemberType, Side::Left, Uplo::Lower, Trans::NoTranspose, ArgDiag
     // Quick return if possible
     if (B.size() == 0) return 0;
 
-    const size_t B_rank     = view_rank(B);
+    const size_t B_rank     = Kokkos::rank(B);
     const size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
     const size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
 
@@ -120,7 +120,7 @@ struct TeamTrsm<MemberType, Side::Right, Uplo::Upper, Trans::NoTranspose, ArgDia
     // Quick return if possible
     if (B.size() == 0) return 0;
 
-    const size_t B_rank     = view_rank(B);
+    const size_t B_rank     = Kokkos::rank(B);
     const size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
     const size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
 
@@ -154,7 +154,7 @@ struct TeamTrsm<MemberType, Side::Right, Uplo::Upper, Trans::NoTranspose, ArgDia
     // Quick return if possible
     if (B.size() == 0) return 0;
 
-    const size_t B_rank     = view_rank(B);
+    const size_t B_rank     = Kokkos::rank(B);
     const size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
     const size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
 
@@ -194,7 +194,7 @@ struct TeamTrsm<MemberType, Side::Right, Uplo::Lower, Trans::NoTranspose, ArgDia
     // Quick return if possible
     if (B.size() == 0) return 0;
 
-    const size_t B_rank     = view_rank(B);
+    const size_t B_rank     = Kokkos::rank(B);
     const size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
     const size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
 
@@ -228,7 +228,7 @@ struct TeamTrsm<MemberType, Side::Right, Uplo::Lower, Trans::NoTranspose, ArgDia
     // Quick return if possible
     if (B.size() == 0) return 0;
 
-    const size_t B_rank     = view_rank(B);
+    const size_t B_rank     = Kokkos::rank(B);
     const size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
     const size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
 
@@ -268,7 +268,7 @@ struct TeamTrsm<MemberType, Side::Right, Uplo::Upper, Trans::Transpose, ArgDiag,
     // Quick return if possible
     if (B.size() == 0) return 0;
 
-    const size_t B_rank     = view_rank(B);
+    const size_t B_rank     = Kokkos::rank(B);
     const size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
     const size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
 
@@ -302,7 +302,7 @@ struct TeamTrsm<MemberType, Side::Right, Uplo::Upper, Trans::Transpose, ArgDiag,
     // Quick return if possible
     if (B.size() == 0) return 0;
 
-    const size_t B_rank     = view_rank(B);
+    const size_t B_rank     = Kokkos::rank(B);
     const size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
     const size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
 
@@ -342,7 +342,7 @@ struct TeamTrsm<MemberType, Side::Left, Uplo::Upper, Trans::NoTranspose, ArgDiag
     // Quick return if possible
     if (B.size() == 0) return 0;
 
-    const size_t B_rank     = view_rank(B);
+    const size_t B_rank     = Kokkos::rank(B);
     const size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
     const size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
 
@@ -376,7 +376,7 @@ struct TeamTrsm<MemberType, Side::Left, Uplo::Upper, Trans::NoTranspose, ArgDiag
     // Quick return if possible
     if (B.size() == 0) return 0;
 
-    const size_t B_rank     = view_rank(B);
+    const size_t B_rank     = Kokkos::rank(B);
     const size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
     const size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
 
@@ -416,7 +416,7 @@ struct TeamTrsm<MemberType, Side::Left, Uplo::Lower, Trans::Transpose, ArgDiag, 
     // Quick return if possible
     if (B.size() == 0) return 0;
 
-    const size_t B_rank     = view_rank(B);
+    const size_t B_rank     = Kokkos::rank(B);
     const size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
     const size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
 
@@ -450,7 +450,7 @@ struct TeamTrsm<MemberType, Side::Left, Uplo::Lower, Trans::Transpose, ArgDiag, 
     // Quick return if possible
     if (B.size() == 0) return 0;
 
-    const size_t B_rank     = view_rank(B);
+    const size_t B_rank     = Kokkos::rank(B);
     const size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
     const size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
 
@@ -490,7 +490,7 @@ struct TeamTrsm<MemberType, Side::Left, Uplo::Upper, Trans::Transpose, ArgDiag, 
     // Quick return if possible
     if (B.size() == 0) return 0;
 
-    const size_t B_rank     = view_rank(B);
+    const size_t B_rank     = Kokkos::rank(B);
     const size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
     const size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
 
@@ -524,7 +524,7 @@ struct TeamTrsm<MemberType, Side::Left, Uplo::Upper, Trans::Transpose, ArgDiag, 
     // Quick return if possible
     if (B.size() == 0) return 0;
 
-    const size_t B_rank     = view_rank(B);
+    const size_t B_rank     = Kokkos::rank(B);
     const size_t B_extent_1 = B_rank == 1 ? 1 : B.extent(1);
     const size_t B_stride_1 = B_rank == 1 ? 1 : B.stride(1);
 


### PR DESCRIPTION
As @dalg24 noticed in #3113:

> There is Kokkos::rank free function with overloads for View and DynRankView.

This PR contains replacement of excess implementation of `rank` on existing `Kokkos::rank()`.