### PR TITLE
BLAS - GEMM: fixing call to scal missing space param

### DIFF
--- a/blas/src/KokkosBlas3_gemm.hpp
+++ b/blas/src/KokkosBlas3_gemm.hpp
@@ -141,7 +141,7 @@ void gemm(const execution_space& space, const char transA[], const char transB[]
 
   // Simply scale C if A matrix is degenerated
   if (A.extent(1) == 0) {
-    scal(C, beta, C);
+    scal(space, C, beta, C);
     return;
   }
 


### PR DESCRIPTION
Fixes issue #3184

@jakub-homola reports this problem in the above issue. It obviously can lead to weird synchronization issues and performance bugs as well. Looked at the rest of the main gemm code path and did not notice any other similar issues but will keep this in mind when working on other part of the code...

I am going to mark this as "BlocksPromotion" so it gets picked in our current release branch and included in 5.2.0 which should come out in a week or so...