### PR TITLE
Batched - GEMM: adjusting unit-test to reduce runtime

### DIFF
--- a/batched/dense/unit_test/Test_Batched_BatchedGemm.hpp
+++ b/batched/dense/unit_test/Test_Batched_BatchedGemm.hpp
@@ -277,9 +277,9 @@ void test_batched_gemm_with_layout(int N) {
 
   // Non-square cases
   for (int i = 1; i < 5; ++i) {
-    int dimM = 1 * i;
+    int dimM = 3 * i;
     int dimN = 2 * i;
-    int dimK = 3 * i;
+    int dimK = i;
     if ((std::is_same<typename ParamTagType::transA, KokkosBatched::Trans::NoTranspose>::value) &&
         (std::is_same<typename ParamTagType::transB, KokkosBatched::Trans::NoTranspose>::value)) {
       Test::impl_test_batched_gemm<DeviceType, ViewType, ScalarType, ParamTagType>(N, dimM, dimK, dimK, dimN, dimM,

--- a/batched/dense/unit_test/Test_Batched_Dense_GEMM.hpp
+++ b/batched/dense/unit_test/Test_Batched_Dense_GEMM.hpp
@@ -5,9 +5,6 @@
 #include "Test_Batched_SerialGemm.hpp"
 #include "Test_Batched_SerialGemm_Real.hpp"
 #include "Test_Batched_SerialGemm_Complex.hpp"
-#include "Test_Batched_BatchedGemm.hpp"
-#include "Test_Batched_BatchedGemm_Real.hpp"
-#include "Test_Batched_BatchedGemm_Complex.hpp"
 
 // Team Kernels
 #include "Test_Batched_TeamGemm.hpp"
@@ -17,5 +14,10 @@
 // TeamVector Kernels
 #include "Test_Batched_TeamVectorGemm_Real.hpp"
 #include "Test_Batched_TeamVectorGemm_Complex.hpp"
+
+// Host dispatch kernels
+#include "Test_Batched_BatchedGemm.hpp"
+#include "Test_Batched_BatchedGemm_Real.hpp"
+#include "Test_Batched_BatchedGemm_Complex.hpp"
 
 #endif  // TEST_BATCHED_DENSE_GEMM_HPP

--- a/batched/dense/unit_test/Test_Batched_TeamGemm.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamGemm.hpp
@@ -242,31 +242,31 @@ int test_batched_teamgemm() {
                                                AlgoTagType>(0, 10, 10, 10, 10, 10, 10);
     for (int i = 0; i < 10; ++i) {
       Test::TeamGemm::impl_test_batched_teamgemm<DeviceType, ValueType, ScalarType, LayoutType, ParamTagType,
-                                                 AlgoTagType>(1024, i, i, i, i, i, i);
+                                                 AlgoTagType>(128, i, i, i, i, i, i);
     }
     for (int i = 0; i < 10; ++i) {
-      int dimM = i;
+      int dimM = 3 * i;
       int dimN = 2 * i;
-      int dimK = 3 * i;
+      int dimK = i;
       if ((std::is_same_v<typename ParamTagType::transA, KokkosBatched::Trans::NoTranspose>)&&(
               std::is_same_v<typename ParamTagType::transB, KokkosBatched::Trans::NoTranspose>)) {
         Test::TeamGemm::impl_test_batched_teamgemm<DeviceType, ValueType, ScalarType, LayoutType, ParamTagType,
-                                                   AlgoTagType>(1024, dimM, dimK, dimK, dimN, dimM, dimN);
+                                                   AlgoTagType>(128, dimM, dimK, dimK, dimN, dimM, dimN);
       }
       if ((std::is_same_v<typename ParamTagType::transA, KokkosBatched::Trans::NoTranspose>)&&(
               !std::is_same_v<typename ParamTagType::transB, KokkosBatched::Trans::NoTranspose>)) {
         Test::TeamGemm::impl_test_batched_teamgemm<DeviceType, ValueType, ScalarType, LayoutType, ParamTagType,
-                                                   AlgoTagType>(1024, dimM, dimK, dimN, dimK, dimM, dimN);
+                                                   AlgoTagType>(128, dimM, dimK, dimN, dimK, dimM, dimN);
       }
       if ((!std::is_same_v<typename ParamTagType::transA, KokkosBatched::Trans::NoTranspose>)&&(
               std::is_same_v<typename ParamTagType::transB, KokkosBatched::Trans::NoTranspose>)) {
         Test::TeamGemm::impl_test_batched_teamgemm<DeviceType, ValueType, ScalarType, LayoutType, ParamTagType,
-                                                   AlgoTagType>(1024, dimK, dimM, dimK, dimN, dimM, dimN);
+                                                   AlgoTagType>(128, dimK, dimM, dimK, dimN, dimM, dimN);
       }
       if ((!std::is_same_v<typename ParamTagType::transA, KokkosBatched::Trans::NoTranspose>)&&(
               !std::is_same_v<typename ParamTagType::transB, KokkosBatched::Trans::NoTranspose>)) {
         Test::TeamGemm::impl_test_batched_teamgemm<DeviceType, ValueType, ScalarType, LayoutType, ParamTagType,
-                                                   AlgoTagType>(1024, dimK, dimM, dimN, dimK, dimM, dimN);
+                                                   AlgoTagType>(128, dimK, dimM, dimN, dimK, dimM, dimN);
       }
     }
   }
@@ -278,31 +278,31 @@ int test_batched_teamgemm() {
                                                AlgoTagType>(0, 10, 10, 10, 10, 10, 10);
     for (int i = 0; i < 10; ++i) {
       Test::TeamGemm::impl_test_batched_teamgemm<DeviceType, ValueType, ScalarType, LayoutType, ParamTagType,
-                                                 AlgoTagType>(1024, i, i, i, i, i, i);
+                                                 AlgoTagType>(128, i, i, i, i, i, i);
     }
     for (int i = 0; i < 10; ++i) {
-      int dimM = i;
+      int dimM = 3 * i;
       int dimN = 2 * i;
-      int dimK = 3 * i;
+      int dimK = i;
       if ((std::is_same_v<typename ParamTagType::transA, KokkosBatched::Trans::NoTranspose>)&&(
               std::is_same_v<typename ParamTagType::transB, KokkosBatched::Trans::NoTranspose>)) {
         Test::TeamGemm::impl_test_batched_teamgemm<DeviceType, ValueType, ScalarType, LayoutType, ParamTagType,
-                                                   AlgoTagType>(1024, dimM, dimK, dimK, dimN, dimM, dimN);
+                                                   AlgoTagType>(128, dimM, dimK, dimK, dimN, dimM, dimN);
       }
       if ((std::is_same_v<typename ParamTagType::transA, KokkosBatched::Trans::NoTranspose>)&&(
               !std::is_same_v<typename ParamTagType::transB, KokkosBatched::Trans::NoTranspose>)) {
         Test::TeamGemm::impl_test_batched_teamgemm<DeviceType, ValueType, ScalarType, LayoutType, ParamTagType,
-                                                   AlgoTagType>(1024, dimM, dimK, dimN, dimK, dimM, dimN);
+                                                   AlgoTagType>(128, dimM, dimK, dimN, dimK, dimM, dimN);
       }
       if ((!std::is_same_v<typename ParamTagType::transA, KokkosBatched::Trans::NoTranspose>)&&(
               std::is_same_v<typename ParamTagType::transB, KokkosBatched::Trans::NoTranspose>)) {
         Test::TeamGemm::impl_test_batched_teamgemm<DeviceType, ValueType, ScalarType, LayoutType, ParamTagType,
-                                                   AlgoTagType>(1024, dimK, dimM, dimK, dimN, dimM, dimN);
+                                                   AlgoTagType>(128, dimK, dimM, dimK, dimN, dimM, dimN);
       }
       if ((!std::is_same_v<typename ParamTagType::transA, KokkosBatched::Trans::NoTranspose>)&&(
               !std::is_same_v<typename ParamTagType::transB, KokkosBatched::Trans::NoTranspose>)) {
         Test::TeamGemm::impl_test_batched_teamgemm<DeviceType, ValueType, ScalarType, LayoutType, ParamTagType,
-                                                   AlgoTagType>(1024, dimK, dimM, dimN, dimK, dimM, dimN);
+                                                   AlgoTagType>(128, dimK, dimM, dimN, dimK, dimM, dimN);
       }
     }
   }


### PR DESCRIPTION
Making the inner dimension smaller since testing time scales with its square. Also reducing the batch size in the TeamGEMM tests.