### PR TITLE
Lapack getrf

### DIFF
--- a/common/src/KokkosKernels_Cuda_Utils.hpp
+++ b/common/src/KokkosKernels_Cuda_Utils.hpp
@@ -4,8 +4,14 @@
 #ifndef KOKKOSKERNELS_CUDA_UTILS_HPP
 #define KOKKOSKERNELS_CUDA_UTILS_HPP
 
-namespace KokkosKernels {
-namespace Impl {
+#include <Kokkos_Macros.hpp>
+#include <Kokkos_Half_FloatingPointWrapper.hpp>
+#include <stdexcept>
+
+#if defined(KOKKOS_ENABLE_CUDA)
+#include <cuda.h>
+
+namespace KokkosKernels::Impl {
 
 template <typename T>
 cudaDataType cuda_data_type_from() {
@@ -50,7 +56,7 @@ inline cudaDataType cuda_data_type_from<Kokkos::complex<double>>() {
   return CUDA_C_64F;
 }
 
-}  // namespace Impl
-}  // namespace KokkosKernels
+}  // namespace KokkosKernels::Impl
 
+#endif  // KOKKOS_ENABLE_CUDA
 #endif  // KOKKOSKERNELS_CUDA_UTILS_HPP

--- a/common/src/KokkosKernels_Cuda_Utils.hpp
+++ b/common/src/KokkosKernels_Cuda_Utils.hpp
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#ifndef KOKKOSKERNELS_CUDA_UTILS_HPP
+#define KOKKOSKERNELS_CUDA_UTILS_HPP
+
+namespace KokkosKernels {
+namespace Impl {
+
+template <typename T>
+cudaDataType cuda_data_type_from() {
+  // Note:  compile-time failure is disabled to allow for packages such as
+  // Ifpack2 to more easily support scalar types that cuBLAS/cuSPARSE/cuSPARSE may not.
+
+  // compile-time failure with a nice message if called on an unsupported type
+  // static_assert(!std::is_same<T, T>::value,
+  //               "CUDA TPLs do not support scalar type");
+  // static_assert(false, ...) is allowed to error even if the code is not
+  // instantiated. obfuscate the predicate Despite this function being
+  // uncompilable, the compiler may decide that a return statement is missing,
+  // so throw to silence that
+  throw std::logic_error("unreachable throw after static_assert");
+}
+
+/* If half_t is not float, need to define a conversion for both
+   otherwise, conversion for half_t IS conversion for float
+*/
+#if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
+template <>
+inline cudaDataType cuda_data_type_from<Kokkos::Experimental::half_t>() {
+  return CUDA_R_16F;  // Kokkos half_t is a half
+}
+#endif
+// half_t is defined to be float, so this works for both half_t and float when
+// half_t is float
+template <>
+inline cudaDataType cuda_data_type_from<float>() {
+  return CUDA_R_32F;  // Kokkos half_t is a float
+}
+template <>
+inline cudaDataType cuda_data_type_from<double>() {
+  return CUDA_R_64F;
+}
+template <>
+inline cudaDataType cuda_data_type_from<Kokkos::complex<float>>() {
+  return CUDA_C_32F;
+}
+template <>
+inline cudaDataType cuda_data_type_from<Kokkos::complex<double>>() {
+  return CUDA_C_64F;
+}
+
+}  // namespace Impl
+}  // namespace KokkosKernels
+
+#endif  // KOKKOSKERNELS_CUDA_UTILS_HPP

--- a/common/src/KokkosKernels_Cuda_Utils.hpp
+++ b/common/src/KokkosKernels_Cuda_Utils.hpp
@@ -5,7 +5,7 @@
 #define KOKKOSKERNELS_CUDA_UTILS_HPP
 
 #include <Kokkos_Macros.hpp>
-#include <Kokkos_Half_FloatingPointWrapper.hpp>
+#include <Kokkos_Half.hpp>
 #include <stdexcept>
 
 #if defined(KOKKOS_ENABLE_CUDA)

--- a/docs/source/API/lapack-index.rst
+++ b/docs/source/API/lapack-index.rst
@@ -32,12 +32,12 @@ Below are tables summarizing the currently supported function calls and third pa
      - rocBLAS
      - oneMKL
    * - getrf
-     - 
-     - 
-     - 
-     - 
-     - 
-     - 
+     - :doc:`getrf <lapack/getrf>`
+     - --
+     - X
+     - X
+     - X
+     - --
    * - getrs
      - 
      - 

--- a/docs/source/API/lapack-index.rst
+++ b/docs/source/API/lapack-index.rst
@@ -10,6 +10,7 @@ API: LAPACK
    lapack/gegqr
    lapack/potrf
    lapack/potrs
+   lapack/getrf
    lapack/gesv
    lapack/gesvd
    lapack/trtri

--- a/docs/source/API/lapack/getrf.rst
+++ b/docs/source/API/lapack/getrf.rst
@@ -1,0 +1,61 @@
+KokkosLapack::getrf
+###################
+
+Defined in header: :code:`KokkosLapack_getrf.hpp`
+
+.. code:: c++
+
+  template <class ExecutionSpace, class AMatrix, class IpivView, class InfoView>
+  void getrf(const ExecutionSpace& space, const AMatrix& A, const IpivView& Ipiv, const InfoView& Info);
+
+  template <class AMatrix, class IpivView, class InfoView>
+  void getrf(const AMatrix& A, const IpivView& Ipiv, const InfoView& Info);
+
+.. math::
+
+   P*A=L*U
+
+where :math:`A` is, on input, the matrix storing the linear system of equations and on output, contains the factors L and U in its lower and upper triangular parts. :math:`Ipiv` contains the pivots used to construct the row permutation matrix :math:`P`.
+
+1. Overwrite :math:`A` with the :math:`L` and :math:`U` factors using the resources associated with ``space``.
+2. Same as 1. but uses the resources of the default execution space from ``AMatrix::execution_space``.
+
+Parameters
+==========
+
+:space: execution space instance.
+
+:A: The input matrix that gets overwritten with the :math:`L` and :math:`U` factors on output.
+
+:Ipiv: The vector holding the pivots selected during the matrix decomposition.
+
+:Info: A scalar (store in a device view) that holds the return code from Lapack when that library gets called.
+
+Type Requirements
+=================
+
+- `ExecutionSpace` must be a Kokkos `execution space <https://kokkos.org/kokkos-core-wiki/API/core/execution_spaces.html>`_
+
+- `AMatrix` must be a Kokkos `View <https://kokkos.org/kokkos-core-wiki/API/core/view/view.html>`_ of rank 2 that satisfies
+
+  - ``Kokkos::SpaceAccessibility<ExecutionSpace, typename AMatrix::memory_space>::accessible``
+
+- `IpivView` must be a Kokkos `View <https://kokkos.org/kokkos-core-wiki/API/core/view/view.html>`_ of rank 1 that satisfies
+
+  - ``Kokkos::SpaceAccessibility<ExecutionSpace, typename Tau::memory_space>::accessible``
+
+- `InfoView` must be a Kokkos `View <https://kokkos.org/kokkos-core-wiki/API/core/view/view.html>`_ of rank 1 that satisfies
+
+  - ``Kokkos::SpaceAccessibility<ExecutionSpace, typename Info::memory_space>::accessible``
+
+Example
+=======
+
+.. literalinclude:: ../../../../example/docs/lapack/KokkosLapack_docs_geqrf.cpp
+  :language: c++
+
+output:
+
+.. code::
+
+   KokkosLapack::getrf() returned correct results!

--- a/example/docs/lapack/CMakeLists.txt
+++ b/example/docs/lapack/CMakeLists.txt
@@ -11,4 +11,5 @@ if( (KOKKOS_ENABLE_CUDA AND KOKKOSKERNELS_ENABLE_TPL_CUSOLVER) OR
   kokkoskernels_add_executable_and_test(docs_gemqr SOURCES KokkosLapack_docs_gemqr.cpp)
   kokkoskernels_add_executable_and_test(docs_gegqr SOURCES KokkosLapack_docs_gegqr.cpp)
   kokkoskernels_add_executable_and_test(docs_potr  SOURCES KokkosLapack_docs_potr.cpp)
+  kokkoskernels_add_executable_and_test(docs_getrf SOURCES KokkosLapack_docs_getrf.cpp)
 endif()

--- a/example/docs/lapack/KokkosLapack_docs_getrf.cpp
+++ b/example/docs/lapack/KokkosLapack_docs_getrf.cpp
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#include <Kokkos_Core.hpp>
+#include <KokkosLapack_getrf.hpp>
+#include <iostream>
+
+int main(void) {
+  bool correct = true;
+  Kokkos::initialize();
+  {
+    using execution_space = Kokkos::DefaultExecutionSpace;
+    using KAT             = KokkosKernels::ArithTraits<double>;
+
+    Kokkos::View<double**, Kokkos::LayoutLeft> A("A", 3, 3);
+    Kokkos::View<int*, Kokkos::LayoutLeft> Ipiv("tau", 3);
+    Kokkos::View<int*, Kokkos::LayoutLeft> Info("Info", 1);
+
+    auto h_A = Kokkos::create_mirror_view(A);
+    h_A(0, 0) = -1;
+    h_A(0, 1) =  2;
+    h_A(0, 2) = -1;
+    h_A(1, 0) =  2;
+    h_A(1, 1) = -1;
+    h_A(1, 2) =  0;
+    h_A(2, 0) =  0;
+    h_A(2, 1) = -1;
+    h_A(2, 2) =  2;
+    Kokkos::deep_copy(A, h_A);
+
+    execution_space space{};
+    KokkosLapack::getrf(space, A, Ipiv, Info);
+    Kokkos::fence();
+    Kokkos::deep_copy(h_A, A);
+
+    auto h_Ipiv = Kokkos::create_mirror_view(Ipiv);
+    Kokkos::deep_copy(h_Ipiv, Ipiv);
+
+    Kokkos::View<double**, Kokkos::DefaultHostExecutionSpace> analytic("result", 3, 3);
+    analytic(0, 0) =  2.;
+    analytic(0, 1) = -1.;
+    analytic(0, 2) =  0.;
+    analytic(1, 0) = -1. / 2.;
+    analytic(1, 1) =  3. / 2.;
+    analytic(1, 2) = -1;
+    analytic(2, 0) =  0.;
+    analytic(2, 1) = -2. / 3.;
+    analytic(2, 2) =  4. / 3.;
+
+    for (int rowIdx = 0; rowIdx < A.extent_int(0); ++rowIdx) {
+      for (int colIdx = 0; colIdx < A.extent_int(1); ++colIdx) {
+        if (KAT::abs(h_A(rowIdx, colIdx) - analytic(rowIdx, colIdx)) >
+            KAT::abs(analytic(rowIdx, colIdx)) * 10 * KAT::epsilon()) {
+          std::cout << "Error: h_A(" << rowIdx << ", " << colIdx << ")=" << h_A(rowIdx, colIdx) << ", analytic is "
+                    << analytic(rowIdx, colIdx) << std::endl;
+          correct = false;
+        }
+      }
+    }
+    if (correct) std::cout << "KokkosLapack::getrf() returned correct results!" << std::endl;
+  }
+  Kokkos::finalize();
+}

--- a/example/docs/lapack/KokkosLapack_docs_getrf.cpp
+++ b/example/docs/lapack/KokkosLapack_docs_getrf.cpp
@@ -16,16 +16,16 @@ int main(void) {
     Kokkos::View<int*, Kokkos::LayoutLeft> Ipiv("tau", 3);
     Kokkos::View<int*, Kokkos::LayoutLeft> Info("Info", 1);
 
-    auto h_A = Kokkos::create_mirror_view(A);
+    auto h_A  = Kokkos::create_mirror_view(A);
     h_A(0, 0) = -1;
-    h_A(0, 1) =  2;
+    h_A(0, 1) = 2;
     h_A(0, 2) = -1;
-    h_A(1, 0) =  2;
+    h_A(1, 0) = 2;
     h_A(1, 1) = -1;
-    h_A(1, 2) =  0;
-    h_A(2, 0) =  0;
+    h_A(1, 2) = 0;
+    h_A(2, 0) = 0;
     h_A(2, 1) = -1;
-    h_A(2, 2) =  2;
+    h_A(2, 2) = 2;
     Kokkos::deep_copy(A, h_A);
 
     execution_space space{};
@@ -37,15 +37,15 @@ int main(void) {
     Kokkos::deep_copy(h_Ipiv, Ipiv);
 
     Kokkos::View<double**, Kokkos::DefaultHostExecutionSpace> analytic("result", 3, 3);
-    analytic(0, 0) =  2.;
+    analytic(0, 0) = 2.;
     analytic(0, 1) = -1.;
-    analytic(0, 2) =  0.;
+    analytic(0, 2) = 0.;
     analytic(1, 0) = -1. / 2.;
-    analytic(1, 1) =  3. / 2.;
+    analytic(1, 1) = 3. / 2.;
     analytic(1, 2) = -1;
-    analytic(2, 0) =  0.;
+    analytic(2, 0) = 0.;
     analytic(2, 1) = -2. / 3.;
-    analytic(2, 2) =  4. / 3.;
+    analytic(2, 2) = 4. / 3.;
 
     for (int rowIdx = 0; rowIdx < A.extent_int(0); ++rowIdx) {
       for (int colIdx = 0; colIdx < A.extent_int(1); ++colIdx) {

--- a/lapack/CMakeLists.txt
+++ b/lapack/CMakeLists.txt
@@ -61,3 +61,9 @@ gen_lapack_eti(Lapack_gemqr gemqr)
 gen_lapack_eti(Lapack_gegqr gegqr)
 gen_lapack_eti(Lapack_potrf potrf)
 gen_lapack_eti(Lapack_potrs potrs)
+
+kokkoskernels_generate_eti(Lapack_getrf getrf
+  COMPONENTS  lapack
+  HEADER_LIST ETI_HEADERS
+  SOURCE_LIST SOURCES
+  TYPE_LISTS  FLOATS ORDINALS LAYOUTS DEVICES)

--- a/lapack/eti/generated_specializations_cpp/getrf/KokkosLapack_getrf_eti_spec_inst.cpp.in
+++ b/lapack/eti/generated_specializations_cpp/getrf/KokkosLapack_getrf_eti_spec_inst.cpp.in
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+
+#define KOKKOSKERNELS_IMPL_COMPILE_LIBRARY true
+#include "KokkosKernels_config.h"
+#include "KokkosLapack_getrf_spec.hpp"
+
+namespace KokkosLapack {
+namespace Impl {
+@LAPACK_GETRF_ETI_INST_BLOCK@
+  } //IMPL 
+} //Kokkos

--- a/lapack/eti/generated_specializations_hpp/KokkosLapack_getrf_eti_spec_avail.hpp.in
+++ b/lapack/eti/generated_specializations_hpp/KokkosLapack_getrf_eti_spec_avail.hpp.in
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#ifndef KOKKOSLAPACK_GETRF_ETI_SPEC_AVAIL_HPP_
+#define KOKKOSLAPACK_GETRF_ETI_SPEC_AVAIL_HPP_
+namespace KokkosLapack {
+namespace Impl {
+@LAPACK_GETRF_ETI_AVAIL_BLOCK@
+  } //IMPL 
+} //Kokkos
+#endif

--- a/lapack/eti/generated_specializations_hpp/KokkosLapack_getrf_eti_spec_decl.hpp.in
+++ b/lapack/eti/generated_specializations_hpp/KokkosLapack_getrf_eti_spec_decl.hpp.in
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#ifndef KOKKOSLAPACK_GETRF_ETI_SPEC_DECL_HPP_
+#define KOKKOSLAPACK_GETRF_ETI_SPEC_DECL_HPP_
+namespace KokkosLapack {
+namespace Impl {
+@LAPACK_GETRF_ETI_DECL_BLOCK@
+  } //IMPL 
+} //Kokkos
+#endif

--- a/lapack/impl/KokkosLapack_getrf_impl.hpp
+++ b/lapack/impl/KokkosLapack_getrf_impl.hpp
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#ifndef KOKKOSLAPACK_IMPL_GETRF_HPP_
+#define KOKKOSLAPACK_IMPL_GETRF_HPP_
+
+/// \file KokkosLapack_getrf_impl.hpp
+/// \brief Implementation(s) of LU factorization.
+
+#include <KokkosKernels_config.h>
+#include <KokkosKernels_ArithTraits.hpp>
+
+namespace KokkosLapack {
+namespace Impl {
+
+// NOTE: Might add the implementation of KokkosLapack::getrf later
+
+}  // namespace Impl
+}  // namespace KokkosLapack
+
+#endif  // KOKKOSLAPACK_IMPL_GETRF_HPP

--- a/lapack/impl/KokkosLapack_getrf_spec.hpp
+++ b/lapack/impl/KokkosLapack_getrf_spec.hpp
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#ifndef KOKKOSLAPACK_IMPL_GETRF_SPEC_HPP_
+#define KOKKOSLAPACK_IMPL_GETRF_SPEC_HPP_
+
+#include <KokkosKernels_config.h>
+#include <Kokkos_Core.hpp>
+#include <KokkosKernels_ArithTraits.hpp>
+
+// Include the actual functors
+#if !defined(KOKKOSKERNELS_ETI_ONLY) || KOKKOSKERNELS_IMPL_COMPILE_LIBRARY
+#include <KokkosLapack_getrf_impl.hpp>
+#endif
+
+namespace KokkosLapack {
+namespace Impl {
+// Specialization struct which defines whether a specialization exists
+template <class ExecutionSpace, class AMatrix, class IpivView, class InfoView>
+struct getrf_eti_spec_avail {
+  enum : bool { value = false };
+};
+}  // namespace Impl
+}  // namespace KokkosLapack
+
+//
+// Macro for declaration of full specialization availability
+// KokkosLapack::Impl::GETRF.  This is NOT for users!!!  All
+// the declarations of full specializations go in this header file.
+// We may spread out definitions (see _INST macro below) across one or
+// more .cpp files.
+//
+#define KOKKOSLAPACK_GETRF_ETI_SPEC_AVAIL(SCALAR_TYPE, ORDINAL_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, MEM_SPACE_TYPE) \
+  template <>                                                                                        \
+  struct getrf_eti_spec_avail<                                                                       \
+      EXEC_SPACE_TYPE,                                                                               \
+      Kokkos::View<SCALAR_TYPE **, LAYOUT_TYPE, Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,     \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                         \
+      Kokkos::View<ORDINAL_TYPE *, LAYOUT_TYPE, Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,     \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                         \
+      Kokkos::View<int *, LAYOUT_TYPE, Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,              \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>> {                                       \
+    enum : bool { value = true };                                                                    \
+  };
+
+// Include the actual specialization declarations
+#include <KokkosLapack_getrf_tpl_spec_avail.hpp>
+#include <generated_specializations_hpp/KokkosLapack_getrf_eti_spec_avail.hpp>
+
+namespace KokkosLapack {
+namespace Impl {
+
+// Unification layer
+template <class ExecutionSpace, class AMatrix, class IpivView, class InfoView,
+          bool tpl_spec_avail = getrf_tpl_spec_avail<ExecutionSpace, AMatrix, IpivView, InfoView>::value,
+          bool eti_spec_avail = getrf_eti_spec_avail<ExecutionSpace, AMatrix, IpivView, InfoView>::value>
+struct GETRF {
+  static void getrf(const ExecutionSpace &space, const AMatrix &A, const IpivView &Ipiv, const InfoView &info);
+};
+
+#if !defined(KOKKOSKERNELS_ETI_ONLY) || KOKKOSKERNELS_IMPL_COMPILE_LIBRARY
+// Unification layer
+template <class ExecutionSpace, class AMatrix, class IpivView, class InfoView>
+struct GETRF<ExecutionSpace, AMatrix, IpivView, InfoView, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
+  static void getrf(const ExecutionSpace & /* space */, const AMatrix & /* A */, const IpivView & /* Tau */,
+                    const InfoView & /* Info */) {
+    // NOTE: Might add the implementation of KokkosLapack::getrf later
+    throw std::runtime_error(
+        "No fallback implementation of GETRF (general LU factorization) "
+        "exists. Enable LAPACK, CUSOLVER, ROCSOLVER or MAGMA TPL.");
+  }
+};
+
+#endif
+}  // namespace Impl
+}  // namespace KokkosLapack
+
+//
+// Macro for declaration of full specialization of
+// KokkosLapack::Impl::GETRF.  This is NOT for users!!!  All
+// the declarations of full specializations go in this header file.
+// We may spread out definitions (see _DEF macro below) across one or
+// more .cpp files.
+//
+#define KOKKOSLAPACK_GETRF_ETI_SPEC_DECL(SCALAR_TYPE, ORDINAL_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, MEM_SPACE_TYPE) \
+  extern template struct GETRF<                                                                     \
+      EXEC_SPACE_TYPE,                                                                              \
+      Kokkos::View<SCALAR_TYPE **, LAYOUT_TYPE, Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,    \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                        \
+      Kokkos::View<ORDINAL_TYPE *, LAYOUT_TYPE, Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,     \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                        \
+      Kokkos::View<int *, LAYOUT_TYPE, Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,             \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                        \
+      false, true>;
+
+#define KOKKOSLAPACK_GETRF_ETI_SPEC_INST(SCALAR_TYPE, ORDINAL_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, MEM_SPACE_TYPE) \
+  template struct GETRF<EXEC_SPACE_TYPE,                                                                           \
+                        Kokkos::View<SCALAR_TYPE **, LAYOUT_TYPE, Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
+                                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                     \
+                        Kokkos::View<ORDINAL_TYPE *, LAYOUT_TYPE, Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,  \
+                                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                     \
+                        Kokkos::View<int *, LAYOUT_TYPE, Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,          \
+                                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                     \
+                        false, true>;
+
+#include <KokkosLapack_getrf_tpl_spec_decl.hpp>
+
+#endif  // KOKKOSLAPACK_IMPL_GETRF_SPEC_HPP_

--- a/lapack/impl/KokkosLapack_getrf_spec.hpp
+++ b/lapack/impl/KokkosLapack_getrf_spec.hpp
@@ -31,16 +31,16 @@ struct getrf_eti_spec_avail {
 // more .cpp files.
 //
 #define KOKKOSLAPACK_GETRF_ETI_SPEC_AVAIL(SCALAR_TYPE, ORDINAL_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, MEM_SPACE_TYPE) \
-  template <>                                                                                        \
-  struct getrf_eti_spec_avail<                                                                       \
-      EXEC_SPACE_TYPE,                                                                               \
-      Kokkos::View<SCALAR_TYPE **, LAYOUT_TYPE, Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,     \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                         \
-      Kokkos::View<ORDINAL_TYPE *, LAYOUT_TYPE, Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,     \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                         \
-      Kokkos::View<int *, LAYOUT_TYPE, Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,              \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>> {                                       \
-    enum : bool { value = true };                                                                    \
+  template <>                                                                                                      \
+  struct getrf_eti_spec_avail<                                                                                     \
+      EXEC_SPACE_TYPE,                                                                                             \
+      Kokkos::View<SCALAR_TYPE **, LAYOUT_TYPE, Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                   \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                       \
+      Kokkos::View<ORDINAL_TYPE *, LAYOUT_TYPE, Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                   \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                       \
+      Kokkos::View<int *, LAYOUT_TYPE, Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                            \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>> {                                                     \
+    enum : bool { value = true };                                                                                  \
   };
 
 // Include the actual specialization declarations
@@ -83,21 +83,21 @@ struct GETRF<ExecutionSpace, AMatrix, IpivView, InfoView, false, KOKKOSKERNELS_I
 // more .cpp files.
 //
 #define KOKKOSLAPACK_GETRF_ETI_SPEC_DECL(SCALAR_TYPE, ORDINAL_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, MEM_SPACE_TYPE) \
-  extern template struct GETRF<                                                                     \
-      EXEC_SPACE_TYPE,                                                                              \
-      Kokkos::View<SCALAR_TYPE **, LAYOUT_TYPE, Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,    \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                        \
-      Kokkos::View<ORDINAL_TYPE *, LAYOUT_TYPE, Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,     \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                        \
-      Kokkos::View<int *, LAYOUT_TYPE, Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,             \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                        \
+  extern template struct GETRF<                                                                                   \
+      EXEC_SPACE_TYPE,                                                                                            \
+      Kokkos::View<SCALAR_TYPE **, LAYOUT_TYPE, Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                  \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                      \
+      Kokkos::View<ORDINAL_TYPE *, LAYOUT_TYPE, Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                  \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                      \
+      Kokkos::View<int *, LAYOUT_TYPE, Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,                           \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                      \
       false, true>;
 
-#define KOKKOSLAPACK_GETRF_ETI_SPEC_INST(SCALAR_TYPE, ORDINAL_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, MEM_SPACE_TYPE) \
+#define KOKKOSLAPACK_GETRF_ETI_SPEC_INST(SCALAR_TYPE, ORDINAL_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, MEM_SPACE_TYPE)  \
   template struct GETRF<EXEC_SPACE_TYPE,                                                                           \
                         Kokkos::View<SCALAR_TYPE **, LAYOUT_TYPE, Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
                                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                     \
-                        Kokkos::View<ORDINAL_TYPE *, LAYOUT_TYPE, Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,  \
+                        Kokkos::View<ORDINAL_TYPE *, LAYOUT_TYPE, Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>, \
                                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                     \
                         Kokkos::View<int *, LAYOUT_TYPE, Kokkos::Device<EXEC_SPACE_TYPE, MEM_SPACE_TYPE>,          \
                                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                     \

--- a/lapack/src/KokkosLapack_getrf.hpp
+++ b/lapack/src/KokkosLapack_getrf.hpp
@@ -12,8 +12,9 @@
 
 #include <type_traits>
 
-#include "KokkosLapack_getrf_spec.hpp"
-#include "KokkosKernels_Error.hpp"
+#include <KokkosLapack_getrf_spec.hpp>
+#include <KokkosKernels_Error.hpp>
+#include <KokkosKernels_helpers.hpp>
 
 namespace KokkosLapack {
 

--- a/lapack/src/KokkosLapack_getrf.hpp
+++ b/lapack/src/KokkosLapack_getrf.hpp
@@ -82,15 +82,17 @@ void getrf(const ExecutionSpace& space, const AMatrix& A, const IpivView& Ipiv, 
     return;
   }
 
-  using ALayout           = typename AMatrix::array_layout;
-  using AMatrix_Internal  = Kokkos::View<typename AMatrix::non_const_value_type**, ALayout, typename AMatrix::device_type,
-					 Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
-  using IpivView_Internal = Kokkos::View<typename IpivView::non_const_value_type*,
-					 typename KokkosKernels::Impl::GetUnifiedLayoutPreferring<IpivView, ALayout>::array_layout,
-					 typename IpivView::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
-  using InfoView_Internal = Kokkos::View<typename InfoView::non_const_value_type*,
-					 typename KokkosKernels::Impl::GetUnifiedLayoutPreferring<InfoView, ALayout>::array_layout,
-                                         typename InfoView::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+  using ALayout          = typename AMatrix::array_layout;
+  using AMatrix_Internal = Kokkos::View<typename AMatrix::non_const_value_type**, ALayout,
+                                        typename AMatrix::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+  using IpivView_Internal =
+      Kokkos::View<typename IpivView::non_const_value_type*,
+                   typename KokkosKernels::Impl::GetUnifiedLayoutPreferring<IpivView, ALayout>::array_layout,
+                   typename IpivView::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+  using InfoView_Internal =
+      Kokkos::View<typename InfoView::non_const_value_type*,
+                   typename KokkosKernels::Impl::GetUnifiedLayoutPreferring<InfoView, ALayout>::array_layout,
+                   typename InfoView::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
 
   AMatrix_Internal A_i     = A;
   IpivView_Internal Ipiv_i = Ipiv;

--- a/lapack/src/KokkosLapack_getrf.hpp
+++ b/lapack/src/KokkosLapack_getrf.hpp
@@ -20,9 +20,9 @@ namespace KokkosLapack {
 /// \brief Computes a LU factorization of a matrix A
 ///
 /// \tparam ExecutionSpace The space where the kernel will run.
-/// \tparam AMatrix   Type of matrix A, as a 2-D Kokkos::View.
-/// \tparam TauArray  Type of array Tau, as a 1-D Kokkos::View.
-/// \tparam InfoArray Type of array Info, as a 1-D Kokkos::View.
+/// \tparam AMatrix   Type of matrix A, as a rank-2 Kokkos::View.
+/// \tparam IpivView  Type of array Ipiv, as a rank-1 Kokkos::View.
+/// \tparam InfoView  Type of array Info, as a rank-1 Kokkos::View.
 ///
 /// \param A [in,out] On entry, the M-by-N matrix to be decomposed.
 ///                   On exit, the L and U factors with L diagaonal assumed
@@ -66,7 +66,7 @@ void getrf(const ExecutionSpace& space, const AMatrix& A, const IpivView& Ipiv, 
   if (ipiv0 != std::min(m, n)) {
     std::ostringstream os;
     os << "KokkosLapack::getrf: length of Ipiv must be equal to min(m,n): "
-       << " A: " << m << " x " << n << ", Ipiv length = " << tau0;
+       << " A: " << m << " x " << n << ", Ipiv length = " << ipiv0;
     KokkosKernels::Impl::throw_runtime_exception(os.str());
   }
 
@@ -76,11 +76,14 @@ void getrf(const ExecutionSpace& space, const AMatrix& A, const IpivView& Ipiv, 
     KokkosKernels::Impl::throw_runtime_exception(os.str());
   }
 
-  using AMatrix_Internal  = Kokkos::View<typename AMatrix::non_const_value_type**, typename AMatrix::array_layout,
-                                        typename AMatrix::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
-  using IpivView_Internal = Kokkos::View<typename IpivView::non_const_value_type*, typename IpivView::array_layout,
-                                        typename IpivView::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
-  using InfoView_Internal = Kokkos::View<typename InfoView::non_const_value_type*, typename InfoView::array_layout,
+  using ALayout           = typename AMatrix::array_layout;
+  using AMatrix_Internal  = Kokkos::View<typename AMatrix::non_const_value_type**, ALayout, typename AMatrix::device_type,
+					 Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+  using IpivView_Internal = Kokkos::View<typename IpivView::non_const_value_type*,
+					 typename KokkosKernels::Impl::GetUnifiedLayoutPreferring<IpivView, ALayout>::array_layout,
+					 typename IpivView::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+  using InfoView_Internal = Kokkos::View<typename InfoView::non_const_value_type*,
+					 typename KokkosKernels::Impl::GetUnifiedLayoutPreferring<InfoView, ALayout>::array_layout,
                                          typename InfoView::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
 
   AMatrix_Internal A_i     = A;

--- a/lapack/src/KokkosLapack_getrf.hpp
+++ b/lapack/src/KokkosLapack_getrf.hpp
@@ -25,7 +25,7 @@ namespace KokkosLapack {
 /// \tparam InfoView  Type of array Info, as a rank-1 Kokkos::View.
 ///
 /// \param A [in,out] On entry, the M-by-N matrix to be decomposed.
-///                   On exit, the L and U factors with L diagaonal assumed
+///                   On exit, the L and U factors with L diagonal assumed
 ///                   to be unit.
 /// \param Ipiv [out] One-dimensional array of size min(M,N) that contains the
 ///                   pivot ordering selected for the decomposition.
@@ -36,9 +36,9 @@ namespace KokkosLapack {
 ///
 template <class ExecutionSpace, class AMatrix, class IpivView, class InfoView>
 void getrf(const ExecutionSpace& space, const AMatrix& A, const IpivView& Ipiv, const InfoView& Info) {
-  // NOTE: Currently, KokkosLapack::getrf only supports LAPACK, MAGMA and
+  // NOTE: Currently, KokkosLapack::getrf only supports LAPACK, cuSOLVER and
   // rocSOLVER TPLs.
-  //       MAGMA/rocSOLVER TPL should be enabled to call the MAGMA/rocSOLVER GPU
+  //       cuSOLVER/rocSOLVER TPL should be enabled to call the cuSOLVER/rocSOLVER GPU
   //       interface for device views LAPACK TPL should be enabled to call the
   //       LAPACK interface for host views
 
@@ -77,7 +77,10 @@ void getrf(const ExecutionSpace& space, const AMatrix& A, const IpivView& Ipiv, 
   }
 
   // Check for possible quick return
-  if (A.extent(0) == 0 || A.extent(1) == 0) return;
+  if (A.extent(0) == 0 || A.extent(1) == 0) {
+    Kokkos::deep_copy(space, Info, 0);
+    return;
+  }
 
   using ALayout           = typename AMatrix::array_layout;
   using AMatrix_Internal  = Kokkos::View<typename AMatrix::non_const_value_type**, ALayout, typename AMatrix::device_type,

--- a/lapack/src/KokkosLapack_getrf.hpp
+++ b/lapack/src/KokkosLapack_getrf.hpp
@@ -76,6 +76,9 @@ void getrf(const ExecutionSpace& space, const AMatrix& A, const IpivView& Ipiv, 
     KokkosKernels::Impl::throw_runtime_exception(os.str());
   }
 
+  // Check for possible quick return
+  if (A.extent(0) == 0 || A.extent(1) == 0) return;
+
   using ALayout           = typename AMatrix::array_layout;
   using AMatrix_Internal  = Kokkos::View<typename AMatrix::non_const_value_type**, ALayout, typename AMatrix::device_type,
 					 Kokkos::MemoryTraits<Kokkos::Unmanaged>>;

--- a/lapack/src/KokkosLapack_getrf.hpp
+++ b/lapack/src/KokkosLapack_getrf.hpp
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+/// \file KokkosLapack_getrf.hpp
+/// \brief LU factorization
+///
+/// This file provides KokkosLapack::getrf. This function performs a
+/// local (no MPI) LU factorization of a M-by-N matrix A.
+
+#ifndef KOKKOSLAPACK_GETRF_HPP_
+#define KOKKOSLAPACK_GETRF_HPP_
+
+#include <type_traits>
+
+#include "KokkosLapack_getrf_spec.hpp"
+#include "KokkosKernels_Error.hpp"
+
+namespace KokkosLapack {
+
+/// \brief Computes a LU factorization of a matrix A
+///
+/// \tparam ExecutionSpace The space where the kernel will run.
+/// \tparam AMatrix   Type of matrix A, as a 2-D Kokkos::View.
+/// \tparam TauArray  Type of array Tau, as a 1-D Kokkos::View.
+/// \tparam InfoArray Type of array Info, as a 1-D Kokkos::View.
+///
+/// \param A [in,out] On entry, the M-by-N matrix to be decomposed.
+///                   On exit, the L and U factors with L diagaonal assumed
+///                   to be unit.
+/// \param Ipiv [out] One-dimensional array of size min(M,N) that contains the
+///                   pivot ordering selected for the decomposition.
+/// \param Info [out] One-dimensional array of integers and of size 1:
+///                   Info[0] = 0: successful exit
+///                   Info[0] < 0: if equal to '-i', the i-th argument had an
+///                                illegal value
+///
+template <class ExecutionSpace, class AMatrix, class IpivView, class InfoView>
+void getrf(const ExecutionSpace& space, const AMatrix& A, const IpivView& Ipiv, const InfoView& Info) {
+  // NOTE: Currently, KokkosLapack::getrf only supports LAPACK, MAGMA and
+  // rocSOLVER TPLs.
+  //       MAGMA/rocSOLVER TPL should be enabled to call the MAGMA/rocSOLVER GPU
+  //       interface for device views LAPACK TPL should be enabled to call the
+  //       LAPACK interface for host views
+
+  static_assert(Kokkos::SpaceAccessibility<ExecutionSpace, typename AMatrix::memory_space>::accessible);
+  static_assert(Kokkos::SpaceAccessibility<ExecutionSpace, typename IpivView::memory_space>::accessible);
+  static_assert(Kokkos::SpaceAccessibility<ExecutionSpace, typename InfoView::memory_space>::accessible);
+
+  static_assert(Kokkos::is_view<AMatrix>::value, "KokkosLapack::getrf: A must be a Kokkos::View.");
+  static_assert(Kokkos::is_view<IpivView>::value, "KokkosLapack::getrf: Ipiv must be Kokkos::View.");
+  static_assert(Kokkos::is_view<InfoView>::value, "KokkosLapack::getrf: Info must be Kokkos::View.");
+
+  static_assert(static_cast<int>(AMatrix::rank) == 2, "KokkosLapack::getrf: A must have rank 2.");
+  static_assert(static_cast<int>(IpivView::rank) == 1, "KokkosLapack::getrf: Ipiv must have rank 1.");
+  static_assert(static_cast<int>(InfoView::rank) == 1, "KokkosLapack::getrf: Info must have rank 1.");
+
+  static_assert(std::is_same_v<typename InfoView::non_const_value_type, int>,
+                "KokkosLapack::getrf: Info must be an array of integers.");
+
+  const int64_t m     = A.extent(0);
+  const int64_t n     = A.extent(1);
+  const int64_t ipiv0 = Ipiv.extent(0);
+  const int64_t info0 = Info.extent(0);
+
+  // Check validity of dimensions
+  if (ipiv0 != std::min(m, n)) {
+    std::ostringstream os;
+    os << "KokkosLapack::getrf: length of Ipiv must be equal to min(m,n): "
+       << " A: " << m << " x " << n << ", Ipiv length = " << tau0;
+    KokkosKernels::Impl::throw_runtime_exception(os.str());
+  }
+
+  if (info0 < 1) {
+    std::ostringstream os;
+    os << "KokkosLapack::getrf: length of Info must be at least 1, Info length = " << info0;
+    KokkosKernels::Impl::throw_runtime_exception(os.str());
+  }
+
+  using AMatrix_Internal  = Kokkos::View<typename AMatrix::non_const_value_type**, typename AMatrix::array_layout,
+                                        typename AMatrix::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+  using IpivView_Internal = Kokkos::View<typename IpivView::non_const_value_type*, typename IpivView::array_layout,
+                                        typename IpivView::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+  using InfoView_Internal = Kokkos::View<typename InfoView::non_const_value_type*, typename InfoView::array_layout,
+                                         typename InfoView::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+
+  AMatrix_Internal A_i     = A;
+  IpivView_Internal Ipiv_i = Ipiv;
+  InfoView_Internal Info_i = Info;
+
+  KokkosLapack::Impl::GETRF<ExecutionSpace, AMatrix_Internal, IpivView_Internal, InfoView_Internal>::getrf(
+      space, A_i, Ipiv_i, Info_i);
+}
+
+/// \brief Computes a LU factorization of a matrix A
+///
+/// \tparam AMatrix   Type of matrix A, as a rank-2 Kokkos::View.
+/// \tparam IpivView  Type of array Ipiv, as a rank-1 Kokkos::View.
+/// \tparam InfoView  Type of array Info, as a rank-1 Kokkos::View.
+///
+/// \param A [in,out] On entry, the M-by-N matrix to be decomposed.
+///                   On exit, the L and U factors with L diagaonal assumed
+///                   to be unit.
+/// \param Ipiv [out] rank-1 view of size min(M,N) that contains the
+///                   pivot ordering selected for the decomposition.
+/// \param Info [out] rank-1 view of integers and of size 1:
+///                   Info[0] = 0: successful exit
+///                   Info[0] < 0: if equal to '-i', the i-th argument had an
+///                                illegal value
+///
+template <class AMatrix, class IpivView, class InfoView>
+void getrf(const AMatrix& A, const IpivView& Ipiv, const InfoView& Info) {
+  typename AMatrix::execution_space space{};
+  getrf(space, A, Ipiv, Info);
+}
+
+}  // namespace KokkosLapack
+
+#endif  // KOKKOSLAPACK_GETRF_HPP_

--- a/lapack/tpls/KokkosLapack_Host_tpl.cpp
+++ b/lapack/tpls/KokkosLapack_Host_tpl.cpp
@@ -262,7 +262,7 @@ int HostLapack<float>::potrs(const char uplo, const int n, const int nrhs, const
 }
 
 template <>
-void HostLapack<float>::getrf(const int m, const int n, float *a, const int lda, int *ipiv, int *info) {
+void HostLapack<float>::getrf(const int m, const int n, float* a, const int lda, int* ipiv, int* info) {
 #if defined(KOKKOSKERNELS_ENABLE_TPL_ACCELERATE)
   sgetrf_(&m, &n, a, &lda, ipiv, info);
 #else
@@ -359,7 +359,7 @@ void HostLapack<double>::gegqr(const int m, const int n, const int k, double* a,
 }
 
 template <>
-void HostLapack<double>::getrf(const int m, const int n, double *a, const int lda, int *ipiv, int *info) {
+void HostLapack<double>::getrf(const int m, const int n, double* a, const int lda, int* ipiv, int* info) {
 #if defined(KOKKOSKERNELS_ENABLE_TPL_ACCELERATE)
   dgetrf_(&m, &n, a, &lda, ipiv, info);
 #else
@@ -457,7 +457,8 @@ int HostLapack<std::complex<float>>::potrs(const char uplo, const int n, const i
 }
 
 template <>
-void HostLapack<std::complex<float>>::getrf(const int m, const int n, std::complex<float> *a, const int lda, int *ipiv, int *info) {
+void HostLapack<std::complex<float>>::getrf(const int m, const int n, std::complex<float>* a, const int lda, int* ipiv,
+                                            int* info) {
 #if defined(KOKKOSKERNELS_ENABLE_TPL_ACCELERATE)
   cgetrf_(&m, &n, a, &lda, ipiv, info);
 #else
@@ -556,7 +557,8 @@ int HostLapack<std::complex<double>>::potrs(const char uplo, const int n, const 
 }
 
 template <>
-void HostLapack<std::complex<double>>::getrf(const int m, const int n, std::complex<double> *a, const int lda, int *ipiv, int *info) {
+void HostLapack<std::complex<double>>::getrf(const int m, const int n, std::complex<double>* a, const int lda,
+                                             int* ipiv, int* info) {
 #if defined(KOKKOSKERNELS_ENABLE_TPL_ACCELERATE)
   zgetrf_(&m, &n, a, &lda, ipiv, info);
 #else

--- a/lapack/tpls/KokkosLapack_Host_tpl.cpp
+++ b/lapack/tpls/KokkosLapack_Host_tpl.cpp
@@ -114,6 +114,15 @@ void F77_BLAS_MANGLE(cpotrs, CPOTRS)(const char*, const int*, const int*, const 
                                      std::complex<float>*, const int*, int*);
 void F77_BLAS_MANGLE(zpotrs, ZPOTRS)(const char*, const int*, const int*, const std::complex<double>*, const int*,
                                      std::complex<double>*, const int*, int*);
+
+///
+/// Getrf
+///
+
+void F77_BLAS_MANGLE(sgetrf, SGETRF)(const int*, const int*, float*, const int*, int*, int*);
+void F77_BLAS_MANGLE(dgetrf, DGETRF)(const int*, const int*, double*, const int*, int*, int*);
+void F77_BLAS_MANGLE(cgetrf, CGETRF)(const int*, const int*, std::complex<float>*, const int*, int*, int*);
+void F77_BLAS_MANGLE(zgetrf, ZGETRF)(const int*, const int*, std::complex<double>*, const int*, int*, int*);
 }
 
 #define F77_FUNC_SGESV F77_BLAS_MANGLE(sgesv, SGESV)
@@ -155,6 +164,11 @@ void F77_BLAS_MANGLE(zpotrs, ZPOTRS)(const char*, const int*, const int*, const 
 #define F77_FUNC_DPOTRS F77_BLAS_MANGLE(dpotrs, DPOTRS)
 #define F77_FUNC_CPOTRS F77_BLAS_MANGLE(cpotrs, CPOTRS)
 #define F77_FUNC_ZPOTRS F77_BLAS_MANGLE(zpotrs, ZPOTRS)
+
+#define F77_FUNC_SGETRF F77_BLAS_MANGLE(sgetrf, SGETRF)
+#define F77_FUNC_DGETRF F77_BLAS_MANGLE(dgetrf, DGETRF)
+#define F77_FUNC_CGETRF F77_BLAS_MANGLE(cgetrf, CGETRF)
+#define F77_FUNC_ZGETRF F77_BLAS_MANGLE(zgetrf, ZGETRF)
 
 #endif  // KOKKOSKERNELS_ENABLE_TPL_LAPACK
 
@@ -247,6 +261,15 @@ int HostLapack<float>::potrs(const char uplo, const int n, const int nrhs, const
   return info;
 }
 
+template <>
+void HostLapack<float>::getrf(const int m, const int n, float *a, const int lda, int *ipiv, int *info) {
+#if defined(KOKKOSKERNELS_ENABLE_TPL_ACCELERATE)
+  sgetrf_(&m, &n, a, &lda, ipiv, info);
+#else
+  F77_FUNC_SGETRF(&m, &n, a, &lda, ipiv, info);
+#endif
+}
+
 ///
 /// double
 ///
@@ -332,6 +355,15 @@ void HostLapack<double>::gegqr(const int m, const int n, const int k, double* a,
   dorgqr_(&m, &n, &k, a, &lda, tau, work, &lwork, info);
 #else
   F77_FUNC_DORGQR(&m, &n, &k, a, &lda, tau, work, &lwork, info);
+#endif
+}
+
+template <>
+void HostLapack<double>::getrf(const int m, const int n, double *a, const int lda, int *ipiv, int *info) {
+#if defined(KOKKOSKERNELS_ENABLE_TPL_ACCELERATE)
+  dgetrf_(&m, &n, a, &lda, ipiv, info);
+#else
+  F77_FUNC_DGETRF(&m, &n, a, &lda, ipiv, info);
 #endif
 }
 
@@ -424,6 +456,15 @@ int HostLapack<std::complex<float>>::potrs(const char uplo, const int n, const i
   return info;
 }
 
+template <>
+void HostLapack<std::complex<float>>::getrf(const int m, const int n, std::complex<float> *a, const int lda, int *ipiv, int *info) {
+#if defined(KOKKOSKERNELS_ENABLE_TPL_ACCELERATE)
+  cgetrf_(&m, &n, a, &lda, ipiv, info);
+#else
+  F77_FUNC_CGETRF(&m, &n, a, &lda, ipiv, info);
+#endif
+}
+
 ///
 /// std::complex<double>
 ///
@@ -512,6 +553,15 @@ int HostLapack<std::complex<double>>::potrs(const char uplo, const int n, const 
   F77_FUNC_ZPOTRS(&uplo, &n, &nrhs, a, &lda, b, &ldb, &info);
 #endif
   return info;
+}
+
+template <>
+void HostLapack<std::complex<double>>::getrf(const int m, const int n, std::complex<double> *a, const int lda, int *ipiv, int *info) {
+#if defined(KOKKOSKERNELS_ENABLE_TPL_ACCELERATE)
+  zgetrf_(&m, &n, a, &lda, ipiv, info);
+#else
+  F77_FUNC_ZGETRF(&m, &n, a, &lda, ipiv, info);
+#endif
 }
 
 }  // namespace Impl

--- a/lapack/tpls/KokkosLapack_Host_tpl.hpp
+++ b/lapack/tpls/KokkosLapack_Host_tpl.hpp
@@ -35,6 +35,8 @@ struct HostLapack {
   static int potrf(const char uplo, const int n, T *a, const int lda);
 
   static int potrs(const char uplo, const int n, const int nrhs, const T *a, const int lda, T *b, const int ldb);
+
+  static void getrf(const int m, const int n, T *a, const int lda, int *ipiv, int *info);
 };
 }  // namespace Impl
 }  // namespace KokkosLapack

--- a/lapack/tpls/KokkosLapack_getrf_tpl_spec_avail.hpp
+++ b/lapack/tpls/KokkosLapack_getrf_tpl_spec_avail.hpp
@@ -43,7 +43,7 @@ namespace Impl {
   struct getrf_tpl_spec_avail<                                                                                         \
       Kokkos::Cuda,                                                                                                    \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEMSPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
-      Kokkos::View<std::int64_t*, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEMSPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
+      Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEMSPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,     \
       Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEMSPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>> {   \
     enum : bool { value = true };                                                                                      \
   };

--- a/lapack/tpls/KokkosLapack_getrf_tpl_spec_avail.hpp
+++ b/lapack/tpls/KokkosLapack_getrf_tpl_spec_avail.hpp
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#ifndef KOKKOSLAPACK_GETRF_TPL_SPEC_AVAIL_HPP_
+#define KOKKOSLAPACK_GETRF_TPL_SPEC_AVAIL_HPP_
+
+namespace KokkosLapack {
+namespace Impl {
+// Specialization struct which defines whether a specialization exists
+template <class ExecutionSpace, class AMatrix, class IpivView, class InfoView>
+struct getrf_tpl_spec_avail {
+  enum : bool { value = false };
+};
+
+// Generic Host side LAPACK (could be MKL or whatever)
+#if defined(KOKKOSKERNELS_ENABLE_TPL_LAPACK) || defined(KOKKOSKERNELS_ENABLE_TPL_ACCELERATE)
+
+#define KOKKOSLAPACK_GETRF_TPL_SPEC_AVAIL_LAPACK(SCALAR, LAYOUT, MEMSPACE)                                          \
+  template <class ExecSpace>                                                                                        \
+  struct getrf_tpl_spec_avail<                                                                                      \
+      ExecSpace,                                                                                                    \
+      Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
+      Kokkos::View<std::int32_t*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
+      Kokkos::View<int*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>> {   \
+    enum : bool { value = true };                                                                                   \
+  };
+
+KOKKOSLAPACK_GETRF_TPL_SPEC_AVAIL_LAPACK(double, Kokkos::LayoutLeft, Kokkos::HostSpace)
+KOKKOSLAPACK_GETRF_TPL_SPEC_AVAIL_LAPACK(float, Kokkos::LayoutLeft, Kokkos::HostSpace)
+KOKKOSLAPACK_GETRF_TPL_SPEC_AVAIL_LAPACK(Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::HostSpace)
+KOKKOSLAPACK_GETRF_TPL_SPEC_AVAIL_LAPACK(Kokkos::complex<float>, Kokkos::LayoutLeft, Kokkos::HostSpace)
+#endif
+}  // namespace Impl
+}  // namespace KokkosLapack
+
+// CUSOLVER
+#ifdef KOKKOSKERNELS_ENABLE_TPL_CUSOLVER
+namespace KokkosLapack {
+namespace Impl {
+
+#define KOKKOSLAPACK_GETRF_TPL_SPEC_AVAIL_CUSOLVER(SCALAR, LAYOUT, MEMSPACE)                                           \
+  template <>                                                                                                          \
+  struct getrf_tpl_spec_avail<                                                                                         \
+      Kokkos::Cuda,                                                                                                    \
+      Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEMSPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
+      Kokkos::View<std::int64_t*, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEMSPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
+      Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEMSPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>> {   \
+    enum : bool { value = true };                                                                                      \
+  };
+
+KOKKOSLAPACK_GETRF_TPL_SPEC_AVAIL_CUSOLVER(double, Kokkos::LayoutLeft, Kokkos::CudaSpace)
+KOKKOSLAPACK_GETRF_TPL_SPEC_AVAIL_CUSOLVER(float, Kokkos::LayoutLeft, Kokkos::CudaSpace)
+KOKKOSLAPACK_GETRF_TPL_SPEC_AVAIL_CUSOLVER(Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::CudaSpace)
+KOKKOSLAPACK_GETRF_TPL_SPEC_AVAIL_CUSOLVER(Kokkos::complex<float>, Kokkos::LayoutLeft, Kokkos::CudaSpace)
+
+#if defined(KOKKOSKERNELS_INST_MEMSPACE_CUDAUVMSPACE)
+KOKKOSLAPACK_GETRF_TPL_SPEC_AVAIL_CUSOLVER(double, Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
+KOKKOSLAPACK_GETRF_TPL_SPEC_AVAIL_CUSOLVER(float, Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
+KOKKOSLAPACK_GETRF_TPL_SPEC_AVAIL_CUSOLVER(Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
+KOKKOSLAPACK_GETRF_TPL_SPEC_AVAIL_CUSOLVER(Kokkos::complex<float>, Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
+#endif
+
+}  // namespace Impl
+}  // namespace KokkosLapack
+#endif  // CUSOLVER
+
+#ifdef KOKKOSKERNELS_ENABLE_TPL_ROCSOLVER
+#include <rocsolver/rocsolver.h>
+
+namespace KokkosLapack {
+namespace Impl {
+
+#define KOKKOSLAPACK_GETRF_TPL_SPEC_AVAIL_ROCSOLVER(SCALAR, LAYOUT, MEMSPACE)                                \
+  template <>                                                                                                         \
+  struct getrf_tpl_spec_avail<                                                                                        \
+      Kokkos::HIP,                                                                                                    \
+      Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEMSPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
+      Kokkos::View<std::int64_t*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEMSPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
+      Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEMSPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>> {   \
+    enum : bool { value = true };                                                                                     \
+  };
+
+KOKKOSLAPACK_GETRF_TPL_SPEC_AVAIL_ROCSOLVER(double, Kokkos::LayoutLeft, Kokkos::HIPSpace)
+KOKKOSLAPACK_GETRF_TPL_SPEC_AVAIL_ROCSOLVER(float, Kokkos::LayoutLeft, Kokkos::HIPSpace)
+KOKKOSLAPACK_GETRF_TPL_SPEC_AVAIL_ROCSOLVER(Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::HIPSpace)
+KOKKOSLAPACK_GETRF_TPL_SPEC_AVAIL_ROCSOLVER(Kokkos::complex<float>, Kokkos::LayoutLeft, Kokkos::HIPSpace)
+
+}  // namespace Impl
+}  // namespace KokkosLapack
+#endif  // KOKKOSKERNELS_ENABLE_TPL_ROCSOLVER
+
+#endif

--- a/lapack/tpls/KokkosLapack_getrf_tpl_spec_avail.hpp
+++ b/lapack/tpls/KokkosLapack_getrf_tpl_spec_avail.hpp
@@ -70,12 +70,12 @@ KOKKOSLAPACK_GETRF_TPL_SPEC_AVAIL_CUSOLVER(Kokkos::complex<float>, Kokkos::Layou
 namespace KokkosLapack {
 namespace Impl {
 
-#define KOKKOSLAPACK_GETRF_TPL_SPEC_AVAIL_ROCSOLVER(SCALAR, LAYOUT, MEMSPACE)                                \
+#define KOKKOSLAPACK_GETRF_TPL_SPEC_AVAIL_ROCSOLVER(SCALAR, LAYOUT, MEMSPACE)                                         \
   template <>                                                                                                         \
   struct getrf_tpl_spec_avail<                                                                                        \
       Kokkos::HIP,                                                                                                    \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEMSPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
-      Kokkos::View<std::int64_t*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEMSPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
+      Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEMSPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,     \
       Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEMSPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>> {   \
     enum : bool { value = true };                                                                                     \
   };

--- a/lapack/tpls/KokkosLapack_getrf_tpl_spec_avail.hpp
+++ b/lapack/tpls/KokkosLapack_getrf_tpl_spec_avail.hpp
@@ -20,7 +20,7 @@ struct getrf_tpl_spec_avail {
   struct getrf_tpl_spec_avail<                                                                                      \
       ExecSpace,                                                                                                    \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
-      Kokkos::View<std::int32_t*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
+      Kokkos::View<int*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,     \
       Kokkos::View<int*, LAYOUT, Kokkos::Device<ExecSpace, MEMSPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>> {   \
     enum : bool { value = true };                                                                                   \
   };

--- a/lapack/tpls/KokkosLapack_getrf_tpl_spec_decl.hpp
+++ b/lapack/tpls/KokkosLapack_getrf_tpl_spec_decl.hpp
@@ -34,8 +34,8 @@ namespace Impl {
 
 template <class AViewType, class IpivView, class InfoView>
 void lapackGetrfWrapper(const AViewType& A, const IpivView& Ipiv, const InfoView& Info) {
-  using Scalar       = typename AViewType::non_const_value_type;
-  using ALayout_t    = typename AViewType::array_layout;
+  using Scalar    = typename AViewType::non_const_value_type;
+  using ALayout_t = typename AViewType::array_layout;
   static_assert(std::is_same_v<ALayout_t, Kokkos::LayoutLeft>,
                 "KokkosLapack - getrf: A needs to have a Kokkos::LayoutLeft");
   const int m   = A.extent_int(0);
@@ -45,8 +45,8 @@ void lapackGetrfWrapper(const AViewType& A, const IpivView& Ipiv, const InfoView
   if constexpr (KokkosKernels::ArithTraits<Scalar>::is_complex) {
     using MagType = typename KokkosKernels::ArithTraits<Scalar>::mag_type;
 
-    HostLapack<std::complex<MagType>>::getrf(m, n, reinterpret_cast<std::complex<MagType>*>(A.data()), lda,
-                                             Ipiv.data(), Info.data());
+    HostLapack<std::complex<MagType>>::getrf(m, n, reinterpret_cast<std::complex<MagType>*>(A.data()), lda, Ipiv.data(),
+                                             Info.data());
   } else {
     HostLapack<Scalar>::getrf(m, n, A.data(), lda, Ipiv.data(), Info.data());
   }
@@ -59,13 +59,13 @@ void lapackGetrfWrapper(const AViewType& A, const IpivView& Ipiv, const InfoView
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,   \
       Kokkos::View<int*, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,       \
       Kokkos::View<int*, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, true, \
-      getrf_eti_spec_avail<EXECSPACE,                                                                                  \
-                           Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>,                        \
-                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                      \
-                           Kokkos::View<int*, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>,	                       \
-                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                      \
-                           Kokkos::View<int*, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>,                            \
-                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>>::value> {                            \
+      getrf_eti_spec_avail<                                                                                            \
+          EXECSPACE,                                                                                                   \
+          Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>,                                         \
+                       Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                       \
+          Kokkos::View<int*, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,   \
+          Kokkos::View<int*, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>,                                             \
+                       Kokkos::MemoryTraits<Kokkos::Unmanaged>>>::value> {                                             \
     using AViewType =                                                                                                  \
         Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>; \
     using IpivView =                                                                                                   \
@@ -136,68 +136,68 @@ void cusolverGetrfWrapper(const ExecutionSpace& space, const AViewType& A, const
     KOKKOSLAPACK_IMPL_CUSOLVER_SAFE_CALL(cusolverDnSgetrf_bufferSize(s.handle, m, n, A.data(), lda, &lwork));
     Kokkos::View<float*, memory_space> Workspace("cusolver sgetrf workspace", lwork);
 
-    KOKKOSLAPACK_IMPL_CUSOLVER_SAFE_CALL(cusolverDnSgetrf(s.handle, m, n, A.data(), lda, Workspace.data(),
-							  Ipiv.data(), Info.data()));
+    KOKKOSLAPACK_IMPL_CUSOLVER_SAFE_CALL(
+        cusolverDnSgetrf(s.handle, m, n, A.data(), lda, Workspace.data(), Ipiv.data(), Info.data()));
   }
   if constexpr (std::is_same_v<Scalar, double>) {
     KOKKOSLAPACK_IMPL_CUSOLVER_SAFE_CALL(cusolverDnDgetrf_bufferSize(s.handle, m, n, A.data(), lda, &lwork));
     Kokkos::View<double*, memory_space> Workspace("cusolver dgetrf workspace", lwork);
 
-    KOKKOSLAPACK_IMPL_CUSOLVER_SAFE_CALL(cusolverDnDgetrf(s.handle, m, n, A.data(), lda, Workspace.data(),
-							  Ipiv.data(), Info.data()));
+    KOKKOSLAPACK_IMPL_CUSOLVER_SAFE_CALL(
+        cusolverDnDgetrf(s.handle, m, n, A.data(), lda, Workspace.data(), Ipiv.data(), Info.data()));
   }
   if constexpr (std::is_same_v<Scalar, Kokkos::complex<float>>) {
-    KOKKOSLAPACK_IMPL_CUSOLVER_SAFE_CALL(cusolverDnCgetrf_bufferSize(s.handle, m, n, reinterpret_cast<cuComplex*>(A.data()),
-								     lda, &lwork));
+    KOKKOSLAPACK_IMPL_CUSOLVER_SAFE_CALL(
+        cusolverDnCgetrf_bufferSize(s.handle, m, n, reinterpret_cast<cuComplex*>(A.data()), lda, &lwork));
     Kokkos::View<cuComplex*, memory_space> Workspace("cusolver cgetrf workspace", lwork);
 
     KOKKOSLAPACK_IMPL_CUSOLVER_SAFE_CALL(cusolverDnCgetrf(s.handle, m, n, reinterpret_cast<cuComplex*>(A.data()), lda,
-							  reinterpret_cast<cuComplex*>(Workspace.data()), Ipiv.data(),
-							  Info.data()));
+                                                          reinterpret_cast<cuComplex*>(Workspace.data()), Ipiv.data(),
+                                                          Info.data()));
   }
   if constexpr (std::is_same_v<Scalar, Kokkos::complex<double>>) {
-    KOKKOSLAPACK_IMPL_CUSOLVER_SAFE_CALL(cusolverDnZgetrf_bufferSize(s.handle, m, n, reinterpret_cast<cuDoubleComplex*>(A.data()),
-								     lda, &lwork));
+    KOKKOSLAPACK_IMPL_CUSOLVER_SAFE_CALL(
+        cusolverDnZgetrf_bufferSize(s.handle, m, n, reinterpret_cast<cuDoubleComplex*>(A.data()), lda, &lwork));
     Kokkos::View<cuDoubleComplex*, memory_space> Workspace("cusolver zgetrf workspace", lwork);
 
     KOKKOSLAPACK_IMPL_CUSOLVER_SAFE_CALL(cusolverDnZgetrf(s.handle, m, n, reinterpret_cast<cuDoubleComplex*>(A.data()),
                                                           lda, reinterpret_cast<cuDoubleComplex*>(Workspace.data()),
-							  Ipiv.data(), Info.data()));
+                                                          Ipiv.data(), Info.data()));
   }
   KOKKOSLAPACK_IMPL_CUSOLVER_SAFE_CALL(cusolverDnSetStream(s.handle, NULL));
 }
 
-#define KOKKOSLAPACK_GETRF_CUSOLVER(SCALAR, LAYOUT, MEM_SPACE)                                                         \
-  template <>                                                                                                          \
-  struct GETRF<                                                                                                        \
-      Kokkos::Cuda,                                                                                                    \
-      Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                                          \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                           \
-      Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,    \
-      Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,    \
-      true,                                                                                                            \
-      getrf_eti_spec_avail<Kokkos::Cuda,                                                                               \
-                           Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                     \
-                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                      \
-                           Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                         \
-                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                      \
-                           Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                         \
-                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>>::value> {                            \
-    using AViewType   = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                        \
-				     Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                         \
-    using IpivViewType = Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                           \
-                                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                        \
-    using InfoViewType =                                                                                               \
-        Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;  \
-                                                                                                                       \
-    static void getrf(const Kokkos::Cuda& space, const AViewType& A, const IpivViewType& Ipiv,                         \
-                      const InfoViewType& Info) {                                                                      \
-      Kokkos::Profiling::pushRegion("KokkosLapack::getrf[TPL_CUSOLVER," #SCALAR "]");                                  \
-      getrf_print_specialization<AViewType, IpivViewType, InfoViewType>();                                             \
-                                                                                                                       \
-      cusolverGetrfWrapper(space, A, Ipiv, Info);                                                                      \
-      Kokkos::Profiling::popRegion();                                                                                  \
-    }                                                                                                                  \
+#define KOKKOSLAPACK_GETRF_CUSOLVER(SCALAR, LAYOUT, MEM_SPACE)                                                        \
+  template <>                                                                                                         \
+  struct GETRF<                                                                                                       \
+      Kokkos::Cuda,                                                                                                   \
+      Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                                         \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                          \
+      Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,   \
+      Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,   \
+      true,                                                                                                           \
+      getrf_eti_spec_avail<Kokkos::Cuda,                                                                              \
+                           Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                    \
+                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                     \
+                           Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                        \
+                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                     \
+                           Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                        \
+                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>>::value> {                           \
+    using AViewType = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                         \
+                                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                          \
+    using IpivViewType =                                                                                              \
+        Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>; \
+    using InfoViewType =                                                                                              \
+        Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>; \
+                                                                                                                      \
+    static void getrf(const Kokkos::Cuda& space, const AViewType& A, const IpivViewType& Ipiv,                        \
+                      const InfoViewType& Info) {                                                                     \
+      Kokkos::Profiling::pushRegion("KokkosLapack::getrf[TPL_CUSOLVER," #SCALAR "]");                                 \
+      getrf_print_specialization<AViewType, IpivViewType, InfoViewType>();                                            \
+                                                                                                                      \
+      cusolverGetrfWrapper(space, A, Ipiv, Info);                                                                     \
+      Kokkos::Profiling::popRegion();                                                                                 \
+    }                                                                                                                 \
   };
 
 KOKKOSLAPACK_GETRF_CUSOLVER(float, Kokkos::LayoutLeft, Kokkos::CudaSpace)
@@ -246,14 +246,12 @@ void rocsolverGetrfWrapper(const ExecutionSpace& space, const AViewType& A, cons
     KOKKOSBLAS_IMPL_ROCBLAS_SAFE_CALL(rocsolver_dgetrf(s.handle, m, n, A.data(), lda, Ipiv.data(), Info.data()));
   }
   if constexpr (std::is_same_v<Scalar, Kokkos::complex<float>>) {
-    KOKKOSBLAS_IMPL_ROCBLAS_SAFE_CALL(rocsolver_cgetrf(s.handle, m, n,
-                                                       reinterpret_cast<rocblas_float_complex*>(A.data()), lda,
-                                                       Ipiv.data(), Info.data()));
+    KOKKOSBLAS_IMPL_ROCBLAS_SAFE_CALL(rocsolver_cgetrf(
+        s.handle, m, n, reinterpret_cast<rocblas_float_complex*>(A.data()), lda, Ipiv.data(), Info.data()));
   }
   if constexpr (std::is_same_v<Scalar, Kokkos::complex<double>>) {
-    KOKKOSBLAS_IMPL_ROCBLAS_SAFE_CALL(rocsolver_zgetrf(s.handle, m, n,
-                                                       reinterpret_cast<rocblas_double_complex*>(A.data()), lda,
-                                                       Ipiv.data(), Info.data()));
+    KOKKOSBLAS_IMPL_ROCBLAS_SAFE_CALL(rocsolver_zgetrf(
+        s.handle, m, n, reinterpret_cast<rocblas_double_complex*>(A.data()), lda, Ipiv.data(), Info.data()));
   }
   KOKKOSBLAS_IMPL_ROCBLAS_SAFE_CALL(rocblas_set_stream(s.handle, NULL));
 }
@@ -266,17 +264,17 @@ void rocsolverGetrfWrapper(const ExecutionSpace& space, const AViewType& A, cons
       Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,     \
       Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,     \
       true,                                                                                                            \
-      getrf_eti_spec_avail<Kokkos::HIP,                                                                                \
-                           Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                      \
-                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                      \
-                           Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                          \
-                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                      \
-                           Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                          \
-                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>>::value> {                            \
-    using AViewType   = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                         \
+      getrf_eti_spec_avail<                                                                                            \
+          Kokkos::HIP,                                                                                                 \
+          Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                                       \
+                       Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                       \
+          Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
+          Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                                           \
+                       Kokkos::MemoryTraits<Kokkos::Unmanaged>>>::value> {                                             \
+    using AViewType = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                           \
                                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                           \
-    using IpivViewType = Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                            \
-                                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                         \
+    using IpivViewType =                                                                                               \
+        Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;   \
     using InfoViewType =                                                                                               \
         Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;   \
                                                                                                                        \

--- a/lapack/tpls/KokkosLapack_getrf_tpl_spec_decl.hpp
+++ b/lapack/tpls/KokkosLapack_getrf_tpl_spec_decl.hpp
@@ -110,12 +110,13 @@ KOKKOSLAPACK_GETRF_LAPACK(Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::T
 // CUSOLVER
 #ifdef KOKKOSKERNELS_ENABLE_TPL_CUSOLVER
 #include "KokkosLapack_cusolver.hpp"
+#include <KokkosKernels_Cuda_Utils.hpp>
 
 namespace KokkosLapack {
 namespace Impl {
 
-template <class ExecutionSpace, class AViewType, class TauViewType, class InfoViewType>
-void cusolverGetrfWrapper(const ExecutionSpace& space, const AViewType& A, const TauViewType& Tau,
+template <class ExecutionSpace, class AViewType, class IpivViewType, class InfoViewType>
+void cusolverGetrfWrapper(const ExecutionSpace& space, const AViewType& A, const IpivViewType& Ipiv,
                           const InfoViewType& Info) {
   using memory_space = typename AViewType::memory_space;
   using Scalar       = typename AViewType::non_const_value_type;
@@ -123,6 +124,9 @@ void cusolverGetrfWrapper(const ExecutionSpace& space, const AViewType& A, const
   using ALayout_t = typename AViewType::array_layout;
   static_assert(std::is_same_v<ALayout_t, Kokkos::LayoutLeft>,
                 "KokkosLapack - cusolver getrf: A needs to have a Kokkos::LayoutLeft");
+
+  const cudaDataType cuda_compute_type = KokkosKernels::Impl::cuda_data_type_from<Scalar>();
+
   const int m   = A.extent_int(0);
   const int n   = A.extent_int(1);
   const int lda = A.stride(1);
@@ -134,34 +138,33 @@ void cusolverGetrfWrapper(const ExecutionSpace& space, const AViewType& A, const
     KOKKOSLAPACK_IMPL_CUSOLVER_SAFE_CALL(cusolverDnSgetrf_bufferSize(s.handle, m, n, A.data(), lda, &lwork));
     Kokkos::View<float*, memory_space> Workspace("cusolver sgetrf workspace", lwork);
 
-    KOKKOSLAPACK_IMPL_CUSOLVER_SAFE_CALL(
-        cusolverDnSgetrf(s.handle, m, n, A.data(), lda, Tau.data(), Workspace.data(), lwork, Info.data()));
+    KOKKOSLAPACK_IMPL_CUSOLVER_SAFE_CALL(cusolverDnSgetrf(s.handle, m, n, A.data(), lda, Workspace.data(),
+							  Ipiv.data(), Info.data()));
   }
   if constexpr (std::is_same_v<Scalar, double>) {
     KOKKOSLAPACK_IMPL_CUSOLVER_SAFE_CALL(cusolverDnDgetrf_bufferSize(s.handle, m, n, A.data(), lda, &lwork));
     Kokkos::View<double*, memory_space> Workspace("cusolver dgetrf workspace", lwork);
 
-    KOKKOSLAPACK_IMPL_CUSOLVER_SAFE_CALL(
-        cusolverDnDgetrf(s.handle, m, n, A.data(), lda, Tau.data(), Workspace.data(), lwork, Info.data()));
+    KOKKOSLAPACK_IMPL_CUSOLVER_SAFE_CALL(cusolverDnDgetrf(s.handle, m, n, A.data(), lda, Workspace.data(),
+							  Ipiv.data(), Info.data()));
   }
   if constexpr (std::is_same_v<Scalar, Kokkos::complex<float>>) {
-    KOKKOSLAPACK_IMPL_CUSOLVER_SAFE_CALL(
-        cusolverDnCgetrf_bufferSize(s.handle, m, n, reinterpret_cast<cuComplex*>(A.data()), lda, &lwork));
+    KOKKOSLAPACK_IMPL_CUSOLVER_SAFE_CALL(cusolverDnCgetrf_bufferSize(s.handle, m, n, reinterpret_cast<cuComplex*>(A.data()),
+								     lda, &lwork));
     Kokkos::View<cuComplex*, memory_space> Workspace("cusolver cgetrf workspace", lwork);
 
-    KOKKOSLAPACK_IMPL_CUSOLVER_SAFE_CALL(cusolverDnCgetrf(
-        s.handle, m, n, reinterpret_cast<cuComplex*>(A.data()), lda, reinterpret_cast<cuComplex*>(Tau.data()),
-        reinterpret_cast<cuComplex*>(Workspace.data()), lwork, Info.data()));
+    KOKKOSLAPACK_IMPL_CUSOLVER_SAFE_CALL(cusolverDnCgetrf(s.handle, m, n, reinterpret_cast<cuComplex*>(A.data()), lda,
+							  reinterpret_cast<cuComplex*>(Workspace.data()), Ipiv.data(),
+							  Info.data()));
   }
   if constexpr (std::is_same_v<Scalar, Kokkos::complex<double>>) {
-    KOKKOSLAPACK_IMPL_CUSOLVER_SAFE_CALL(
-        cusolverDnZgetrf_bufferSize(s.handle, m, n, reinterpret_cast<cuDoubleComplex*>(A.data()), lda, &lwork));
+    KOKKOSLAPACK_IMPL_CUSOLVER_SAFE_CALL(cusolverDnZgetrf_bufferSize(s.handle, m, n, reinterpret_cast<cuDoubleComplex*>(A.data()),
+								     lda, &lwork));
     Kokkos::View<cuDoubleComplex*, memory_space> Workspace("cusolver zgetrf workspace", lwork);
 
     KOKKOSLAPACK_IMPL_CUSOLVER_SAFE_CALL(cusolverDnZgetrf(s.handle, m, n, reinterpret_cast<cuDoubleComplex*>(A.data()),
-                                                          lda, reinterpret_cast<cuDoubleComplex*>(Tau.data()),
-                                                          reinterpret_cast<cuDoubleComplex*>(Workspace.data()), lwork,
-                                                          Info.data()));
+                                                          lda, reinterpret_cast<cuDoubleComplex*>(Workspace.data()),
+							  Ipiv.data(), Info.data()));
   }
   KOKKOSLAPACK_IMPL_CUSOLVER_SAFE_CALL(cusolverDnSetStream(s.handle, NULL));
 }
@@ -172,29 +175,29 @@ void cusolverGetrfWrapper(const ExecutionSpace& space, const AViewType& A, const
       Kokkos::Cuda,                                                                                                    \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                                          \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                           \
-      Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
+      Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,    \
       Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,    \
       true,                                                                                                            \
       getrf_eti_spec_avail<Kokkos::Cuda,                                                                               \
                            Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                     \
                                         Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                      \
-                           Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                      \
+                           Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                         \
                                         Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                      \
                            Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                         \
                                         Kokkos::MemoryTraits<Kokkos::Unmanaged>>>::value> {                            \
     using AViewType   = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                        \
-                                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                         \
-    using TauViewType = Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                         \
-                                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                         \
+				     Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                         \
+    using IpivViewType = Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                           \
+                                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                        \
     using InfoViewType =                                                                                               \
         Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;  \
                                                                                                                        \
-    static void getrf(const Kokkos::Cuda& space, const AViewType& A, const TauViewType& Tau,                           \
+    static void getrf(const Kokkos::Cuda& space, const AViewType& A, const IpivViewType& Ipiv,                         \
                       const InfoViewType& Info) {                                                                      \
       Kokkos::Profiling::pushRegion("KokkosLapack::getrf[TPL_CUSOLVER," #SCALAR "]");                                  \
-      getrf_print_specialization<AViewType, TauViewType, InfoViewType>();                                              \
+      getrf_print_specialization<AViewType, IpivViewType, InfoViewType>();                                             \
                                                                                                                        \
-      cusolverGetrfWrapper(space, A, Tau, Info);                                                                       \
+      cusolverGetrfWrapper(space, A, Ipiv, Info);                                                                      \
       Kokkos::Profiling::popRegion();                                                                                  \
     }                                                                                                                  \
   };

--- a/lapack/tpls/KokkosLapack_getrf_tpl_spec_decl.hpp
+++ b/lapack/tpls/KokkosLapack_getrf_tpl_spec_decl.hpp
@@ -226,14 +226,15 @@ KOKKOSLAPACK_GETRF_CUSOLVER(Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos:
 namespace KokkosLapack {
 namespace Impl {
 
-template <class ExecutionSpace, class AViewType, class TauViewType, class InfoViewType>
-void rocsolverGetrfWrapper(const ExecutionSpace& space, const AViewType& A, const TauViewType& Tau,
+template <class ExecutionSpace, class AViewType, class IpivViewType, class InfoViewType>
+void rocsolverGetrfWrapper(const ExecutionSpace& space, const AViewType& A, const IpivViewType& Ipiv,
                            const InfoViewType& Info) {
   using Scalar = typename AViewType::non_const_value_type;
 
   using ALayout_t = typename AViewType::array_layout;
   static_assert(std::is_same_v<ALayout_t, Kokkos::LayoutLeft>,
                 "KokkosLapack - rocsolver getrf: A needs to have a Kokkos::LayoutLeft");
+
   const rocblas_int m   = static_cast<rocblas_int>(A.extent(0));
   const rocblas_int n   = static_cast<rocblas_int>(A.extent(1));
   const rocblas_int lda = static_cast<rocblas_int>(A.stride(1));
@@ -241,20 +242,20 @@ void rocsolverGetrfWrapper(const ExecutionSpace& space, const AViewType& A, cons
   KokkosBlas::Impl::RocBlasSingleton& s = KokkosBlas::Impl::RocBlasSingleton::singleton();
   KOKKOSBLAS_IMPL_ROCBLAS_SAFE_CALL(rocblas_set_stream(s.handle, space.hip_stream()));
   if constexpr (std::is_same_v<Scalar, float>) {
-    KOKKOSBLAS_IMPL_ROCBLAS_SAFE_CALL(rocsolver_sgetrf(s.handle, m, n, A.data(), lda, Tau.data()));
+    KOKKOSBLAS_IMPL_ROCBLAS_SAFE_CALL(rocsolver_sgetrf(s.handle, m, n, A.data(), lda, Ipiv.data(), Info.data()));
   }
   if constexpr (std::is_same_v<Scalar, double>) {
-    KOKKOSBLAS_IMPL_ROCBLAS_SAFE_CALL(rocsolver_dgetrf(s.handle, m, n, A.data(), lda, Tau.data()));
+    KOKKOSBLAS_IMPL_ROCBLAS_SAFE_CALL(rocsolver_dgetrf(s.handle, m, n, A.data(), lda, Ipiv.data(), Info.data()));
   }
   if constexpr (std::is_same_v<Scalar, Kokkos::complex<float>>) {
     KOKKOSBLAS_IMPL_ROCBLAS_SAFE_CALL(rocsolver_cgetrf(s.handle, m, n,
                                                        reinterpret_cast<rocblas_float_complex*>(A.data()), lda,
-                                                       reinterpret_cast<rocblas_float_complex*>(Tau.data())));
+                                                       Ipiv.data(), Info.data()));
   }
   if constexpr (std::is_same_v<Scalar, Kokkos::complex<double>>) {
     KOKKOSBLAS_IMPL_ROCBLAS_SAFE_CALL(rocsolver_zgetrf(s.handle, m, n,
                                                        reinterpret_cast<rocblas_double_complex*>(A.data()), lda,
-                                                       reinterpret_cast<rocblas_double_complex*>(Tau.data())));
+                                                       Ipiv.data(), Info.data()));
   }
   Kokkos::deep_copy(Info, 0);  // Success
   KOKKOSBLAS_IMPL_ROCBLAS_SAFE_CALL(rocblas_set_stream(s.handle, NULL));
@@ -265,29 +266,29 @@ void rocsolverGetrfWrapper(const ExecutionSpace& space, const AViewType& A, cons
   struct GETRF<                                                                                                        \
       Kokkos::HIP,                                                                                                     \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
-      Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,  \
+      Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,     \
       Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,     \
       true,                                                                                                            \
       getrf_eti_spec_avail<Kokkos::HIP,                                                                                \
                            Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                      \
                                         Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                      \
-                           Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                       \
+                           Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                          \
                                         Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                      \
                            Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                          \
                                         Kokkos::MemoryTraits<Kokkos::Unmanaged>>>::value> {                            \
     using AViewType   = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                         \
-                                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                         \
-    using TauViewType = Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                          \
+                                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                           \
+    using IpivViewType = Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                            \
                                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                         \
     using InfoViewType =                                                                                               \
         Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;   \
                                                                                                                        \
-    static void getrf(const Kokkos::HIP& space, const AViewType& A, const TauViewType& Tau,                            \
+    static void getrf(const Kokkos::HIP& space, const AViewType& A, const IpivViewType& Ipiv,                          \
                       const InfoViewType& Info) {                                                                      \
       Kokkos::Profiling::pushRegion("KokkosLapack::getrf[TPL_ROCSOLVER," #SCALAR "]");                                 \
-      getrf_print_specialization<AViewType, TauViewType, InfoViewType>();                                              \
+      getrf_print_specialization<AViewType, IpivViewType, InfoViewType>();                                             \
                                                                                                                        \
-      rocsolverGetrfWrapper(space, A, Tau, Info);                                                                      \
+      rocsolverGetrfWrapper(space, A, Ipiv, Info);                                                                     \
       Kokkos::Profiling::popRegion();                                                                                  \
     }                                                                                                                  \
   };

--- a/lapack/tpls/KokkosLapack_getrf_tpl_spec_decl.hpp
+++ b/lapack/tpls/KokkosLapack_getrf_tpl_spec_decl.hpp
@@ -57,21 +57,21 @@ void lapackGetrfWrapper(const AViewType& A, const IpivView& Ipiv, const InfoView
   struct GETRF<                                                                                                        \
       EXECSPACE,                                                                                                       \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,   \
-      Kokkos::View<std::int32_t*, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
+      Kokkos::View<int*, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,       \
       Kokkos::View<int*, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, true, \
       getrf_eti_spec_avail<EXECSPACE,                                                                                  \
                            Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>,                        \
                                         Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                      \
-                           Kokkos::View<std::int32_t*, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>,	               \
+                           Kokkos::View<int*, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>,	                       \
                                         Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                      \
-                           Kokkos::View<std::int32_t*, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>,                   \
+                           Kokkos::View<int*, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>,                            \
                                         Kokkos::MemoryTraits<Kokkos::Unmanaged>>>::value> {                            \
     using AViewType =                                                                                                  \
         Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>; \
     using IpivView =                                                                                                   \
-        Kokkos::View<std::int32_t*, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>; \
+        Kokkos::View<int*, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;     \
     using InfoViewType =                                                                                               \
-        Kokkos::View<std::int32_t*, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>; \
+        Kokkos::View<int*, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;     \
                                                                                                                        \
     static void getrf(const EXECSPACE& /* space */, const AViewType& A, const IpivView& Ipiv,                          \
                       const InfoViewType& Info) {                                                                      \
@@ -124,8 +124,6 @@ void cusolverGetrfWrapper(const ExecutionSpace& space, const AViewType& A, const
   using ALayout_t = typename AViewType::array_layout;
   static_assert(std::is_same_v<ALayout_t, Kokkos::LayoutLeft>,
                 "KokkosLapack - cusolver getrf: A needs to have a Kokkos::LayoutLeft");
-
-  const cudaDataType cuda_compute_type = KokkosKernels::Impl::cuda_data_type_from<Scalar>();
 
   const int m   = A.extent_int(0);
   const int n   = A.extent_int(1);
@@ -257,7 +255,6 @@ void rocsolverGetrfWrapper(const ExecutionSpace& space, const AViewType& A, cons
                                                        reinterpret_cast<rocblas_double_complex*>(A.data()), lda,
                                                        Ipiv.data(), Info.data()));
   }
-  Kokkos::deep_copy(Info, 0);  // Success
   KOKKOSBLAS_IMPL_ROCBLAS_SAFE_CALL(rocblas_set_stream(s.handle, NULL));
 }
 

--- a/lapack/tpls/KokkosLapack_getrf_tpl_spec_decl.hpp
+++ b/lapack/tpls/KokkosLapack_getrf_tpl_spec_decl.hpp
@@ -1,0 +1,301 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#ifndef KOKKOSLAPACK_GETRF_TPL_SPEC_DECL_HPP_
+#define KOKKOSLAPACK_GETRF_TPL_SPEC_DECL_HPP_
+
+#include <iostream>
+
+namespace KokkosLapack {
+namespace Impl {
+template <class AViewType, class TauViewType, class InfoViewType>
+inline void getrf_print_specialization() {
+#ifdef KOKKOSKERNELS_ENABLE_CHECK_SPECIALIZATION
+#ifdef KOKKOSKERNELS_ENABLE_TPL_MAGMA
+  printf("KokkosLapack::getrf<> TPL MAGMA specialization for < %s , %s, %s >\n", typeid(AViewType).name(),
+         typeid(TauViewType).name(), typeid(InfoViewType).name());
+#else
+#ifdef KOKKOSKERNELS_ENABLE_TPL_LAPACK
+  printf("KokkosLapack::getrf<> TPL Lapack specialization for < %s , %s, %s >\n", typeid(AViewType).name(),
+         typeid(TauViewType).name(), typeid(InfoViewType).name());
+#endif
+#endif
+#endif
+}
+}  // namespace Impl
+}  // namespace KokkosLapack
+
+// Generic Host side LAPACK (could be MKL or whatever)
+#if defined(KOKKOSKERNELS_ENABLE_TPL_LAPACK) || defined(KOKKOSKERNELS_ENABLE_TPL_ACCELERATE)
+#include <KokkosLapack_Host_tpl.hpp>
+
+namespace KokkosLapack {
+namespace Impl {
+
+template <class AViewType, class IpivView, class InfoView>
+void lapackGetrfWrapper(const AViewType& A, const IpivView& Ipiv, const InfoView& Info) {
+  using Scalar       = typename AViewType::non_const_value_type;
+  using ALayout_t    = typename AViewType::array_layout;
+  static_assert(std::is_same_v<ALayout_t, Kokkos::LayoutLeft>,
+                "KokkosLapack - getrf: A needs to have a Kokkos::LayoutLeft");
+  const int m   = A.extent_int(0);
+  const int n   = A.extent_int(1);
+  const int lda = A.stride(1);
+
+  if constexpr (KokkosKernels::ArithTraits<Scalar>::is_complex) {
+    using MagType = typename KokkosKernels::ArithTraits<Scalar>::mag_type;
+
+    HostLapack<std::complex<MagType>>::getrf(m, n, reinterpret_cast<std::complex<MagType>*>(A.data()), lda,
+                                             Ipiv.data(), Info.data());
+  } else {
+    HostLapack<Scalar>::getrf(m, n, A.data(), lda, Ipiv.data(), Info.data());
+  }
+}
+
+#define KOKKOSLAPACK_GETRF_LAPACK(SCALAR, LAYOUT, EXECSPACE, MEM_SPACE)                                                \
+  template <>                                                                                                          \
+  struct GETRF<                                                                                                        \
+      EXECSPACE,                                                                                                       \
+      Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,   \
+      Kokkos::View<std::int32_t*, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
+      Kokkos::View<int*, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, true, \
+      getrf_eti_spec_avail<EXECSPACE,                                                                                  \
+                           Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>,                        \
+                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                      \
+                           Kokkos::View<std::int32_t*, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>,	               \
+                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                      \
+                           Kokkos::View<std::int32_t*, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>,                   \
+                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>>::value> {                            \
+    using AViewType =                                                                                                  \
+        Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>; \
+    using IpivView =                                                                                                   \
+        Kokkos::View<std::int32_t*, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>; \
+    using InfoViewType =                                                                                               \
+        Kokkos::View<std::int32_t*, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>; \
+                                                                                                                       \
+    static void getrf(const EXECSPACE& /* space */, const AViewType& A, const IpivView& Ipiv,                          \
+                      const InfoViewType& Info) {                                                                      \
+      Kokkos::Profiling::pushRegion("KokkosLapack::getrf[TPL_LAPACK," #SCALAR "]");                                    \
+      getrf_print_specialization<AViewType, IpivView, InfoViewType>();                                                 \
+      lapackGetrfWrapper(A, Ipiv, Info);                                                                               \
+      Kokkos::Profiling::popRegion();                                                                                  \
+    }                                                                                                                  \
+  };
+
+#if defined(KOKKOS_ENABLE_SERIAL)
+KOKKOSLAPACK_GETRF_LAPACK(float, Kokkos::LayoutLeft, Kokkos::Serial, Kokkos::HostSpace)
+KOKKOSLAPACK_GETRF_LAPACK(double, Kokkos::LayoutLeft, Kokkos::Serial, Kokkos::HostSpace)
+KOKKOSLAPACK_GETRF_LAPACK(Kokkos::complex<float>, Kokkos::LayoutLeft, Kokkos::Serial, Kokkos::HostSpace)
+KOKKOSLAPACK_GETRF_LAPACK(Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::Serial, Kokkos::HostSpace)
+#endif
+
+#if defined(KOKKOS_ENABLE_OPENMP)
+KOKKOSLAPACK_GETRF_LAPACK(float, Kokkos::LayoutLeft, Kokkos::OpenMP, Kokkos::HostSpace)
+KOKKOSLAPACK_GETRF_LAPACK(double, Kokkos::LayoutLeft, Kokkos::OpenMP, Kokkos::HostSpace)
+KOKKOSLAPACK_GETRF_LAPACK(Kokkos::complex<float>, Kokkos::LayoutLeft, Kokkos::OpenMP, Kokkos::HostSpace)
+KOKKOSLAPACK_GETRF_LAPACK(Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::OpenMP, Kokkos::HostSpace)
+#endif
+
+#if defined(KOKKOS_ENABLE_THREADS)
+KOKKOSLAPACK_GETRF_LAPACK(float, Kokkos::LayoutLeft, Kokkos::Threads, Kokkos::HostSpace)
+KOKKOSLAPACK_GETRF_LAPACK(double, Kokkos::LayoutLeft, Kokkos::Threads, Kokkos::HostSpace)
+KOKKOSLAPACK_GETRF_LAPACK(Kokkos::complex<float>, Kokkos::LayoutLeft, Kokkos::Threads, Kokkos::HostSpace)
+KOKKOSLAPACK_GETRF_LAPACK(Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::Threads, Kokkos::HostSpace)
+#endif
+
+}  // namespace Impl
+}  // namespace KokkosLapack
+#endif  // KOKKOSKERNELS_ENABLE_TPL_LAPACK
+
+// CUSOLVER
+#ifdef KOKKOSKERNELS_ENABLE_TPL_CUSOLVER
+#include "KokkosLapack_cusolver.hpp"
+
+namespace KokkosLapack {
+namespace Impl {
+
+template <class ExecutionSpace, class AViewType, class TauViewType, class InfoViewType>
+void cusolverGetrfWrapper(const ExecutionSpace& space, const AViewType& A, const TauViewType& Tau,
+                          const InfoViewType& Info) {
+  using memory_space = typename AViewType::memory_space;
+  using Scalar       = typename AViewType::non_const_value_type;
+
+  using ALayout_t = typename AViewType::array_layout;
+  static_assert(std::is_same_v<ALayout_t, Kokkos::LayoutLeft>,
+                "KokkosLapack - cusolver getrf: A needs to have a Kokkos::LayoutLeft");
+  const int m   = A.extent_int(0);
+  const int n   = A.extent_int(1);
+  const int lda = A.stride(1);
+  int lwork     = 0;
+
+  CudaLapackSingleton& s = CudaLapackSingleton::singleton();
+  KOKKOSLAPACK_IMPL_CUSOLVER_SAFE_CALL(cusolverDnSetStream(s.handle, space.cuda_stream()));
+  if constexpr (std::is_same_v<Scalar, float>) {
+    KOKKOSLAPACK_IMPL_CUSOLVER_SAFE_CALL(cusolverDnSgetrf_bufferSize(s.handle, m, n, A.data(), lda, &lwork));
+    Kokkos::View<float*, memory_space> Workspace("cusolver sgetrf workspace", lwork);
+
+    KOKKOSLAPACK_IMPL_CUSOLVER_SAFE_CALL(
+        cusolverDnSgetrf(s.handle, m, n, A.data(), lda, Tau.data(), Workspace.data(), lwork, Info.data()));
+  }
+  if constexpr (std::is_same_v<Scalar, double>) {
+    KOKKOSLAPACK_IMPL_CUSOLVER_SAFE_CALL(cusolverDnDgetrf_bufferSize(s.handle, m, n, A.data(), lda, &lwork));
+    Kokkos::View<double*, memory_space> Workspace("cusolver dgetrf workspace", lwork);
+
+    KOKKOSLAPACK_IMPL_CUSOLVER_SAFE_CALL(
+        cusolverDnDgetrf(s.handle, m, n, A.data(), lda, Tau.data(), Workspace.data(), lwork, Info.data()));
+  }
+  if constexpr (std::is_same_v<Scalar, Kokkos::complex<float>>) {
+    KOKKOSLAPACK_IMPL_CUSOLVER_SAFE_CALL(
+        cusolverDnCgetrf_bufferSize(s.handle, m, n, reinterpret_cast<cuComplex*>(A.data()), lda, &lwork));
+    Kokkos::View<cuComplex*, memory_space> Workspace("cusolver cgetrf workspace", lwork);
+
+    KOKKOSLAPACK_IMPL_CUSOLVER_SAFE_CALL(cusolverDnCgetrf(
+        s.handle, m, n, reinterpret_cast<cuComplex*>(A.data()), lda, reinterpret_cast<cuComplex*>(Tau.data()),
+        reinterpret_cast<cuComplex*>(Workspace.data()), lwork, Info.data()));
+  }
+  if constexpr (std::is_same_v<Scalar, Kokkos::complex<double>>) {
+    KOKKOSLAPACK_IMPL_CUSOLVER_SAFE_CALL(
+        cusolverDnZgetrf_bufferSize(s.handle, m, n, reinterpret_cast<cuDoubleComplex*>(A.data()), lda, &lwork));
+    Kokkos::View<cuDoubleComplex*, memory_space> Workspace("cusolver zgetrf workspace", lwork);
+
+    KOKKOSLAPACK_IMPL_CUSOLVER_SAFE_CALL(cusolverDnZgetrf(s.handle, m, n, reinterpret_cast<cuDoubleComplex*>(A.data()),
+                                                          lda, reinterpret_cast<cuDoubleComplex*>(Tau.data()),
+                                                          reinterpret_cast<cuDoubleComplex*>(Workspace.data()), lwork,
+                                                          Info.data()));
+  }
+  KOKKOSLAPACK_IMPL_CUSOLVER_SAFE_CALL(cusolverDnSetStream(s.handle, NULL));
+}
+
+#define KOKKOSLAPACK_GETRF_CUSOLVER(SCALAR, LAYOUT, MEM_SPACE)                                                         \
+  template <>                                                                                                          \
+  struct GETRF<                                                                                                        \
+      Kokkos::Cuda,                                                                                                    \
+      Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                                          \
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                           \
+      Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
+      Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,    \
+      true,                                                                                                            \
+      getrf_eti_spec_avail<Kokkos::Cuda,                                                                               \
+                           Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                     \
+                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                      \
+                           Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                      \
+                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                      \
+                           Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                         \
+                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>>::value> {                            \
+    using AViewType   = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                        \
+                                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                         \
+    using TauViewType = Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                         \
+                                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                         \
+    using InfoViewType =                                                                                               \
+        Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;  \
+                                                                                                                       \
+    static void getrf(const Kokkos::Cuda& space, const AViewType& A, const TauViewType& Tau,                           \
+                      const InfoViewType& Info) {                                                                      \
+      Kokkos::Profiling::pushRegion("KokkosLapack::getrf[TPL_CUSOLVER," #SCALAR "]");                                  \
+      getrf_print_specialization<AViewType, TauViewType, InfoViewType>();                                              \
+                                                                                                                       \
+      cusolverGetrfWrapper(space, A, Tau, Info);                                                                       \
+      Kokkos::Profiling::popRegion();                                                                                  \
+    }                                                                                                                  \
+  };
+
+KOKKOSLAPACK_GETRF_CUSOLVER(float, Kokkos::LayoutLeft, Kokkos::CudaSpace)
+KOKKOSLAPACK_GETRF_CUSOLVER(double, Kokkos::LayoutLeft, Kokkos::CudaSpace)
+KOKKOSLAPACK_GETRF_CUSOLVER(Kokkos::complex<float>, Kokkos::LayoutLeft, Kokkos::CudaSpace)
+KOKKOSLAPACK_GETRF_CUSOLVER(Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::CudaSpace)
+
+#if defined(KOKKOSKERNELS_INST_MEMSPACE_CUDAUVMSPACE)
+KOKKOSLAPACK_GETRF_CUSOLVER(float, Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
+KOKKOSLAPACK_GETRF_CUSOLVER(double, Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
+KOKKOSLAPACK_GETRF_CUSOLVER(Kokkos::complex<float>, Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
+KOKKOSLAPACK_GETRF_CUSOLVER(Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
+#endif
+
+}  // namespace Impl
+}  // namespace KokkosLapack
+#endif  // KOKKOSKERNELS_ENABLE_TPL_CUSOLVER
+
+// ROCSOLVER
+#ifdef KOKKOSKERNELS_ENABLE_TPL_ROCSOLVER
+#include <KokkosBlas_tpl_spec.hpp>
+#include <rocsolver/rocsolver.h>
+
+namespace KokkosLapack {
+namespace Impl {
+
+template <class ExecutionSpace, class AViewType, class TauViewType, class InfoViewType>
+void rocsolverGetrfWrapper(const ExecutionSpace& space, const AViewType& A, const TauViewType& Tau,
+                           const InfoViewType& Info) {
+  using Scalar = typename AViewType::non_const_value_type;
+
+  using ALayout_t = typename AViewType::array_layout;
+  static_assert(std::is_same_v<ALayout_t, Kokkos::LayoutLeft>,
+                "KokkosLapack - rocsolver getrf: A needs to have a Kokkos::LayoutLeft");
+  const rocblas_int m   = static_cast<rocblas_int>(A.extent(0));
+  const rocblas_int n   = static_cast<rocblas_int>(A.extent(1));
+  const rocblas_int lda = static_cast<rocblas_int>(A.stride(1));
+
+  KokkosBlas::Impl::RocBlasSingleton& s = KokkosBlas::Impl::RocBlasSingleton::singleton();
+  KOKKOSBLAS_IMPL_ROCBLAS_SAFE_CALL(rocblas_set_stream(s.handle, space.hip_stream()));
+  if constexpr (std::is_same_v<Scalar, float>) {
+    KOKKOSBLAS_IMPL_ROCBLAS_SAFE_CALL(rocsolver_sgetrf(s.handle, m, n, A.data(), lda, Tau.data()));
+  }
+  if constexpr (std::is_same_v<Scalar, double>) {
+    KOKKOSBLAS_IMPL_ROCBLAS_SAFE_CALL(rocsolver_dgetrf(s.handle, m, n, A.data(), lda, Tau.data()));
+  }
+  if constexpr (std::is_same_v<Scalar, Kokkos::complex<float>>) {
+    KOKKOSBLAS_IMPL_ROCBLAS_SAFE_CALL(rocsolver_cgetrf(s.handle, m, n,
+                                                       reinterpret_cast<rocblas_float_complex*>(A.data()), lda,
+                                                       reinterpret_cast<rocblas_float_complex*>(Tau.data())));
+  }
+  if constexpr (std::is_same_v<Scalar, Kokkos::complex<double>>) {
+    KOKKOSBLAS_IMPL_ROCBLAS_SAFE_CALL(rocsolver_zgetrf(s.handle, m, n,
+                                                       reinterpret_cast<rocblas_double_complex*>(A.data()), lda,
+                                                       reinterpret_cast<rocblas_double_complex*>(Tau.data())));
+  }
+  Kokkos::deep_copy(Info, 0);  // Success
+  KOKKOSBLAS_IMPL_ROCBLAS_SAFE_CALL(rocblas_set_stream(s.handle, NULL));
+}
+
+#define KOKKOSLAPACK_GETRF_ROCSOLVER(SCALAR, LAYOUT, MEM_SPACE)                                                        \
+  template <>                                                                                                          \
+  struct GETRF<                                                                                                        \
+      Kokkos::HIP,                                                                                                     \
+      Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
+      Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,  \
+      Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,     \
+      true,                                                                                                            \
+      getrf_eti_spec_avail<Kokkos::HIP,                                                                                \
+                           Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                      \
+                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                      \
+                           Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                       \
+                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                      \
+                           Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                          \
+                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>>::value> {                            \
+    using AViewType   = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                         \
+                                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                         \
+    using TauViewType = Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                          \
+                                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                         \
+    using InfoViewType =                                                                                               \
+        Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;   \
+                                                                                                                       \
+    static void getrf(const Kokkos::HIP& space, const AViewType& A, const TauViewType& Tau,                            \
+                      const InfoViewType& Info) {                                                                      \
+      Kokkos::Profiling::pushRegion("KokkosLapack::getrf[TPL_ROCSOLVER," #SCALAR "]");                                 \
+      getrf_print_specialization<AViewType, TauViewType, InfoViewType>();                                              \
+                                                                                                                       \
+      rocsolverGetrfWrapper(space, A, Tau, Info);                                                                      \
+      Kokkos::Profiling::popRegion();                                                                                  \
+    }                                                                                                                  \
+  };
+
+KOKKOSLAPACK_GETRF_ROCSOLVER(float, Kokkos::LayoutLeft, Kokkos::HIPSpace)
+KOKKOSLAPACK_GETRF_ROCSOLVER(double, Kokkos::LayoutLeft, Kokkos::HIPSpace)
+KOKKOSLAPACK_GETRF_ROCSOLVER(Kokkos::complex<float>, Kokkos::LayoutLeft, Kokkos::HIPSpace)
+KOKKOSLAPACK_GETRF_ROCSOLVER(Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::HIPSpace)
+
+}  // namespace Impl
+}  // namespace KokkosLapack
+#endif  // KOKKOSKERNELS_ENABLE_TPL_ROCSOLVER
+
+#endif

--- a/lapack/unit_test/Test_Lapack.hpp
+++ b/lapack/unit_test/Test_Lapack.hpp
@@ -11,5 +11,6 @@
 #include "Test_Lapack_gegqr.hpp"
 #include "Test_Lapack_potrf.hpp"
 #include "Test_Lapack_potrs.hpp"
+#include "Test_Lapack_getrf.hpp"
 
 #endif  // TEST_LAPACK_HPP

--- a/lapack/unit_test/Test_Lapack_getrf.hpp
+++ b/lapack/unit_test/Test_Lapack_getrf.hpp
@@ -23,15 +23,13 @@ template <class MatrixType>
 struct copy_U {
   MatrixType m_A, m_U;
 
-  copy_U(const MatrixType &A, const MatrixType &U) : m_A(A), m_U(U) {
-    static_assert(MatrixType::rank() == 2);
-  }
+  copy_U(const MatrixType &A, const MatrixType &U) : m_A(A), m_U(U) { static_assert(MatrixType::rank() == 2); }
 
-  KOKKOS_FUNCTION void operator() (const int idx) const {
+  KOKKOS_FUNCTION void operator()(const int idx) const {
     const int colIdx = idx / m_A.extent(0);
     const int rowIdx = idx % m_A.extent(0);
 
-    if(rowIdx <= colIdx) {
+    if (rowIdx <= colIdx) {
       m_U(rowIdx, colIdx) = m_A(rowIdx, colIdx);
     }
   }
@@ -43,15 +41,13 @@ struct copy_L_plus_I {
 
   MatrixType m_A, m_L;
 
-  copy_L_plus_I(const MatrixType &A, const MatrixType &L) : m_A(A), m_L(L) {
-    static_assert(MatrixType::rank() == 2);
-  }
+  copy_L_plus_I(const MatrixType &A, const MatrixType &L) : m_A(A), m_L(L) { static_assert(MatrixType::rank() == 2); }
 
-  KOKKOS_FUNCTION void operator() (const int idx) const {
+  KOKKOS_FUNCTION void operator()(const int idx) const {
     const int colIdx = idx / m_A.extent(0);
     const int rowIdx = idx % m_A.extent(0);
 
-    if(rowIdx == colIdx) {
+    if (rowIdx == colIdx) {
       m_L(rowIdx, colIdx) = ATS::one();
     } else if (rowIdx > colIdx) {
       m_L(rowIdx, colIdx) = m_A(rowIdx, colIdx);
@@ -61,9 +57,9 @@ struct copy_L_plus_I {
 
 template <class AMatrixType>
 void impl_test_getrf_sym() {
-  using Device   = typename AMatrixType::device_type;
-  using IpivType = Kokkos::View<int*, Device>;
-  using InfoType = Kokkos::View<int*, Device>;
+  using Device         = typename AMatrixType::device_type;
+  using IpivType       = Kokkos::View<int *, Device>;
+  using InfoType       = Kokkos::View<int *, Device>;
   using scalar_type    = typename AMatrixType::non_const_value_type;
   using ExecutionSpace = typename Device::execution_space;
 
@@ -72,11 +68,23 @@ void impl_test_getrf_sym() {
   const scalar_type two  = one + one;
 
   AMatrixType A("matrix A", 4, 4);
-  auto A_h = Kokkos::create_mirror_view(A);
-  A_h(0, 0) =  two; A_h(0, 1) = -one; A_h(0, 2) = zero; A_h(0, 3) = zero;
-  A_h(1, 0) = -one; A_h(1, 1) =  two; A_h(1, 2) = -one; A_h(1, 3) = zero;
-  A_h(2, 0) = zero; A_h(2, 1) = -one; A_h(2, 2) =  two; A_h(2, 3) = -one;
-  A_h(3, 0) = zero; A_h(3, 1) = zero; A_h(3, 2) = -one; A_h(3, 3) =  two;
+  auto A_h  = Kokkos::create_mirror_view(A);
+  A_h(0, 0) = two;
+  A_h(0, 1) = -one;
+  A_h(0, 2) = zero;
+  A_h(0, 3) = zero;
+  A_h(1, 0) = -one;
+  A_h(1, 1) = two;
+  A_h(1, 2) = -one;
+  A_h(1, 3) = zero;
+  A_h(2, 0) = zero;
+  A_h(2, 1) = -one;
+  A_h(2, 2) = two;
+  A_h(2, 3) = -one;
+  A_h(3, 0) = zero;
+  A_h(3, 1) = zero;
+  A_h(3, 2) = -one;
+  A_h(3, 3) = two;
   Kokkos::deep_copy(A, A_h);
 
   const int min_mn = Kokkos::min(A.extent(0), A.extent(1));
@@ -90,9 +98,9 @@ void impl_test_getrf_sym() {
   const scalar_type four  = two + two;
   const scalar_type five  = two + three;
 
-  auto tol  = 10*KokkosKernels::ArithTraits<scalar_type>::eps();
+  auto tol = 10 * KokkosKernels::ArithTraits<scalar_type>::eps();
 
-  EXPECT_NEAR_KK_REL(A_h(0, 0),  two, tol);
+  EXPECT_NEAR_KK_REL(A_h(0, 0), two, tol);
   EXPECT_NEAR_KK_REL(A_h(0, 1), -one, tol);
   EXPECT_NEAR_KK_REL(A_h(0, 2), zero, tol);
   EXPECT_NEAR_KK_REL(A_h(0, 3), zero, tol);
@@ -116,17 +124,23 @@ void impl_test_getrf_sym() {
 
 template <class AMatrixType>
 void impl_test_getrf_unsym() {
-  using Device   = typename AMatrixType::device_type;
-  using IpivType = Kokkos::View<int*, Device>;
-  using InfoType = Kokkos::View<int*, Device>;
+  using Device         = typename AMatrixType::device_type;
+  using IpivType       = Kokkos::View<int *, Device>;
+  using InfoType       = Kokkos::View<int *, Device>;
   using scalar_type    = typename AMatrixType::non_const_value_type;
   using ExecutionSpace = typename Device::execution_space;
 
   AMatrixType A("matrix A", 3, 3);
-  auto A_h = Kokkos::create_mirror_view(A);
-  A_h(0, 0) = scalar_type(0); A_h(0, 1) = scalar_type(5); A_h(0, 2) = scalar_type(22. / 3);
-  A_h(1, 0) = scalar_type(4); A_h(1, 1) = scalar_type(2); A_h(1, 2) = scalar_type(1);
-  A_h(2, 0) = scalar_type(2); A_h(2, 1) = scalar_type(7); A_h(2, 2) = scalar_type(9);
+  auto A_h  = Kokkos::create_mirror_view(A);
+  A_h(0, 0) = scalar_type(0);
+  A_h(0, 1) = scalar_type(5);
+  A_h(0, 2) = scalar_type(22. / 3);
+  A_h(1, 0) = scalar_type(4);
+  A_h(1, 1) = scalar_type(2);
+  A_h(1, 2) = scalar_type(1);
+  A_h(2, 0) = scalar_type(2);
+  A_h(2, 1) = scalar_type(7);
+  A_h(2, 2) = scalar_type(9);
   Kokkos::deep_copy(A, A_h);
 
   const int min_mn = Kokkos::min(A.extent(0), A.extent(1));
@@ -138,7 +152,7 @@ void impl_test_getrf_unsym() {
   auto ipiv_h = Kokkos::create_mirror_view(ipiv);
   Kokkos::deep_copy(ipiv_h, ipiv);
 
-  auto tol  = 10*KokkosKernels::ArithTraits<scalar_type>::eps();
+  auto tol = 10 * KokkosKernels::ArithTraits<scalar_type>::eps();
 
   ASSERT_EQ(ipiv_h(0), 2);
   ASSERT_EQ(ipiv_h(1), 3);
@@ -160,9 +174,9 @@ void impl_test_getrf_unsym() {
 
 template <class AMatrixType>
 void impl_test_getrf_tall() {
-  using Device   = typename AMatrixType::device_type;
-  using IpivType = Kokkos::View<int*, Device>;
-  using InfoType = Kokkos::View<int*, Device>;
+  using Device         = typename AMatrixType::device_type;
+  using IpivType       = Kokkos::View<int *, Device>;
+  using InfoType       = Kokkos::View<int *, Device>;
   using scalar_type    = typename AMatrixType::non_const_value_type;
   using ExecutionSpace = typename Device::execution_space;
 
@@ -174,15 +188,23 @@ void impl_test_getrf_tall() {
 
   constexpr int m = 4, n = 3;
   const int min_mn = Kokkos::min(m, n);
-  const auto tol = min_mn*m*n*KokkosKernels::ArithTraits<scalar_type>::eps();
+  const auto tol   = min_mn * m * n * KokkosKernels::ArithTraits<scalar_type>::eps();
 
   AMatrixType A("matrix A", m, n), L("L factor", m, min_mn), U("U factor", min_mn, n), LU("L*U product", m, n);
   auto A_h = Kokkos::create_mirror_view(A);
-  Kokkos::View<scalar_type**, Kokkos::HostSpace> Aref("A reference", m, n);
-  A_h(0, 0) =  two; A_h(0, 1) = -one; A_h(0, 2) = zero;
-  A_h(1, 0) = -one; A_h(1, 1) =  two; A_h(1, 2) = -one;
-  A_h(2, 0) = zero; A_h(2, 1) = -one; A_h(2, 2) =  two;
-  A_h(3, 0) =  one; A_h(3, 1) =  one; A_h(3, 2) =  one;
+  Kokkos::View<scalar_type **, Kokkos::HostSpace> Aref("A reference", m, n);
+  A_h(0, 0) = two;
+  A_h(0, 1) = -one;
+  A_h(0, 2) = zero;
+  A_h(1, 0) = -one;
+  A_h(1, 1) = two;
+  A_h(1, 2) = -one;
+  A_h(2, 0) = zero;
+  A_h(2, 1) = -one;
+  A_h(2, 2) = two;
+  A_h(3, 0) = one;
+  A_h(3, 1) = one;
+  A_h(3, 2) = one;
   Kokkos::deep_copy(A, A_h);
   Kokkos::deep_copy(Aref, A_h);
 
@@ -208,9 +230,9 @@ void impl_test_getrf_tall() {
   for (int rowIdx = 0; rowIdx < m; ++rowIdx) {
     for (int colIdx = 0; colIdx < n; ++colIdx) {
       if (rowIdx < min_mn) {
-	tmp = Aref(rowIdx, colIdx);
-	Aref(rowIdx, colIdx) = Aref(ipiv_h(rowIdx) - 1, colIdx);
-	Aref(ipiv_h(rowIdx) - 1, colIdx) = tmp;
+        tmp                              = Aref(rowIdx, colIdx);
+        Aref(rowIdx, colIdx)             = Aref(ipiv_h(rowIdx) - 1, colIdx);
+        Aref(ipiv_h(rowIdx) - 1, colIdx) = tmp;
       }
       EXPECT_NEAR_KK_REL(Aref(rowIdx, colIdx), LU_h(rowIdx, colIdx), tol);
     }
@@ -219,14 +241,14 @@ void impl_test_getrf_tall() {
 
 template <class AMatrixType>
 void impl_test_getrf(const int m, const int n) {
-  using Device   = typename AMatrixType::device_type;
-  using IpivType = Kokkos::View<int*, Device>;
-  using InfoType = Kokkos::View<int*, Device>;
+  using Device         = typename AMatrixType::device_type;
+  using IpivType       = Kokkos::View<int *, Device>;
+  using InfoType       = Kokkos::View<int *, Device>;
   using scalar_type    = typename AMatrixType::non_const_value_type;
   using ExecutionSpace = typename Device::execution_space;
 
   const int min_mn = Kokkos::min(m, n);
-  const auto tol  = min_mn*m*n*KokkosKernels::ArithTraits<scalar_type>::eps();
+  const auto tol   = min_mn * m * n * KokkosKernels::ArithTraits<scalar_type>::eps();
 
   AMatrixType A("matrix A", m, n), Aref("copy of A for reference", m, n), LU("LU product", m, n);
   AMatrixType L("L", m, min_mn), U("U", min_mn, n);
@@ -260,12 +282,12 @@ void impl_test_getrf(const int m, const int n) {
   Kokkos::deep_copy(LU_h, LU);
 
   scalar_type tmp = KokkosKernels::ArithTraits<scalar_type>::zero();
-  for(int rowIdx = 0; rowIdx < m; ++rowIdx) {
-    for(int colIdx = 0; colIdx < n; ++colIdx) {
+  for (int rowIdx = 0; rowIdx < m; ++rowIdx) {
+    for (int colIdx = 0; colIdx < n; ++colIdx) {
       if (rowIdx < min_mn) {
-	tmp = Aref_h(rowIdx, colIdx);
-	Aref_h(rowIdx, colIdx) = Aref_h(ipiv_h(rowIdx) - 1, colIdx);
-	Aref_h(ipiv_h(rowIdx) - 1, colIdx) = tmp;
+        tmp                                = Aref_h(rowIdx, colIdx);
+        Aref_h(rowIdx, colIdx)             = Aref_h(ipiv_h(rowIdx) - 1, colIdx);
+        Aref_h(ipiv_h(rowIdx) - 1, colIdx) = tmp;
       }
       EXPECT_NEAR_KK_REL(LU_h(rowIdx, colIdx), Aref_h(rowIdx, colIdx), tol);
     }
@@ -278,7 +300,7 @@ template <class Scalar, class Device>
 void test_getrf() {
 #if defined(KOKKOSKERNELS_INST_LAYOUTLEFT) || \
     (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
-  using view_type_a = Kokkos::View<Scalar**, Kokkos::LayoutLeft, Device>;
+  using view_type_a = Kokkos::View<Scalar **, Kokkos::LayoutLeft, Device>;
 
   Test::impl_test_getrf_sym<view_type_a>();
   Test::impl_test_getrf_unsym<view_type_a>();

--- a/lapack/unit_test/Test_Lapack_getrf.hpp
+++ b/lapack/unit_test/Test_Lapack_getrf.hpp
@@ -14,9 +14,32 @@
 
 #include <KokkosLapack_getrf.hpp>
 #include <KokkosBlas3_gemm.hpp>
+#include <KokkosBlas3_trsm.hpp>
 #include <KokkosKernels_TestUtils.hpp>
 
 namespace Test {
+
+template <class MatrixType>
+struct copy_L_plus_I {
+  using ATS = KokkosKernels::ArithTraits<typename MatrixType::non_const_value_type>;
+
+  MatrixType m_A, m_L;
+
+  copy_L_plus_I(const MatrixType &A, const MatrixType &L) : m_A(A), m_L(L) {
+    static_assert(MatrixType::rank() == 2);
+  }
+
+  KOKKOS_FUNCTION void operator() (const int idx) const {
+    const int colIdx = idx / m_A.extent(0);
+    const int rowIdx = idx % m_A.extent(0);
+
+    if(colIdx == rowIdx) {
+      m_L(rowIdx, colIdx) = ATS::one();
+    } else if(colIdx < rowIdx) {
+      m_L(rowIdx, colIdx) = m_A(rowIdx, colIdx);
+    }
+  }
+};
 
 template <class AMatrixType>
 void impl_test_getrf_sym() {
@@ -125,16 +148,39 @@ void impl_test_getrf(const int m, const int n) {
 
   const int minMN = Kokkos::min(m, n);
 
-  AMatrixType A("matrix A", m, n);
+  AMatrixType A("matrix A", m, n), Aref("copy of A for reference", m, n), LU("LU product", m, n);
 
   IpivType ipiv("LU pivots", minMN);
   InfoType info("LU info", 1);
 
   Kokkos::Random_XorShift64_Pool<ExecutionSpace> rand_pool(13718);
   Kokkos::fill_random(A, rand_pool, Kokkos::rand<Kokkos::Random_XorShift64<ExecutionSpace>, scalar_type>::max());
+  Kokkos::deep_copy(Aref, A);
+
+  std::cout << "Aref\n"
+	    << "   [" << Aref(0, 0) << ", " << Aref(0, 1) << ", " << Aref(0, 2) << ", " << Aref(0, 3) << "]\n"
+	    << "   [" << Aref(1, 0) << ", " << Aref(1, 1) << ", " << Aref(1, 2) << ", " << Aref(1, 3) << "]\n"
+	    << "   [" << Aref(2, 0) << ", " << Aref(2, 1) << ", " << Aref(2, 2) << ", " << Aref(2, 3) << "]\n"
+	    << "   [" << Aref(3, 0) << ", " << Aref(3, 1) << ", " << Aref(3, 2) << ", " << Aref(3, 3) << "]" << std::endl;
 
   KokkosLapack::getrf(ExecutionSpace(), A, ipiv, info);
 
+  std::cout << "A\n"
+	    << "   [" << A(0, 0) << ", " << A(0, 1) << ", " << A(0, 2) << ", " << A(0, 3) << "]\n"
+	    << "   [" << A(1, 0) << ", " << A(1, 1) << ", " << A(1, 2) << ", " << A(1, 3) << "]\n"
+	    << "   [" << A(2, 0) << ", " << A(2, 1) << ", " << A(2, 2) << ", " << A(2, 3) << "]\n"
+	    << "   [" << A(3, 0) << ", " << A(3, 1) << ", " << A(3, 2) << ", " << A(3, 3) << "]" << std::endl;
+  std::cout << "ipiv: [" << ipiv(0) << ", " << ipiv(1) << ", " << ipiv(2) << ",  " << ipiv(3) << "]" << std::endl;
+
+  copy_L_plus_I my_func(A, LU);
+  Kokkos::parallel_for(Kokkos::RangePolicy<ExecutionSpace>(0, m * n), my_func);
+  KokkosBlas::trsm(ExecutionSpace(), "R", "U", "N", "N", 1.0, A, LU);
+
+  std::cout << "LU\n"
+	    << "   [" << LU(0, 0) << ", " << LU(0, 1) << ", " << LU(0, 2) << ", " << LU(0, 3) << "]\n"
+	    << "   [" << LU(1, 0) << ", " << LU(1, 1) << ", " << LU(1, 2) << ", " << LU(1, 3) << "]\n"
+	    << "   [" << LU(2, 0) << ", " << LU(2, 1) << ", " << LU(2, 2) << ", " << LU(2, 3) << "]\n"
+	    << "   [" << LU(3, 0) << ", " << LU(3, 1) << ", " << LU(3, 2) << ", " << LU(3, 3) << "]" << std::endl;
 }
 
 }  // namespace Test
@@ -148,9 +194,9 @@ void test_getrf() {
   Test::impl_test_getrf_sym<view_type_a>();
   Test::impl_test_getrf_unsym<view_type_a>();
 
-  Test::impl_test_getrf<view_type_a>(100, 100);
-  Test::impl_test_getrf<view_type_a>(100, 70);
-  Test::impl_test_getrf<view_type_a>(70, 100);
+  Test::impl_test_getrf<view_type_a>(4, 4);
+  // Test::impl_test_getrf<view_type_a>(100, 70);
+  // Test::impl_test_getrf<view_type_a>(70, 100);
 #endif
 }
 

--- a/lapack/unit_test/Test_Lapack_getrf.hpp
+++ b/lapack/unit_test/Test_Lapack_getrf.hpp
@@ -262,8 +262,8 @@ void impl_test_getrf(const int m, const int n) {
     for(int colIdx = 0; colIdx < n; ++colIdx) {
       if (rowIdx < min_mn) {
 	tmp = Aref_h(rowIdx, colIdx);
-	Aref_h(rowIdx, colIdx) = Aref_h(ipiv(rowIdx) - 1, colIdx);
-	Aref_h(ipiv(rowIdx) - 1, colIdx) = tmp;
+	Aref_h(rowIdx, colIdx) = Aref_h(ipiv_h(rowIdx) - 1, colIdx);
+	Aref_h(ipiv_h(rowIdx) - 1, colIdx) = tmp;
       }
       EXPECT_NEAR_KK_REL(LU_h(rowIdx, colIdx), Aref_h(rowIdx, colIdx), tol);
     }

--- a/lapack/unit_test/Test_Lapack_getrf.hpp
+++ b/lapack/unit_test/Test_Lapack_getrf.hpp
@@ -14,10 +14,28 @@
 
 #include <KokkosLapack_getrf.hpp>
 #include <KokkosBlas3_gemm.hpp>
-#include <KokkosBlas3_trsm.hpp>
+#include <KokkosBlas3_trmm.hpp>
 #include <KokkosKernels_TestUtils.hpp>
 
 namespace Test {
+
+template <class MatrixType>
+struct copy_U {
+  MatrixType m_A, m_U;
+
+  copy_U(const MatrixType &A, const MatrixType &U) : m_A(A), m_U(U) {
+    static_assert(MatrixType::rank() == 2);
+  }
+
+  KOKKOS_FUNCTION void operator() (const int idx) const {
+    const int colIdx = idx / m_A.extent(0);
+    const int rowIdx = idx % m_A.extent(0);
+
+    if(rowIdx <= colIdx) {
+      m_U(rowIdx, colIdx) = m_A(rowIdx, colIdx);
+    }
+  }
+};
 
 template <class MatrixType>
 struct copy_L_plus_I {
@@ -33,9 +51,9 @@ struct copy_L_plus_I {
     const int colIdx = idx / m_A.extent(0);
     const int rowIdx = idx % m_A.extent(0);
 
-    if(colIdx == rowIdx) {
+    if(rowIdx == colIdx) {
       m_L(rowIdx, colIdx) = ATS::one();
-    } else if(colIdx < rowIdx) {
+    } else if (rowIdx > colIdx) {
       m_L(rowIdx, colIdx) = m_A(rowIdx, colIdx);
     }
   }
@@ -61,7 +79,8 @@ void impl_test_getrf_sym() {
   A_h(3, 0) = zero; A_h(3, 1) = zero; A_h(3, 2) = -one; A_h(3, 3) =  two;
   Kokkos::deep_copy(A, A_h);
 
-  IpivType ipiv("LU pivots", 4);
+  const int min_mn = Kokkos::min(A.extent(0), A.extent(1));
+  IpivType ipiv("LU pivots", min_mn);
   InfoType info("LU info", 1);
 
   KokkosLapack::getrf(ExecutionSpace(), A, ipiv, info);
@@ -110,7 +129,8 @@ void impl_test_getrf_unsym() {
   A_h(2, 0) = scalar_type(2); A_h(2, 1) = scalar_type(7); A_h(2, 2) = scalar_type(9);
   Kokkos::deep_copy(A, A_h);
 
-  IpivType ipiv("LU pivots", 3);
+  const int min_mn = Kokkos::min(A.extent(0), A.extent(1));
+  IpivType ipiv("LU pivots", min_mn);
   InfoType info("LU info", 1);
 
   KokkosLapack::getrf(ExecutionSpace(), A, ipiv, info);
@@ -139,6 +159,63 @@ void impl_test_getrf_unsym() {
 }  // impl_test_getrf_unsym
 
 template <class AMatrixType>
+void impl_test_getrf_tall() {
+  using Device   = typename AMatrixType::device_type;
+  using IpivType = Kokkos::View<int*, Device>;
+  using InfoType = Kokkos::View<int*, Device>;
+  using scalar_type    = typename AMatrixType::non_const_value_type;
+  using ExecutionSpace = typename Device::execution_space;
+
+  const scalar_type zero = KokkosKernels::ArithTraits<scalar_type>::zero();
+  const scalar_type one  = KokkosKernels::ArithTraits<scalar_type>::one();
+  const scalar_type two  = one + one;
+
+  constexpr int m = 4, n = 3;
+  const int min_mn = Kokkos::min(m, n);
+  const auto tol = min_mn*m*n*KokkosKernels::ArithTraits<scalar_type>::eps();
+
+  AMatrixType A("matrix A", m, n), L("L factor", m, min_mn), U("U factor", min_mn, n), LU("L*U product", m, n);
+  auto A_h = Kokkos::create_mirror_view(A);
+  Kokkos::View<scalar_type**, Kokkos::HostSpace> Aref("A reference", m, n);
+  A_h(0, 0) =  two; A_h(0, 1) = -one; A_h(0, 2) = zero;
+  A_h(1, 0) = -one; A_h(1, 1) =  two; A_h(1, 2) = -one;
+  A_h(2, 0) = zero; A_h(2, 1) = -one; A_h(2, 2) =  two;
+  A_h(3, 0) =  one; A_h(3, 1) =  one; A_h(3, 2) =  one;
+  Kokkos::deep_copy(A, A_h);
+  Kokkos::deep_copy(Aref, A_h);
+
+  IpivType ipiv("LU pivots", min_mn);
+  InfoType info("LU info", 1);
+
+  KokkosLapack::getrf(ExecutionSpace(), A, ipiv, info);
+  Kokkos::deep_copy(A_h, A);
+
+  copy_L_plus_I my_func_L(A, L);
+  Kokkos::parallel_for(Kokkos::RangePolicy<ExecutionSpace>(0, m * n), my_func_L);
+  copy_U my_func_U(A, U);
+  Kokkos::parallel_for(Kokkos::RangePolicy<ExecutionSpace>(0, m * n), my_func_U);
+  KokkosBlas::gemm(ExecutionSpace(), "N", "N", 1.0, L, U, 0.0, LU);
+
+  auto LU_h = Kokkos::create_mirror_view(LU);
+  Kokkos::deep_copy(LU_h, LU);
+
+  auto ipiv_h = Kokkos::create_mirror_view(ipiv);
+  Kokkos::deep_copy(ipiv_h, ipiv);
+
+  scalar_type tmp = zero;
+  for (int rowIdx = 0; rowIdx < m; ++rowIdx) {
+    for (int colIdx = 0; colIdx < n; ++colIdx) {
+      if (rowIdx < min_mn) {
+	tmp = Aref(rowIdx, colIdx);
+	Aref(rowIdx, colIdx) = Aref(ipiv_h(rowIdx) - 1, colIdx);
+	Aref(ipiv_h(rowIdx) - 1, colIdx) = tmp;
+      }
+      EXPECT_NEAR_KK_REL(Aref(rowIdx, colIdx), LU_h(rowIdx, colIdx), tol);
+    }
+  }
+}  // impl_test_getrf_tall
+
+template <class AMatrixType>
 void impl_test_getrf(const int m, const int n) {
   using Device   = typename AMatrixType::device_type;
   using IpivType = Kokkos::View<int*, Device>;
@@ -146,41 +223,51 @@ void impl_test_getrf(const int m, const int n) {
   using scalar_type    = typename AMatrixType::non_const_value_type;
   using ExecutionSpace = typename Device::execution_space;
 
-  const int minMN = Kokkos::min(m, n);
+  const int min_mn = Kokkos::min(m, n);
+  const auto tol  = min_mn*m*n*KokkosKernels::ArithTraits<scalar_type>::eps();
 
   AMatrixType A("matrix A", m, n), Aref("copy of A for reference", m, n), LU("LU product", m, n);
+  AMatrixType L("L", m, min_mn), U("U", min_mn, n);
 
-  IpivType ipiv("LU pivots", minMN);
+  IpivType ipiv("LU pivots", min_mn);
   InfoType info("LU info", 1);
 
   Kokkos::Random_XorShift64_Pool<ExecutionSpace> rand_pool(13718);
   Kokkos::fill_random(A, rand_pool, Kokkos::rand<Kokkos::Random_XorShift64<ExecutionSpace>, scalar_type>::max());
   Kokkos::deep_copy(Aref, A);
 
-  std::cout << "Aref\n"
-	    << "   [" << Aref(0, 0) << ", " << Aref(0, 1) << ", " << Aref(0, 2) << ", " << Aref(0, 3) << "]\n"
-	    << "   [" << Aref(1, 0) << ", " << Aref(1, 1) << ", " << Aref(1, 2) << ", " << Aref(1, 3) << "]\n"
-	    << "   [" << Aref(2, 0) << ", " << Aref(2, 1) << ", " << Aref(2, 2) << ", " << Aref(2, 3) << "]\n"
-	    << "   [" << Aref(3, 0) << ", " << Aref(3, 1) << ", " << Aref(3, 2) << ", " << Aref(3, 3) << "]" << std::endl;
-
   KokkosLapack::getrf(ExecutionSpace(), A, ipiv, info);
 
-  std::cout << "A\n"
-	    << "   [" << A(0, 0) << ", " << A(0, 1) << ", " << A(0, 2) << ", " << A(0, 3) << "]\n"
-	    << "   [" << A(1, 0) << ", " << A(1, 1) << ", " << A(1, 2) << ", " << A(1, 3) << "]\n"
-	    << "   [" << A(2, 0) << ", " << A(2, 1) << ", " << A(2, 2) << ", " << A(2, 3) << "]\n"
-	    << "   [" << A(3, 0) << ", " << A(3, 1) << ", " << A(3, 2) << ", " << A(3, 3) << "]" << std::endl;
-  std::cout << "ipiv: [" << ipiv(0) << ", " << ipiv(1) << ", " << ipiv(2) << ",  " << ipiv(3) << "]" << std::endl;
+  auto ipiv_h = Kokkos::create_mirror_view(ipiv);
+  Kokkos::deep_copy(ipiv_h, ipiv);
 
-  copy_L_plus_I my_func(A, LU);
-  Kokkos::parallel_for(Kokkos::RangePolicy<ExecutionSpace>(0, m * n), my_func);
-  KokkosBlas::trsm(ExecutionSpace(), "R", "U", "N", "N", 1.0, A, LU);
+  copy_U my_func_U(A, U);
+  Kokkos::parallel_for(Kokkos::RangePolicy<ExecutionSpace>(0, m * n), my_func_U);
+  Kokkos::fence();
 
-  std::cout << "LU\n"
-	    << "   [" << LU(0, 0) << ", " << LU(0, 1) << ", " << LU(0, 2) << ", " << LU(0, 3) << "]\n"
-	    << "   [" << LU(1, 0) << ", " << LU(1, 1) << ", " << LU(1, 2) << ", " << LU(1, 3) << "]\n"
-	    << "   [" << LU(2, 0) << ", " << LU(2, 1) << ", " << LU(2, 2) << ", " << LU(2, 3) << "]\n"
-	    << "   [" << LU(3, 0) << ", " << LU(3, 1) << ", " << LU(3, 2) << ", " << LU(3, 3) << "]" << std::endl;
+  copy_L_plus_I my_func_L(A, L);
+  Kokkos::parallel_for(Kokkos::RangePolicy<ExecutionSpace>(0, m * n), my_func_L);
+  Kokkos::fence();
+
+  KokkosBlas::gemm(ExecutionSpace(), "N", "N", 1.0, L, U, 0.0, LU);
+  Kokkos::fence();
+
+  auto Aref_h = Kokkos::create_mirror_view(Aref);
+  Kokkos::deep_copy(Aref_h, Aref);
+  auto LU_h = Kokkos::create_mirror_view(LU);
+  Kokkos::deep_copy(LU_h, LU);
+
+  scalar_type tmp = KokkosKernels::ArithTraits<scalar_type>::zero();
+  for(int rowIdx = 0; rowIdx < m; ++rowIdx) {
+    for(int colIdx = 0; colIdx < n; ++colIdx) {
+      if (rowIdx < min_mn) {
+	tmp = Aref_h(rowIdx, colIdx);
+	Aref_h(rowIdx, colIdx) = Aref_h(ipiv(rowIdx) - 1, colIdx);
+	Aref_h(ipiv(rowIdx) - 1, colIdx) = tmp;
+      }
+      EXPECT_NEAR_KK_REL(LU_h(rowIdx, colIdx), Aref_h(rowIdx, colIdx), tol);
+    }
+  }
 }
 
 }  // namespace Test
@@ -193,10 +280,15 @@ void test_getrf() {
 
   Test::impl_test_getrf_sym<view_type_a>();
   Test::impl_test_getrf_unsym<view_type_a>();
+  Test::impl_test_getrf_tall<view_type_a>();
 
+  Test::impl_test_getrf<view_type_a>(0, 0);
+  Test::impl_test_getrf<view_type_a>(1, 1);
+  Test::impl_test_getrf<view_type_a>(2, 2);
   Test::impl_test_getrf<view_type_a>(4, 4);
-  // Test::impl_test_getrf<view_type_a>(100, 70);
-  // Test::impl_test_getrf<view_type_a>(70, 100);
+  Test::impl_test_getrf<view_type_a>(100, 100);
+  Test::impl_test_getrf<view_type_a>(100, 70);
+  Test::impl_test_getrf<view_type_a>(70, 100);
 #endif
 }
 

--- a/lapack/unit_test/Test_Lapack_getrf.hpp
+++ b/lapack/unit_test/Test_Lapack_getrf.hpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-// only enable this test where KokkosLapack supports gesv:
+// only enable this test where KokkosLapack supports getrf:
 // CUDA+CUSOLVER, HIP+ROCSOLVER and HOST+LAPACK
 #if (defined(TEST_CUDA_LAPACK_CPP) && defined(KOKKOSKERNELS_ENABLE_TPL_CUSOLVER)) ||               \
     (defined(TEST_HIP_LAPACK_CPP) && defined(KOKKOSKERNELS_ENABLE_TPL_ROCSOLVER)) ||               \
@@ -166,6 +166,8 @@ void impl_test_getrf_tall() {
   using scalar_type    = typename AMatrixType::non_const_value_type;
   using ExecutionSpace = typename Device::execution_space;
 
+  ExecutionSpace space{};
+
   const scalar_type zero = KokkosKernels::ArithTraits<scalar_type>::zero();
   const scalar_type one  = KokkosKernels::ArithTraits<scalar_type>::one();
   const scalar_type two  = one + one;
@@ -187,14 +189,14 @@ void impl_test_getrf_tall() {
   IpivType ipiv("LU pivots", min_mn);
   InfoType info("LU info", 1);
 
-  KokkosLapack::getrf(ExecutionSpace(), A, ipiv, info);
+  KokkosLapack::getrf(space, A, ipiv, info);
   Kokkos::deep_copy(A_h, A);
 
   copy_L_plus_I my_func_L(A, L);
-  Kokkos::parallel_for(Kokkos::RangePolicy<ExecutionSpace>(0, m * n), my_func_L);
+  Kokkos::parallel_for(Kokkos::RangePolicy(space, 0, m * n), my_func_L);
   copy_U my_func_U(A, U);
-  Kokkos::parallel_for(Kokkos::RangePolicy<ExecutionSpace>(0, m * n), my_func_U);
-  KokkosBlas::gemm(ExecutionSpace(), "N", "N", 1.0, L, U, 0.0, LU);
+  Kokkos::parallel_for(Kokkos::RangePolicy(space, 0, m * n), my_func_U);
+  KokkosBlas::gemm(space, "N", "N", 1.0, L, U, 0.0, LU);
 
   auto LU_h = Kokkos::create_mirror_view(LU);
   Kokkos::deep_copy(LU_h, LU);

--- a/lapack/unit_test/Test_Lapack_getrf.hpp
+++ b/lapack/unit_test/Test_Lapack_getrf.hpp
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+// only enable this test where KokkosLapack supports gesv:
+// CUDA+CUSOLVER, HIP+ROCSOLVER and HOST+LAPACK
+#if (defined(TEST_CUDA_LAPACK_CPP) && defined(KOKKOSKERNELS_ENABLE_TPL_CUSOLVER)) ||               \
+    (defined(TEST_HIP_LAPACK_CPP) && defined(KOKKOSKERNELS_ENABLE_TPL_ROCSOLVER)) ||               \
+    ((defined(KOKKOSKERNELS_ENABLE_TPL_LAPACK) || defined(KOKKOSKERNELS_ENABLE_TPL_ACCELERATE)) && \
+     (defined(TEST_OPENMP_LAPACK_CPP) || defined(TEST_SERIAL_LAPACK_CPP) || defined(TEST_THREADS_LAPACK_CPP)))
+
+#include <gtest/gtest.h>
+#include <Kokkos_Core.hpp>
+#include <Kokkos_Random.hpp>
+
+#include <KokkosLapack_getrf.hpp>
+#include <KokkosBlas3_gemm.hpp>
+#include <KokkosKernels_TestUtils.hpp>
+
+namespace Test {
+
+template <class AMatrixType>
+void impl_test_getrf_sym() {
+  using Device   = typename AMatrixType::device_type;
+  using IpivType = Kokkos::View<int*, Device>;
+  using InfoType = Kokkos::View<int*, Device>;
+  using scalar_type    = typename AMatrixType::non_const_value_type;
+  using ExecutionSpace = typename Device::execution_space;
+
+  const scalar_type zero = KokkosKernels::ArithTraits<scalar_type>::zero();
+  const scalar_type one  = KokkosKernels::ArithTraits<scalar_type>::one();
+  const scalar_type two  = one + one;
+
+  AMatrixType A("matrix A", 4, 4);
+  auto A_h = Kokkos::create_mirror_view(A);
+  A_h(0, 0) =  two; A_h(0, 1) = -one; A_h(0, 2) = zero; A_h(0, 3) = zero;
+  A_h(1, 0) = -one; A_h(1, 1) =  two; A_h(1, 2) = -one; A_h(1, 3) = zero;
+  A_h(2, 0) = zero; A_h(2, 1) = -one; A_h(2, 2) =  two; A_h(2, 3) = -one;
+  A_h(3, 0) = zero; A_h(3, 1) = zero; A_h(3, 2) = -one; A_h(3, 3) =  two;
+  Kokkos::deep_copy(A, A_h);
+
+  IpivType ipiv("LU pivots", 4);
+  InfoType info("LU info", 1);
+
+  KokkosLapack::getrf(ExecutionSpace(), A, ipiv, info);
+  Kokkos::deep_copy(A_h, A);
+
+  const scalar_type three = one + two;
+  const scalar_type four  = two + two;
+  const scalar_type five  = two + three;
+
+  auto tol  = 10*KokkosKernels::ArithTraits<scalar_type>::eps();
+
+  EXPECT_NEAR_KK_REL(A_h(0, 0),  two, tol);
+  EXPECT_NEAR_KK_REL(A_h(0, 1), -one, tol);
+  EXPECT_NEAR_KK_REL(A_h(0, 2), zero, tol);
+  EXPECT_NEAR_KK_REL(A_h(0, 3), zero, tol);
+
+  EXPECT_NEAR_KK_REL(A_h(1, 0), -one / two, tol);
+  EXPECT_NEAR_KK_REL(A_h(1, 1), three / two, tol);
+  EXPECT_NEAR_KK_REL(A_h(1, 2), -one, tol);
+  EXPECT_NEAR_KK_REL(A_h(1, 3), zero, tol);
+
+  EXPECT_NEAR_KK_REL(A_h(2, 0), zero, tol);
+  EXPECT_NEAR_KK_REL(A_h(2, 1), -two / three, tol);
+  EXPECT_NEAR_KK_REL(A_h(2, 2), four / three, tol);
+  EXPECT_NEAR_KK_REL(A_h(2, 3), -one, tol);
+
+  EXPECT_NEAR_KK_REL(A_h(3, 0), zero, tol);
+  EXPECT_NEAR_KK_REL(A_h(3, 1), zero, tol);
+  EXPECT_NEAR_KK_REL(A_h(3, 2), -three / four, tol);
+  EXPECT_NEAR_KK_REL(A_h(3, 3), five / four, tol);
+
+}  // impl_test_getrf_sym
+
+template <class AMatrixType>
+void impl_test_getrf_unsym() {
+  using Device   = typename AMatrixType::device_type;
+  using IpivType = Kokkos::View<int*, Device>;
+  using InfoType = Kokkos::View<int*, Device>;
+  using scalar_type    = typename AMatrixType::non_const_value_type;
+  using ExecutionSpace = typename Device::execution_space;
+
+  AMatrixType A("matrix A", 3, 3);
+  auto A_h = Kokkos::create_mirror_view(A);
+  A_h(0, 0) = scalar_type(0); A_h(0, 1) = scalar_type(5); A_h(0, 2) = scalar_type(22. / 3);
+  A_h(1, 0) = scalar_type(4); A_h(1, 1) = scalar_type(2); A_h(1, 2) = scalar_type(1);
+  A_h(2, 0) = scalar_type(2); A_h(2, 1) = scalar_type(7); A_h(2, 2) = scalar_type(9);
+  Kokkos::deep_copy(A, A_h);
+
+  IpivType ipiv("LU pivots", 3);
+  InfoType info("LU info", 1);
+
+  KokkosLapack::getrf(ExecutionSpace(), A, ipiv, info);
+  Kokkos::deep_copy(A_h, A);
+  auto ipiv_h = Kokkos::create_mirror_view(ipiv);
+  Kokkos::deep_copy(ipiv_h, ipiv);
+
+  auto tol  = 10*KokkosKernels::ArithTraits<scalar_type>::eps();
+
+  ASSERT_EQ(ipiv_h(0), 2);
+  ASSERT_EQ(ipiv_h(1), 3);
+  ASSERT_EQ(ipiv_h(2), 3);
+
+  EXPECT_NEAR_KK_REL(A_h(0, 0), scalar_type(4), tol);
+  EXPECT_NEAR_KK_REL(A_h(0, 1), scalar_type(2), tol);
+  EXPECT_NEAR_KK_REL(A_h(0, 2), scalar_type(1), tol);
+
+  EXPECT_NEAR_KK_REL(A_h(1, 0), scalar_type(1. / 2), tol);
+  EXPECT_NEAR_KK_REL(A_h(1, 1), scalar_type(6), tol);
+  EXPECT_NEAR_KK_REL(A_h(1, 2), scalar_type(17. / 2), tol);
+
+  EXPECT_NEAR_KK_REL(A_h(2, 0), scalar_type(0), tol);
+  EXPECT_NEAR_KK_REL(A_h(2, 1), scalar_type(5. / 6), tol);
+  EXPECT_NEAR_KK_REL(A_h(2, 2), scalar_type(1. / 4), tol);
+
+}  // impl_test_getrf_unsym
+
+template <class AMatrixType>
+void impl_test_getrf(const int m, const int n) {
+  using Device   = typename AMatrixType::device_type;
+  using IpivType = Kokkos::View<int*, Device>;
+  using InfoType = Kokkos::View<int*, Device>;
+  using scalar_type    = typename AMatrixType::non_const_value_type;
+  using ExecutionSpace = typename Device::execution_space;
+
+  const int minMN = Kokkos::min(m, n);
+
+  AMatrixType A("matrix A", m, n);
+
+  IpivType ipiv("LU pivots", minMN);
+  InfoType info("LU info", 1);
+
+  Kokkos::Random_XorShift64_Pool<ExecutionSpace> rand_pool(13718);
+  Kokkos::fill_random(A, rand_pool, Kokkos::rand<Kokkos::Random_XorShift64<ExecutionSpace>, scalar_type>::max());
+
+  KokkosLapack::getrf(ExecutionSpace(), A, ipiv, info);
+
+}
+
+}  // namespace Test
+
+template <class Scalar, class Device>
+void test_getrf() {
+#if defined(KOKKOSKERNELS_INST_LAYOUTLEFT) || \
+    (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+  using view_type_a = Kokkos::View<Scalar**, Kokkos::LayoutLeft, Device>;
+
+  Test::impl_test_getrf_sym<view_type_a>();
+  Test::impl_test_getrf_unsym<view_type_a>();
+
+  Test::impl_test_getrf<view_type_a>(100, 100);
+  Test::impl_test_getrf<view_type_a>(100, 70);
+  Test::impl_test_getrf<view_type_a>(70, 100);
+#endif
+}
+
+#if defined(KOKKOSKERNELS_INST_FLOAT) || \
+    (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+TEST_F(TestCategory, getrf_float) {
+  Kokkos::Profiling::pushRegion("KokkosLapack::Test::getrf_float");
+  test_getrf<float, TestDevice>();
+  Kokkos::Profiling::popRegion();
+}
+#endif
+
+#if defined(KOKKOSKERNELS_INST_DOUBLE) || \
+    (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+TEST_F(TestCategory, getrf_double) {
+  Kokkos::Profiling::pushRegion("KokkosLapack::Test::getrf_double");
+  test_getrf<double, TestDevice>();
+  Kokkos::Profiling::popRegion();
+}
+#endif
+
+#if defined(KOKKOSKERNELS_INST_COMPLEX_FLOAT) || \
+    (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+TEST_F(TestCategory, getrf_complex_float) {
+  Kokkos::Profiling::pushRegion("KokkosLapack::Test::getrf_complex_float");
+  test_getrf<Kokkos::complex<float>, TestDevice>();
+  Kokkos::Profiling::popRegion();
+}
+#endif
+
+#if defined(KOKKOSKERNELS_INST_COMPLEX_DOUBLE) || \
+    (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
+TEST_F(TestCategory, getrf_complex_double) {
+  Kokkos::Profiling::pushRegion("KokkosLapack::Test::getrf_complex_double");
+  test_getrf<Kokkos::complex<double>, TestDevice>();
+  Kokkos::Profiling::popRegion();
+}
+#endif
+
+#endif  // CUDA+CUSOLVER or HIP+ROCSOLVER or LAPACK+HOST

--- a/scripts/check_api_updates.py
+++ b/scripts/check_api_updates.py
@@ -70,6 +70,7 @@ SRC_DOC_MAPPING = dict([
     ('lapack/src/KokkosLapack_gegqr.hpp', ['docs/source/API/lapack/gegqr.rst']),
     ('lapack/src/KokkosLapack_potrf.hpp', ['docs/source/API/lapack/potrf.rst']),
     ('lapack/src/KokkosLapack_potrs.hpp', ['docs/source/API/lapack/potrs.rst']),
+    ('lapack/src/KokkosLapack_getrf.hpp', ['docs/source/API/lapack/getrf.rst']),
     ('lapack/src/KokkosLapack_gesv.hpp', ['docs/source/API/lapack/gesv.rst']),
     ('lapack/src/KokkosLapack_svd.hpp', ['docs/source/API/lapack/gesvd.rst']),
     ('lapack/src/KokkosLapack_trtri.hpp', ['docs/source/API/lapack/trtri.rst']),

--- a/sparse/src/KokkosSparse_Utils_cusparse.hpp
+++ b/sparse/src/KokkosSparse_Utils_cusparse.hpp
@@ -34,7 +34,7 @@ inline void cusparse_internal_safe_call(cusparseStatus_t cusparseStatus, const c
 #define KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(call) \
   KokkosSparse::Impl::cusparse_internal_safe_call(call, #call, __FILE__, __LINE__)
 
-  //  [[deprecated("Please use KokkosKernels::Impl::cuda_data_type_from() in KokkosKernels_Cuda_utils.hpp")]]
+  //  [[deprecated("Please use KokkosKernels::Impl::cuda_data_type_from() in KokkosKernels_Cuda_Utils.hpp")]]
 template <typename T>
 cudaDataType cuda_data_type_from() {
   return KokkosKernels::Impl::cuda_data_type_from<T>();

--- a/sparse/src/KokkosSparse_Utils_cusparse.hpp
+++ b/sparse/src/KokkosSparse_Utils_cusparse.hpp
@@ -34,7 +34,7 @@ inline void cusparse_internal_safe_call(cusparseStatus_t cusparseStatus, const c
 #define KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(call) \
   KokkosSparse::Impl::cusparse_internal_safe_call(call, #call, __FILE__, __LINE__)
 
-  //  [[deprecated("Please use KokkosKernels::Impl::cuda_data_type_from() in KokkosKernels_Cuda_Utils.hpp")]]
+//  [[deprecated("Please use KokkosKernels::Impl::cuda_data_type_from() in KokkosKernels_Cuda_Utils.hpp")]]
 template <typename T>
 cudaDataType cuda_data_type_from() {
   return KokkosKernels::Impl::cuda_data_type_from<T>();

--- a/sparse/src/KokkosSparse_Utils_cusparse.hpp
+++ b/sparse/src/KokkosSparse_Utils_cusparse.hpp
@@ -9,6 +9,8 @@
 #include "cuda_runtime.h"
 #include "cusparse.h"
 
+#include <KokkosKernels_Cuda_Utils.hpp>
+
 namespace KokkosSparse {
 namespace Impl {
 
@@ -32,47 +34,10 @@ inline void cusparse_internal_safe_call(cusparseStatus_t cusparseStatus, const c
 #define KOKKOSSPARSE_IMPL_CUSPARSE_SAFE_CALL(call) \
   KokkosSparse::Impl::cusparse_internal_safe_call(call, #call, __FILE__, __LINE__)
 
+  //  [[deprecated("Please use KokkosKernels::Impl::cuda_data_type_from() in KokkosKernels_Cuda_utils.hpp")]]
 template <typename T>
 cudaDataType cuda_data_type_from() {
-  // Note:  compile-time failure is disabled to allow for packages such as
-  // Ifpack2 to more easily support scalar types that cuSPARSE may not.
-
-  // compile-time failure with a nice message if called on an unsupported type
-  // static_assert(!std::is_same<T, T>::value,
-  //               "cuSparse TPL does not support scalar type");
-  // static_assert(false, ...) is allowed to error even if the code is not
-  // instantiated. obfuscate the predicate Despite this function being
-  // uncompilable, the compiler may decide that a return statement is missing,
-  // so throw to silence that
-  throw std::logic_error("unreachable throw after static_assert");
-}
-
-/* If half_t is not float, need to define a conversion for both
-   otherwise, conversion for half_t IS conversion for float
-*/
-#if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
-template <>
-inline cudaDataType cuda_data_type_from<Kokkos::Experimental::half_t>() {
-  return CUDA_R_16F;  // Kokkos half_t is a half
-}
-#endif
-// half_t is defined to be float, so this works for both half_t and float when
-// half_t is float
-template <>
-inline cudaDataType cuda_data_type_from<float>() {
-  return CUDA_R_32F;  // Kokkos half_t is a float
-}
-template <>
-inline cudaDataType cuda_data_type_from<double>() {
-  return CUDA_R_64F;
-}
-template <>
-inline cudaDataType cuda_data_type_from<Kokkos::complex<float>>() {
-  return CUDA_C_32F;
-}
-template <>
-inline cudaDataType cuda_data_type_from<Kokkos::complex<double>>() {
-  return CUDA_C_64F;
+  return KokkosKernels::Impl::cuda_data_type_from<T>();
 }
 
 template <typename T>


### PR DESCRIPTION
Adding support for triangular factorization in Lapack, this follows in the footsteps of recent work on Cholesky factorization.
There should not be anything too surprising here except maybe for the move of some utilities in a separate Cuda Utils header...