### PR TITLE
Fixing spgemm due to hash spilling

### DIFF
--- a/sparse/impl/KokkosSparse_bspgemm_impl_kkmem.hpp
+++ b/sparse/impl/KokkosSparse_bspgemm_impl_kkmem.hpp
@@ -596,11 +596,12 @@ struct KokkosBSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_
           nnz_lno_t search_end = team_cuckoo_key_size;  // KOKKOSKERNELS_MACRO_MIN(team_cuckoo_key_size,
                                                         // hash + max_tries);
           for (nnz_lno_t trial = hash; trial < search_end;) {
-            if (keys[trial] == my_b_col) {
+            const nnz_lno_t curr = Kokkos::atomic_load(keys + trial);
+            if (curr == my_b_col) {
               kk_vector_block_add_mul(block_dim, vals + trial * block_size, a_val, b_val);
               fail = 0;
               break;
-            } else if (keys[trial] == init_value) {
+            } else if (curr == init_value) {
               if (!insert_is_on) {
                 try_to_insert = false;
                 break;
@@ -619,11 +620,12 @@ struct KokkosBSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_
             search_end = hash;  // max_tries - (team_cuckoo_key_size -  hash);
 
             for (nnz_lno_t trial = 0; try_to_insert && trial < search_end;) {
-              if (keys[trial] == my_b_col) {
+              const nnz_lno_t curr = Kokkos::atomic_load(keys + trial);
+              if (curr == my_b_col) {
                 kk_vector_block_add_mul(block_dim, vals + trial * block_size, a_val, b_val);
                 fail = 0;
                 break;
-              } else if (keys[trial] == init_value) {
+              } else if (curr == init_value) {
                 if (!insert_is_on) {
                   break;
                 } else if (init_value == Kokkos::atomic_compare_exchange(keys + trial, init_value, my_b_col)) {
@@ -642,12 +644,13 @@ struct KokkosBSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_
               nnz_lno_t new_hash = (my_b_col * HASHSCALAR) & pow2_hash_func;
 
               for (nnz_lno_t trial = new_hash; trial < pow2_hash_size;) {
-                if (global_acc_row_keys[trial] == my_b_col) {
+                const nnz_lno_t curr = Kokkos::atomic_load(global_acc_row_keys + trial);
+                if (curr == my_b_col) {
                   kk_vector_block_add_mul(block_dim, global_acc_row_vals + trial * block_size, a_val, b_val);
                   // c_row_vals[trial] += my_b_val;
                   fail = 0;
                   break;
-                } else if (global_acc_row_keys[trial] == init_value) {
+                } else if (curr == init_value) {
                   if (init_value ==
                       Kokkos::atomic_compare_exchange(global_acc_row_keys + trial, init_value, my_b_col)) {
                     kk_vector_block_add_mul(block_dim, global_acc_row_vals + trial * block_size, a_val, b_val);
@@ -662,12 +665,13 @@ struct KokkosBSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_
               }
               if (fail) {
                 for (nnz_lno_t trial = 0; trial < new_hash;) {
-                  if (global_acc_row_keys[trial] == my_b_col) {
+                  const nnz_lno_t curr = Kokkos::atomic_load(global_acc_row_keys + trial);
+                  if (curr == my_b_col) {
                     // c_row_vals[trial] += my_b_val;
                     kk_vector_block_add_mul(block_dim, global_acc_row_vals + trial * block_size, a_val, b_val);
                     fail = 0;
                     break;
-                  } else if (global_acc_row_keys[trial] == init_value) {
+                  } else if (curr == init_value) {
                     if (init_value ==
                         Kokkos::atomic_compare_exchange(global_acc_row_keys + trial, init_value, my_b_col)) {
                       // Kokkos::atomic_inc(used_hash_sizes + 1);
@@ -698,11 +702,12 @@ struct KokkosBSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_
               nnz_lno_t trial = (my_b_col * HASHSCALAR) & team_cuckoo_hash_func;
               for (nnz_lno_t max_tries = team_cuckoo_key_size; max_tries-- > 0;
                    trial               = (trial + 1) & team_cuckoo_hash_func) {
-                if (keys[trial] == my_b_col) {
+                const nnz_lno_t curr = Kokkos::atomic_load(keys + trial);
+                if (curr == my_b_col) {
                   kk_block_add(block_dim, vals + trial * block_size, b_val);
                   fail = 0;
                   break;
-                } else if (keys[trial] == init_value) {
+                } else if (curr == init_value) {
                   break;
                 }
               }
@@ -873,11 +878,12 @@ struct KokkosBSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_
           fail = 1;
 
           for (nnz_lno_t trial = hash; trial < team_cuckoo_key_size;) {
-            if (keys[trial] == my_b_col) {
+            const nnz_lno_t curr = Kokkos::atomic_load(keys + trial);
+            if (curr == my_b_col) {
               kk_vector_block_add_mul(block_dim, vals + trial * block_size, a_val, b_val);
               fail = 0;
               break;
-            } else if (keys[trial] == init_value) {
+            } else if (curr == init_value) {
               if (init_value == Kokkos::atomic_compare_exchange(keys + trial, init_value, my_b_col)) {
                 kk_vector_block_add_mul(block_dim, vals + trial * block_size, a_val, b_val);
                 fail = 0;
@@ -889,11 +895,12 @@ struct KokkosBSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_
           }
           if (fail) {
             for (nnz_lno_t trial = 0; trial < hash;) {
-              if (keys[trial] == my_b_col) {
+              const nnz_lno_t curr = Kokkos::atomic_load(keys + trial);
+              if (curr == my_b_col) {
                 kk_vector_block_add_mul(block_dim, vals + trial * block_size, a_val, b_val);
                 fail = 0;
                 break;
-              } else if (keys[trial] == init_value) {
+              } else if (curr == init_value) {
                 if (init_value == Kokkos::atomic_compare_exchange(keys + trial, init_value, my_b_col)) {
                   kk_vector_block_add_mul(block_dim, vals + trial * block_size, a_val, b_val);
                   fail = 0;

--- a/sparse/impl/KokkosSparse_bspgemm_impl_kkmem.hpp
+++ b/sparse/impl/KokkosSparse_bspgemm_impl_kkmem.hpp
@@ -493,7 +493,7 @@ struct KokkosBSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_
       scalar_t *global_acc_row_vals  = c_row_vals;
       nnz_lno_t *tmp                 = NULL;
 
-      if (c_row_size > max_first_level_hash_size) {
+      if (c_row_size > max_first_level_hash_size || c_row_size < pow2_hash_size) {
         {
           while (tmp == NULL) {
             Kokkos::single(
@@ -510,10 +510,19 @@ struct KokkosBSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_
           // (team_cuckoo_key_size & (vector_size - 1)) * 1;
           Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember, num_threads), [&](nnz_lno_t teamind) {
             Kokkos::parallel_for(Kokkos::ThreadVectorRange(teamMember, vector_size), [&](nnz_lno_t i) {
-              const auto idx = teamind * vector_size + i;
+              const auto idx           = teamind * vector_size + i;
+              global_acc_row_keys[idx] = init_value;
               kk_block_init(block_dim, global_acc_row_vals + idx * block_size);
             });
           });
+        }
+      }
+      if (tmp == NULL) {
+        // When second-level hash storage aliases output row memory, explicitly
+        // initialize it; entriesC/valuesC are allocated without initialization.
+        for (nnz_lno_t my_index = vector_shift; my_index < c_row_size; my_index += bs) {
+          c_row[my_index] = init_value;
+          kk_block_init(block_dim, c_row_vals + my_index * block_size);
         }
       }
 
@@ -537,8 +546,9 @@ struct KokkosBSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_
         used_hash_sizes[1] = 0;
       });
 
-      bool insert_is_on                  = true;
-      const size_type a_col_begin_offset = row_mapA[row_index];
+      bool insert_is_on                        = true;
+      const nnz_lno_t first_level_insert_limit = team_cuckoo_key_size;
+      const size_type a_col_begin_offset       = row_mapA[row_index];
 
       nnz_lno_t a_col_ind   = entriesA[a_col_begin_offset];
       const scalar_t *a_val = valuesA.data() + a_col_begin_offset * block_size;
@@ -597,7 +607,7 @@ struct KokkosBSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_
               } else if (init_value == Kokkos::atomic_compare_exchange(keys + trial, init_value, my_b_col)) {
                 kk_vector_block_add_mul(block_dim, vals + trial * block_size, a_val, b_val);
                 Kokkos::atomic_inc(used_hash_sizes);
-                if (used_hash_sizes[0] > max_first_level_hash_size) insert_is_on = false;
+                if (used_hash_sizes[0] > first_level_insert_limit) insert_is_on = false;
                 fail = 0;
                 break;
               }
@@ -619,7 +629,7 @@ struct KokkosBSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_
                 } else if (init_value == Kokkos::atomic_compare_exchange(keys + trial, init_value, my_b_col)) {
                   kk_vector_block_add_mul(block_dim, vals + trial * block_size, a_val, b_val);
                   Kokkos::atomic_inc(used_hash_sizes);
-                  if (used_hash_sizes[0] > max_first_level_hash_size) insert_is_on = false;
+                  if (used_hash_sizes[0] > first_level_insert_limit) insert_is_on = false;
                   fail = 0;
                   break;
                 }
@@ -655,6 +665,7 @@ struct KokkosBSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_
                   if (global_acc_row_keys[trial] == my_b_col) {
                     // c_row_vals[trial] += my_b_val;
                     kk_vector_block_add_mul(block_dim, global_acc_row_vals + trial * block_size, a_val, b_val);
+                    fail = 0;
                     break;
                   } else if (global_acc_row_keys[trial] == init_value) {
                     if (init_value ==
@@ -662,6 +673,7 @@ struct KokkosBSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_
                       // Kokkos::atomic_inc(used_hash_sizes + 1);
                       kk_vector_block_add_mul(block_dim, global_acc_row_vals + trial * block_size, a_val, b_val);
                       // c_row_vals[trial] = my_b_val;
+                      fail = 0;
                       break;
                     }
                   } else {

--- a/sparse/impl/KokkosSparse_spgemm_impl_kkmem.hpp
+++ b/sparse/impl/KokkosSparse_spgemm_impl_kkmem.hpp
@@ -579,7 +579,7 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_v
       scalar_t *global_acc_row_vals  = c_row_vals;
       volatile nnz_lno_t *tmp        = NULL;
 
-      if (c_row_size > max_first_level_hash_size) {
+      if (c_row_size > max_first_level_hash_size || c_row_size < pow2_hash_size) {
         {
           while (tmp == NULL) {
             Kokkos::single(
@@ -598,9 +598,19 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_v
           // not needed as team_cuckoo_key_size is always pow2. +
           // (team_cuckoo_key_size & (vector_size - 1)) * 1;
           Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember, num_threads), [&](nnz_lno_t teamind) {
-            Kokkos::parallel_for(Kokkos::ThreadVectorRange(teamMember, vector_size),
-                                 [&](nnz_lno_t i) { global_acc_row_vals[teamind * vector_size + i] = 0; });
+            Kokkos::parallel_for(Kokkos::ThreadVectorRange(teamMember, vector_size), [&](nnz_lno_t i) {
+              global_acc_row_keys[teamind * vector_size + i] = init_value;
+              global_acc_row_vals[teamind * vector_size + i] = 0;
+            });
           });
+        }
+      }
+      if (tmp == NULL) {
+        // When second-level hash storage aliases output row memory, explicitly
+        // initialize it; entriesC/valuesC are allocated without initialization.
+        for (nnz_lno_t my_index = vector_shift; my_index < c_row_size; my_index += bs) {
+          c_row[my_index]      = init_value;
+          c_row_vals[my_index] = 0;
         }
       }
 
@@ -623,8 +633,9 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_v
         used_hash_sizes[1] = 0;
       });
 
-      bool insert_is_on                  = true;
-      const size_type a_col_begin_offset = row_mapA[row_index];
+      bool insert_is_on                        = true;
+      const nnz_lno_t first_level_insert_limit = team_cuckoo_key_size;
+      const size_type a_col_begin_offset       = row_mapA[row_index];
 
       nnz_lno_t a_col_ind = entriesA[a_col_begin_offset];
       scalar_t a_col_val  = valuesA[a_col_begin_offset];
@@ -682,7 +693,7 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_v
               } else if (init_value == Kokkos::atomic_compare_exchange(keys + trial, init_value, my_b_col)) {
                 Kokkos::atomic_add(vals + trial, my_b_val);
                 Kokkos::atomic_inc(used_hash_sizes);
-                if (used_hash_sizes[0] > max_first_level_hash_size) insert_is_on = false;
+                if (used_hash_sizes[0] > first_level_insert_limit) insert_is_on = false;
                 fail = 0;
                 break;
               }
@@ -704,7 +715,7 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_v
                 } else if (init_value == Kokkos::atomic_compare_exchange(keys + trial, init_value, my_b_col)) {
                   Kokkos::atomic_add(vals + trial, my_b_val);
                   Kokkos::atomic_inc(used_hash_sizes);
-                  if (used_hash_sizes[0] > max_first_level_hash_size) insert_is_on = false;
+                  if (used_hash_sizes[0] > first_level_insert_limit) insert_is_on = false;
                   fail = 0;
                   break;
                 }
@@ -741,7 +752,7 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_v
                   if (global_acc_row_keys[trial] == my_b_col) {
                     // c_row_vals[trial] += my_b_val;
                     Kokkos::atomic_add(global_acc_row_vals + trial, my_b_val);
-
+                    fail = 0;
                     break;
                   } else if (global_acc_row_keys[trial] == init_value) {
                     if (init_value ==
@@ -749,6 +760,7 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_v
                       // Kokkos::atomic_inc(used_hash_sizes + 1);
                       Kokkos::atomic_add(global_acc_row_vals + trial, my_b_val);
                       // c_row_vals[trial] = my_b_val;
+                      fail = 0;
                       break;
                     }
                   } else {

--- a/sparse/impl/KokkosSparse_spgemm_impl_kkmem.hpp
+++ b/sparse/impl/KokkosSparse_spgemm_impl_kkmem.hpp
@@ -682,11 +682,12 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_v
           nnz_lno_t search_end = team_cuckoo_key_size;  // KOKKOSKERNELS_MACRO_MIN(team_cuckoo_key_size,
                                                         // hash + max_tries);
           for (nnz_lno_t trial = hash; trial < search_end;) {
-            if (keys[trial] == my_b_col) {
+            const nnz_lno_t curr = Kokkos::atomic_load(keys + trial);
+            if (curr == my_b_col) {
               Kokkos::atomic_add(vals + trial, my_b_val);
               fail = 0;
               break;
-            } else if (keys[trial] == init_value) {
+            } else if (curr == init_value) {
               if (!insert_is_on) {
                 try_to_insert = false;
                 break;
@@ -705,11 +706,12 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_v
             search_end = hash;  // max_tries - (team_cuckoo_key_size -  hash);
 
             for (nnz_lno_t trial = 0; try_to_insert && trial < search_end;) {
-              if (keys[trial] == my_b_col) {
+              const nnz_lno_t curr = Kokkos::atomic_load(keys + trial);
+              if (curr == my_b_col) {
                 Kokkos::atomic_add(vals + trial, my_b_val);
                 fail = 0;
                 break;
-              } else if (keys[trial] == init_value) {
+              } else if (curr == init_value) {
                 if (!insert_is_on) {
                   break;
                 } else if (init_value == Kokkos::atomic_compare_exchange(keys + trial, init_value, my_b_col)) {
@@ -728,13 +730,14 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_v
               nnz_lno_t new_hash = (my_b_col * HASHSCALAR) & pow2_hash_func;
 
               for (nnz_lno_t trial = new_hash; trial < pow2_hash_size;) {
-                if (global_acc_row_keys[trial] == my_b_col) {
+                const nnz_lno_t curr = Kokkos::atomic_load(global_acc_row_keys + trial);
+                if (curr == my_b_col) {
                   Kokkos::atomic_add(global_acc_row_vals + trial, my_b_val);
 
                   // c_row_vals[trial] += my_b_val;
                   fail = 0;
                   break;
-                } else if (global_acc_row_keys[trial] == init_value) {
+                } else if (curr == init_value) {
                   if (init_value ==
                       Kokkos::atomic_compare_exchange(global_acc_row_keys + trial, init_value, my_b_col)) {
                     Kokkos::atomic_add(global_acc_row_vals + trial, my_b_val);
@@ -749,12 +752,13 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_v
               }
               if (fail) {
                 for (nnz_lno_t trial = 0; trial < new_hash;) {
-                  if (global_acc_row_keys[trial] == my_b_col) {
+                  const nnz_lno_t curr = Kokkos::atomic_load(global_acc_row_keys + trial);
+                  if (curr == my_b_col) {
                     // c_row_vals[trial] += my_b_val;
                     Kokkos::atomic_add(global_acc_row_vals + trial, my_b_val);
                     fail = 0;
                     break;
-                  } else if (global_acc_row_keys[trial] == init_value) {
+                  } else if (curr == init_value) {
                     if (init_value ==
                         Kokkos::atomic_compare_exchange(global_acc_row_keys + trial, init_value, my_b_col)) {
                       // Kokkos::atomic_inc(used_hash_sizes + 1);
@@ -788,22 +792,24 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_v
               nnz_lno_t search_end = team_cuckoo_key_size;  // KOKKOSKERNELS_MACRO_MIN(team_cuckoo_key_size,
                                                             // hash + max_tries);
               for (nnz_lno_t trial = hash; trial < search_end; ++trial) {
-                if (keys[trial] == my_b_col) {
+                const nnz_lno_t curr = Kokkos::atomic_load(keys + trial);
+                if (curr == my_b_col) {
                   vals[trial] += my_b_val;
                   fail = 0;
                   break;
-                } else if (keys[trial] == init_value) {
+                } else if (curr == init_value) {
                   break;
                 }
               }
               search_end = hash;  // max_tries - (team_cuckoo_key_size -  hash);
 
               for (nnz_lno_t trial = 0; trial < search_end; ++trial) {
-                if (keys[trial] == my_b_col) {
+                const nnz_lno_t curr = Kokkos::atomic_load(keys + trial);
+                if (curr == my_b_col) {
                   vals[trial] += my_b_val;
                   fail = 0;
                   break;
-                } else if (keys[trial] == init_value) {
+                } else if (curr == init_value) {
                   break;
                 }
               }
@@ -972,11 +978,12 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_v
           fail = 1;
 
           for (nnz_lno_t trial = hash; trial < team_cuckoo_key_size;) {
-            if (keys[trial] == my_b_col) {
+            const nnz_lno_t curr = Kokkos::atomic_load(keys + trial);
+            if (curr == my_b_col) {
               Kokkos::atomic_add(vals + trial, my_b_val);
               fail = 0;
               break;
-            } else if (keys[trial] == init_value) {
+            } else if (curr == init_value) {
               if (init_value == Kokkos::atomic_compare_exchange(keys + trial, init_value, my_b_col)) {
                 Kokkos::atomic_add(vals + trial, my_b_val);
                 fail = 0;
@@ -988,11 +995,12 @@ struct KokkosSPGEMM<HandleType, a_row_view_t_, a_lno_nnz_view_t_, a_scalar_nnz_v
           }
           if (fail) {
             for (nnz_lno_t trial = 0; trial < hash;) {
-              if (keys[trial] == my_b_col) {
+              const nnz_lno_t curr = Kokkos::atomic_load(keys + trial);
+              if (curr == my_b_col) {
                 Kokkos::atomic_add(vals + trial, my_b_val);
                 fail = 0;
                 break;
-              } else if (keys[trial] == init_value) {
+              } else if (curr == init_value) {
                 if (init_value == Kokkos::atomic_compare_exchange(keys + trial, init_value, my_b_col)) {
                   Kokkos::atomic_add(vals + trial, my_b_val);
                   fail = 0;

--- a/sparse/unit_test/Test_Sparse_Utils.hpp
+++ b/sparse/unit_test/Test_Sparse_Utils.hpp
@@ -92,8 +92,71 @@ bool is_same_matrix(crsMat_t output_mat_actual, crsMat_t output_mat_reference) {
 
   if (!is_identical) {
     std::cout << "entries are different." << std::endl;
+    auto rowmap_actual = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), output_mat_actual.graph.row_map);
+    auto rowmap_reference =
+        Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), output_mat_reference.graph.row_map);
+    auto entries_actual = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), output_mat_actual.graph.entries);
+    auto entries_reference =
+        Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), output_mat_reference.graph.entries);
+
+    size_t first_mismatch = nentries_actual;
+    for (size_t i = 0; i < nentries_actual; ++i) {
+      if (entries_actual(i) != entries_reference(i)) {
+        first_mismatch = i;
+        break;
+      }
+    }
+
+    if (first_mismatch < nentries_actual) {
+      size_t mismatch_row = 0;
+      for (size_t r = 0; r + 1 < rowmap_actual.extent(0); ++r) {
+        if (rowmap_actual(r) <= first_mismatch && first_mismatch < rowmap_actual(r + 1)) {
+          mismatch_row = r;
+          break;
+        }
+      }
+
+      size_t row_begin_actual = rowmap_actual(mismatch_row);
+      size_t row_end_actual   = rowmap_actual(mismatch_row + 1);
+      size_t row_begin_ref    = rowmap_reference(mismatch_row);
+      size_t row_end_ref      = rowmap_reference(mismatch_row + 1);
+
+      std::cout << "  first mismatch index: " << first_mismatch << '\n';
+      std::cout << "  mismatch row: " << mismatch_row << '\n';
+      std::cout << "  actual row range: [" << row_begin_actual << ", " << row_end_actual << ")\n";
+      std::cout << "  reference row range: [" << row_begin_ref << ", " << row_end_ref << ")\n";
+
+      std::cout << "  actual row entries: ";
+      for (size_t i = row_begin_actual; i < row_end_actual; ++i) {
+        std::cout << entries_actual(i) << (i + 1 < row_end_actual ? ' ' : '\n');
+      }
+
+      std::cout << "  reference row entries: ";
+      for (size_t i = row_begin_ref; i < row_end_ref; ++i) {
+        std::cout << entries_reference(i) << (i + 1 < row_end_ref ? ' ' : '\n');
+      }
+    }
     KokkosKernels::Impl::kk_print_1Dview(output_mat_actual.graph.entries);
     KokkosKernels::Impl::kk_print_1Dview(output_mat_reference.graph.entries);
+
+    // Check whether the two matrices are at least functionally equivalent
+    // under SpMV; this helps distinguish ordering-only mismatches from
+    // correctness bugs.
+    using scalar_t = typename scalar_view_t::value_type;
+    using x_view_t = Kokkos::View<scalar_t *, typename crsMat_t::device_type>;
+    x_view_t x("debug_x", output_mat_actual.numCols());
+    scalar_t randStart, randEnd;
+    KokkosKernels::Impl::getRandomBounds(10.0, randStart, randEnd);
+    Kokkos::Random_XorShift64_Pool<typename crsMat_t::execution_space> pool(424242);
+    Kokkos::fill_random(x, pool, randStart, randEnd);
+    auto y_actual  = create_random_y_vector(output_mat_actual, x);
+    auto y_ref     = create_random_y_vector(output_mat_reference, x);
+    using mag_t    = typename KokkosKernels::ArithTraits<scalar_t>::mag_type;
+    mag_t spmv_eps = std::is_same<mag_t, float>::value ? 3.7e-3 : 1e-7;
+    bool spmv_same = KokkosKernels::Impl::kk_is_relatively_identical_view<decltype(y_actual), decltype(y_ref), mag_t,
+                                                                          typename device::execution_space>(
+        y_actual, y_ref, spmv_eps);
+    std::cout << "  SpMV functional equivalence: " << (spmv_same ? "PASS" : "FAIL") << std::endl;
     return false;
   }
 

--- a/sparse/unit_test/Test_Sparse_Utils.hpp
+++ b/sparse/unit_test/Test_Sparse_Utils.hpp
@@ -110,7 +110,9 @@ bool is_same_matrix(crsMat_t output_mat_actual, crsMat_t output_mat_reference) {
     if (first_mismatch < nentries_actual) {
       size_t mismatch_row = 0;
       for (size_t r = 0; r + 1 < rowmap_actual.extent(0); ++r) {
-        if (rowmap_actual(r) <= first_mismatch && first_mismatch < rowmap_actual(r + 1)) {
+        const size_t row_begin = static_cast<size_t>(rowmap_actual(r));
+        const size_t row_end   = static_cast<size_t>(rowmap_actual(r + 1));
+        if (row_begin <= first_mismatch && first_mismatch < row_end) {
           mismatch_row = r;
           break;
         }

--- a/sparse/unit_test/Test_Sparse_spgemm.hpp
+++ b/sparse/unit_test/Test_Sparse_spgemm.hpp
@@ -312,8 +312,9 @@ void test_spgemm(lno_t m, lno_t k, lno_t n, size_type nnz, lno_t bandwidth, lno_
       EXPECT_TRUE((res == 0)) << algo;
       bool is_identical = is_same_matrix<crsMat_t, device>(output_mat, output_mat2);
       EXPECT_TRUE(is_identical) << "SpGEMM result incorrect: algo=" << algo << ", callMode=" << int(callMode)
-                  << ", testReuse=" << int(testReuse) << ", m=" << m << ", k=" << k << ", n=" << n << ", nnz=" << nnz
-                  << ", bandwidth=" << bandwidth << ", row_size_variance=" << row_size_variance;
+                                << ", testReuse=" << int(testReuse) << ", m=" << m << ", k=" << k << ", n=" << n 
+                                << ", nnz=" << nnz << ", bandwidth=" << bandwidth 
+                                << ", row_size_variance=" << row_size_variance;
       // EXPECT_TRUE( equal) << algo;
     }
     // std::cout << "algo:" << algo << " spgemm_time:" << spgemm_time << "

--- a/sparse/unit_test/Test_Sparse_spgemm.hpp
+++ b/sparse/unit_test/Test_Sparse_spgemm.hpp
@@ -129,7 +129,6 @@ int run_spgemm_old_interface(crsMat_t &A, crsMat_t &B, KokkosSparse::SPGEMMAlgor
   KernelHandle kh;
   kh.set_team_work_size(16);
   kh.set_dynamic_scheduling(true);
-  // kh.set_verbose(true);
 
   kh.create_spgemm_handle(spgemm_algorithm);
   {
@@ -312,6 +311,11 @@ void test_spgemm(lno_t m, lno_t k, lno_t n, size_type nnz, lno_t bandwidth, lno_
     if (!is_expected_to_fail) {
       EXPECT_TRUE((res == 0)) << algo;
       bool is_identical = is_same_matrix<crsMat_t, device>(output_mat, output_mat2);
+      if (!is_identical) {
+        std::cout << "SpGEMM mismatch context: algo=" << algo << ", callMode=" << int(callMode)
+                  << ", testReuse=" << int(testReuse) << ", m=" << m << ", k=" << k << ", n=" << n << ", nnz=" << nnz
+                  << ", bandwidth=" << bandwidth << ", row_size_variance=" << row_size_variance << std::endl;
+      }
       EXPECT_TRUE(is_identical) << algo;
       // EXPECT_TRUE( equal) << algo;
     }

--- a/sparse/unit_test/Test_Sparse_spgemm.hpp
+++ b/sparse/unit_test/Test_Sparse_spgemm.hpp
@@ -311,12 +311,9 @@ void test_spgemm(lno_t m, lno_t k, lno_t n, size_type nnz, lno_t bandwidth, lno_
     if (!is_expected_to_fail) {
       EXPECT_TRUE((res == 0)) << algo;
       bool is_identical = is_same_matrix<crsMat_t, device>(output_mat, output_mat2);
-      if (!is_identical) {
-        std::cout << "SpGEMM mismatch context: algo=" << algo << ", callMode=" << int(callMode)
+      EXPECT_TRUE(is_identical) << "SpGEMM result incorrect: algo=" << algo << ", callMode=" << int(callMode)
                   << ", testReuse=" << int(testReuse) << ", m=" << m << ", k=" << k << ", n=" << n << ", nnz=" << nnz
-                  << ", bandwidth=" << bandwidth << ", row_size_variance=" << row_size_variance << std::endl;
-      }
-      EXPECT_TRUE(is_identical) << algo;
+                  << ", bandwidth=" << bandwidth << ", row_size_variance=" << row_size_variance;
       // EXPECT_TRUE( equal) << algo;
     }
     // std::cout << "algo:" << algo << " spgemm_time:" << spgemm_time << "

--- a/sparse/unit_test/Test_Sparse_spgemm.hpp
+++ b/sparse/unit_test/Test_Sparse_spgemm.hpp
@@ -312,8 +312,8 @@ void test_spgemm(lno_t m, lno_t k, lno_t n, size_type nnz, lno_t bandwidth, lno_
       EXPECT_TRUE((res == 0)) << algo;
       bool is_identical = is_same_matrix<crsMat_t, device>(output_mat, output_mat2);
       EXPECT_TRUE(is_identical) << "SpGEMM result incorrect: algo=" << algo << ", callMode=" << int(callMode)
-                                << ", testReuse=" << int(testReuse) << ", m=" << m << ", k=" << k << ", n=" << n 
-                                << ", nnz=" << nnz << ", bandwidth=" << bandwidth 
+                                << ", testReuse=" << int(testReuse) << ", m=" << m << ", k=" << k << ", n=" << n
+                                << ", nnz=" << nnz << ", bandwidth=" << bandwidth
                                 << ", row_size_variance=" << row_size_variance;
       // EXPECT_TRUE( equal) << algo;
     }


### PR DESCRIPTION
With some help from Codex 5.3 Medium, iterated over the test to confirm that the test failures are related to spilling the hashes and some uninitialized variables. When failures do happen, additional diagnostic output is given and I kept that code.
The fixes include:

  * The key fix is letting the first-level hash accept inserts up to its actual full capacity (team_cuckoo_key_size) instead of cutting off early at max_first_level_hash_size.
  * So the hash table itself isn’t fundamentally bigger; we stop spilling too early.
  * I also kept the earlier safety fix that avoids undersized aliasing of L2 storage (c_row_size < pow2_hash_size), which is about correct storage usage rather than increasing nominal hash size.

Fix for #2083