### PR TITLE
CodeQL: grouping dependabot updates of CodeQL

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    group:
+      codeql-action:
+        pattern:
+	  - "github/codeql-action/*"
 
   - package-ecosystem: pip
     directory: /docs

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,8 @@ updates:
       interval: weekly
     group:
       codeql-action:
-        pattern:
-	  - "github/codeql-action/*"
+        patterns:
+          - "github/codeql-action/*"
 
   - package-ecosystem: pip
     directory: /docs


### PR DESCRIPTION
This should allow these updates to actually pass CI without having to create new PRs manually which also mean I won't need to bug a second person to review the manual PR either...
This follows the pattern of the same PR [#9399](https://github.com/kokkos/kokkos/pull/9399) that was made against Kokkos Core.