### PR TITLE
CI: clearing kokkos-kernels-performance on Frontier

### DIFF
--- a/.gitlab/olcf-gitlab-ci.yml
+++ b/.gitlab/olcf-gitlab-ci.yml
@@ -19,6 +19,7 @@ hipcc:
     - cmake --build build_hip --target install
     - cd ../..
     - ctest -VV -S ${PWD}/kokkos-kernels/.gitlab/frontier-ctest.cmake
+    - rm -rf kokkos-kernels-performance
     - git clone https://github.com/kokkos/kokkos-kernels-performance.git
     - find kokkos-kernels_build/benchmarks -name "*.json" -exec mv {} kokkos-kernels-performance/Frontier \;
     - cd kokkos-kernels-performance


### PR DESCRIPTION
Just adding a command to delete the directory in case it already exists and is in a bad state...