### PR TITLE
Some minor improvements to test stuff, moved from other PR

### DIFF
--- a/batched/dense/unit_test/Test_Batched_BatchedGemm.hpp
+++ b/batched/dense/unit_test/Test_Batched_BatchedGemm.hpp
@@ -64,7 +64,7 @@ void impl_test_batched_gemm_with_handle(BatchedGemmHandle* batchedGemmHandle, co
   if (algo_type == GemmKokkosBatchedAlgos::KK_DBLBUF) {
     // Check for DblBuf runtime errors related to team_size
     try {
-      fmsg = kk_failure_str(__FILE__, __FUNCTION__, __LINE__);
+      fmsg = TestUtils::kk_failure_str(__FILE__, __FUNCTION__, __LINE__);
       KokkosBatched::Impl::BatchedDblBufGemm<transA, transB, batchLayout, BatchedGemmHandle, ScalarType,
                                              decltype(a_actual), decltype(b_actual), decltype(c_actual),
                                              BoundsCheck::Yes, AlphaTag::No, 65536, 1, 65536>(
@@ -76,7 +76,7 @@ void impl_test_batched_gemm_with_handle(BatchedGemmHandle* batchedGemmHandle, co
 
     // Check for DblBuf runtime errors related to vector_len
     try {
-      fmsg = kk_failure_str(__FILE__, __FUNCTION__, __LINE__);
+      fmsg = TestUtils::kk_failure_str(__FILE__, __FUNCTION__, __LINE__);
       KokkosBatched::Impl::BatchedDblBufGemm<transA, transB, batchLayout, BatchedGemmHandle, ScalarType,
                                              decltype(a_actual), decltype(b_actual), decltype(c_actual),
                                              BoundsCheck::No, AlphaTag::No, 65536, 65536 * 2, 65536>(
@@ -97,7 +97,7 @@ void impl_test_batched_gemm_with_handle(BatchedGemmHandle* batchedGemmHandle, co
     }
 #endif
 
-    fmsg = kk_failure_str(__FILE__, __FUNCTION__, __LINE__);
+    fmsg = TestUtils::kk_failure_str(__FILE__, __FUNCTION__, __LINE__);
     ret  = BatchedGemm<transA, transB, batchLayout>(batchedGemmHandle, alpha, a_actual, b_actual, beta,
                                                    c_actual);  // Compute c_actual
   } catch (const std::runtime_error& error) {
@@ -170,7 +170,7 @@ void impl_test_batched_gemm_with_handle(BatchedGemmHandle* batchedGemmHandle, co
     }
   }
 
-  EXPECT_NEAR_KK(diff / sum, 0, eps, fmsg + fmsg_rhs);
+  EXPECT_NEAR_KK(diff / sum, 0, eps) << fmsg + fmsg_rhs;
 }
 
 template <typename DeviceType, typename ViewType, typename ScalarType, typename ParamTagType>
@@ -239,7 +239,7 @@ void impl_test_batched_gemm(const int N, const int matAdim1, const int matAdim2,
             ScalarType alpha = 0.34;
             ScalarType beta  = 0.43;
             BatchedGemm<ta, tb, bl>(&batchedGemmHandle, alpha, a_actual, b_actual, beta, c_actual);
-            std::string fmsg = kk_failure_str(__FILE__, __FUNCTION__, __LINE__);
+            std::string fmsg = TestUtils::kk_failure_str(__FILE__, __FUNCTION__, __LINE__);
             FAIL() << fmsg;
           } catch (const std::runtime_error& error) {
           }
@@ -248,7 +248,7 @@ void impl_test_batched_gemm(const int N, const int matAdim1, const int matAdim2,
 #if !defined(KOKKOSKERNELS_ENABLE_TPL_ARMPL) || (ARMPL_BUILD < 1058)
         if (algo_type == BaseTplAlgos::ARMPL) {
         } else {
-          std::string fmsg = kk_failure_str(__FILE__, __FUNCTION__, __LINE__);
+          std::string fmsg = TestUtils::kk_failure_str(__FILE__, __FUNCTION__, __LINE__);
           FAIL() << fmsg;
         }
 #endif  // KOKKOSKERNELS_ENABLE_TPL_ARMPL
@@ -309,7 +309,7 @@ int test_batched_gemm() {
     (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
   if constexpr (std::is_same_v<typename ParamTagType::batchLayout, typename BatchLayout::Right>) {
     using param_tag_type =
-        ::Test::SharedParamTag<typename ParamTagType::transA, typename ParamTagType::transB, BatchLayout::Right>;
+        TestUtils::SharedParamTag<typename ParamTagType::transA, typename ParamTagType::transB, BatchLayout::Right>;
     typedef Kokkos::View<ValueType***, Kokkos::LayoutLeft, DeviceType> llVt;
     test_batched_gemm_with_layout<llVt, DeviceType, ValueType, ScalarType, param_tag_type>(0);
     test_batched_gemm_with_layout<llVt, DeviceType, ValueType, ScalarType, param_tag_type>(1);
@@ -327,7 +327,7 @@ int test_batched_gemm() {
     (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
   if constexpr (std::is_same_v<typename ParamTagType::batchLayout, typename BatchLayout::Left>) {
     using param_tag_type =
-        ::Test::SharedParamTag<typename ParamTagType::transA, typename ParamTagType::transB, BatchLayout::Left>;
+        TestUtils::SharedParamTag<typename ParamTagType::transA, typename ParamTagType::transB, BatchLayout::Left>;
     typedef Kokkos::View<ValueType***, Kokkos::LayoutRight, DeviceType> lrVt;
     test_batched_gemm_with_layout<lrVt, DeviceType, ValueType, ScalarType, param_tag_type>(0);
     test_batched_gemm_with_layout<lrVt, DeviceType, ValueType, ScalarType, param_tag_type>(1);

--- a/batched/dense/unit_test/Test_Batched_BatchedGemm_Complex.hpp
+++ b/batched/dense/unit_test/Test_Batched_BatchedGemm_Complex.hpp
@@ -3,43 +3,43 @@
 #if defined(KOKKOSKERNELS_INST_COMPLEX_FLOAT)
 /********************* BatchLayout::Left *********************/
 TEST_F(TestCategory, batched_scalar_batched_gemm_nt_nt_scomplex_scomplex_left) {
-  typedef ::Test::SharedParamTag<Trans::NoTranspose, Trans::NoTranspose, BatchLayout::Left> param_tag_type;
+  typedef TestUtils::SharedParamTag<Trans::NoTranspose, Trans::NoTranspose, BatchLayout::Left> param_tag_type;
 
   test_batched_gemm<TestDevice, Kokkos::complex<float>, Kokkos::complex<float>, param_tag_type>();
 }
 TEST_F(TestCategory, batched_scalar_batched_gemm_t_nt_scomplex_scomplex_left) {
-  typedef ::Test::SharedParamTag<Trans::Transpose, Trans::NoTranspose, BatchLayout::Left> param_tag_type;
+  typedef TestUtils::SharedParamTag<Trans::Transpose, Trans::NoTranspose, BatchLayout::Left> param_tag_type;
 
   test_batched_gemm<TestDevice, Kokkos::complex<float>, Kokkos::complex<float>, param_tag_type>();
 }
 TEST_F(TestCategory, batched_scalar_batched_gemm_nt_t_scomplex_scomplex_left) {
-  typedef ::Test::SharedParamTag<Trans::NoTranspose, Trans::Transpose, BatchLayout::Left> param_tag_type;
+  typedef TestUtils::SharedParamTag<Trans::NoTranspose, Trans::Transpose, BatchLayout::Left> param_tag_type;
 
   test_batched_gemm<TestDevice, Kokkos::complex<float>, Kokkos::complex<float>, param_tag_type>();
 }
 TEST_F(TestCategory, batched_scalar_batched_gemm_t_t_scomplex_scomplex_left) {
-  typedef ::Test::SharedParamTag<Trans::Transpose, Trans::Transpose, BatchLayout::Left> param_tag_type;
+  typedef TestUtils::SharedParamTag<Trans::Transpose, Trans::Transpose, BatchLayout::Left> param_tag_type;
 
   test_batched_gemm<TestDevice, Kokkos::complex<float>, Kokkos::complex<float>, param_tag_type>();
 }
 /********************* BatchLayout::Right *********************/
 TEST_F(TestCategory, batched_scalar_batched_gemm_nt_nt_scomplex_scomplex_right) {
-  typedef ::Test::SharedParamTag<Trans::NoTranspose, Trans::NoTranspose, BatchLayout::Right> param_tag_type;
+  typedef TestUtils::SharedParamTag<Trans::NoTranspose, Trans::NoTranspose, BatchLayout::Right> param_tag_type;
 
   test_batched_gemm<TestDevice, Kokkos::complex<float>, Kokkos::complex<float>, param_tag_type>();
 }
 TEST_F(TestCategory, batched_scalar_batched_gemm_t_nt_scomplex_scomplex_right) {
-  typedef ::Test::SharedParamTag<Trans::Transpose, Trans::NoTranspose, BatchLayout::Right> param_tag_type;
+  typedef TestUtils::SharedParamTag<Trans::Transpose, Trans::NoTranspose, BatchLayout::Right> param_tag_type;
 
   test_batched_gemm<TestDevice, Kokkos::complex<float>, Kokkos::complex<float>, param_tag_type>();
 }
 TEST_F(TestCategory, batched_scalar_batched_gemm_nt_t_scomplex_scomplex_right) {
-  typedef ::Test::SharedParamTag<Trans::NoTranspose, Trans::Transpose, BatchLayout::Right> param_tag_type;
+  typedef TestUtils::SharedParamTag<Trans::NoTranspose, Trans::Transpose, BatchLayout::Right> param_tag_type;
 
   test_batched_gemm<TestDevice, Kokkos::complex<float>, Kokkos::complex<float>, param_tag_type>();
 }
 TEST_F(TestCategory, batched_scalar_batched_gemm_t_t_scomplex_scomplex_right) {
-  typedef ::Test::SharedParamTag<Trans::Transpose, Trans::Transpose, BatchLayout::Right> param_tag_type;
+  typedef TestUtils::SharedParamTag<Trans::Transpose, Trans::Transpose, BatchLayout::Right> param_tag_type;
 
   test_batched_gemm<TestDevice, Kokkos::complex<float>, Kokkos::complex<float>, param_tag_type>();
 }
@@ -48,43 +48,43 @@ TEST_F(TestCategory, batched_scalar_batched_gemm_t_t_scomplex_scomplex_right) {
 #if defined(KOKKOSKERNELS_INST_COMPLEX_DOUBLE)
 /********************* BatchLayout::Left *********************/
 TEST_F(TestCategory, batched_scalar_batched_gemm_nt_nt_dcomplex_dcomplex_left) {
-  typedef ::Test::SharedParamTag<Trans::NoTranspose, Trans::NoTranspose, BatchLayout::Left> param_tag_type;
+  typedef TestUtils::SharedParamTag<Trans::NoTranspose, Trans::NoTranspose, BatchLayout::Left> param_tag_type;
 
   test_batched_gemm<TestDevice, Kokkos::complex<double>, Kokkos::complex<double>, param_tag_type>();
 }
 TEST_F(TestCategory, batched_scalar_batched_gemm_t_nt_dcomplex_dcomplex_left) {
-  typedef ::Test::SharedParamTag<Trans::Transpose, Trans::NoTranspose, BatchLayout::Left> param_tag_type;
+  typedef TestUtils::SharedParamTag<Trans::Transpose, Trans::NoTranspose, BatchLayout::Left> param_tag_type;
 
   test_batched_gemm<TestDevice, Kokkos::complex<double>, Kokkos::complex<double>, param_tag_type>();
 }
 TEST_F(TestCategory, batched_scalar_batched_gemm_nt_t_dcomplex_dcomplex_left) {
-  typedef ::Test::SharedParamTag<Trans::NoTranspose, Trans::Transpose, BatchLayout::Left> param_tag_type;
+  typedef TestUtils::SharedParamTag<Trans::NoTranspose, Trans::Transpose, BatchLayout::Left> param_tag_type;
 
   test_batched_gemm<TestDevice, Kokkos::complex<double>, Kokkos::complex<double>, param_tag_type>();
 }
 TEST_F(TestCategory, batched_scalar_batched_gemm_t_t_dcomplex_dcomplex_left) {
-  typedef ::Test::SharedParamTag<Trans::Transpose, Trans::Transpose, BatchLayout::Left> param_tag_type;
+  typedef TestUtils::SharedParamTag<Trans::Transpose, Trans::Transpose, BatchLayout::Left> param_tag_type;
 
   test_batched_gemm<TestDevice, Kokkos::complex<double>, Kokkos::complex<double>, param_tag_type>();
 }
 /********************* BatchLayout::Right *********************/
 TEST_F(TestCategory, batched_scalar_batched_gemm_nt_nt_dcomplex_dcomplex_right) {
-  typedef ::Test::SharedParamTag<Trans::NoTranspose, Trans::NoTranspose, BatchLayout::Right> param_tag_type;
+  typedef TestUtils::SharedParamTag<Trans::NoTranspose, Trans::NoTranspose, BatchLayout::Right> param_tag_type;
 
   test_batched_gemm<TestDevice, Kokkos::complex<double>, Kokkos::complex<double>, param_tag_type>();
 }
 TEST_F(TestCategory, batched_scalar_batched_gemm_t_nt_dcomplex_dcomplex_right) {
-  typedef ::Test::SharedParamTag<Trans::Transpose, Trans::NoTranspose, BatchLayout::Right> param_tag_type;
+  typedef TestUtils::SharedParamTag<Trans::Transpose, Trans::NoTranspose, BatchLayout::Right> param_tag_type;
 
   test_batched_gemm<TestDevice, Kokkos::complex<double>, Kokkos::complex<double>, param_tag_type>();
 }
 TEST_F(TestCategory, batched_scalar_batched_gemm_nt_t_dcomplex_dcomplex_right) {
-  typedef ::Test::SharedParamTag<Trans::NoTranspose, Trans::Transpose, BatchLayout::Right> param_tag_type;
+  typedef TestUtils::SharedParamTag<Trans::NoTranspose, Trans::Transpose, BatchLayout::Right> param_tag_type;
 
   test_batched_gemm<TestDevice, Kokkos::complex<double>, Kokkos::complex<double>, param_tag_type>();
 }
 TEST_F(TestCategory, batched_scalar_batched_gemm_t_t_dcomplex_dcomplex_right) {
-  typedef ::Test::SharedParamTag<Trans::Transpose, Trans::Transpose, BatchLayout::Right> param_tag_type;
+  typedef TestUtils::SharedParamTag<Trans::Transpose, Trans::Transpose, BatchLayout::Right> param_tag_type;
 
   test_batched_gemm<TestDevice, Kokkos::complex<double>, Kokkos::complex<double>, param_tag_type>();
 }

--- a/batched/dense/unit_test/Test_Batched_BatchedGemm_Real.hpp
+++ b/batched/dense/unit_test/Test_Batched_BatchedGemm_Real.hpp
@@ -7,43 +7,43 @@
     defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
 /********************* BatchLayout::Left *********************/
 TEST_F(TestCategory, batched_scalar_batched_gemm_nt_nt_bhalf_bhalf_left) {
-  typedef ::Test::SharedParamTag<Trans::NoTranspose, Trans::NoTranspose, BatchLayout::Left> param_tag_type;
+  typedef TestUtils::SharedParamTag<Trans::NoTranspose, Trans::NoTranspose, BatchLayout::Left> param_tag_type;
 
   test_batched_gemm<TestDevice, ::Test::bhalfScalarType, ::Test::bhalfScalarType, param_tag_type>();
 }
 TEST_F(TestCategory, batched_scalar_batched_gemm_t_nt_bhalf_bhalf_left) {
-  typedef ::Test::SharedParamTag<Trans::Transpose, Trans::NoTranspose, BatchLayout::Left> param_tag_type;
+  typedef TestUtils::SharedParamTag<Trans::Transpose, Trans::NoTranspose, BatchLayout::Left> param_tag_type;
 
   test_batched_gemm<TestDevice, ::Test::bhalfScalarType, ::Test::bhalfScalarType, param_tag_type>();
 }
 TEST_F(TestCategory, batched_scalar_batched_gemm_nt_t_bhalf_bhalf_left) {
-  typedef ::Test::SharedParamTag<Trans::NoTranspose, Trans::Transpose, BatchLayout::Left> param_tag_type;
+  typedef TestUtils::SharedParamTag<Trans::NoTranspose, Trans::Transpose, BatchLayout::Left> param_tag_type;
 
   test_batched_gemm<TestDevice, ::Test::bhalfScalarType, ::Test::bhalfScalarType, param_tag_type>();
 }
 TEST_F(TestCategory, batched_scalar_batched_gemm_t_t_bhalf_bhalf_left) {
-  typedef ::Test::SharedParamTag<Trans::Transpose, Trans::Transpose, BatchLayout::Left> param_tag_type;
+  typedef TestUtils::SharedParamTag<Trans::Transpose, Trans::Transpose, BatchLayout::Left> param_tag_type;
 
   test_batched_gemm<TestDevice, ::Test::bhalfScalarType, ::Test::bhalfScalarType, param_tag_type>();
 }
 /********************* BatchLayout::Right *********************/
 TEST_F(TestCategory, batched_scalar_batched_gemm_nt_nt_bhalf_bhalf_right) {
-  typedef ::Test::SharedParamTag<Trans::NoTranspose, Trans::NoTranspose, BatchLayout::Right> param_tag_type;
+  typedef TestUtils::SharedParamTag<Trans::NoTranspose, Trans::NoTranspose, BatchLayout::Right> param_tag_type;
 
   test_batched_gemm<TestDevice, ::Test::bhalfScalarType, ::Test::bhalfScalarType, param_tag_type>();
 }
 TEST_F(TestCategory, batched_scalar_batched_gemm_t_nt_bhalf_bhalf_right) {
-  typedef ::Test::SharedParamTag<Trans::Transpose, Trans::NoTranspose, BatchLayout::Right> param_tag_type;
+  typedef TestUtils::SharedParamTag<Trans::Transpose, Trans::NoTranspose, BatchLayout::Right> param_tag_type;
 
   test_batched_gemm<TestDevice, ::Test::bhalfScalarType, ::Test::bhalfScalarType, param_tag_type>();
 }
 TEST_F(TestCategory, batched_scalar_batched_gemm_nt_t_bhalf_bhalf_right) {
-  typedef ::Test::SharedParamTag<Trans::NoTranspose, Trans::Transpose, BatchLayout::Right> param_tag_type;
+  typedef TestUtils::SharedParamTag<Trans::NoTranspose, Trans::Transpose, BatchLayout::Right> param_tag_type;
 
   test_batched_gemm<TestDevice, ::Test::bhalfScalarType, ::Test::bhalfScalarType, param_tag_type>();
 }
 TEST_F(TestCategory, batched_scalar_batched_gemm_t_t_bhalf_bhalf_right) {
-  typedef ::Test::SharedParamTag<Trans::Transpose, Trans::Transpose, BatchLayout::Right> param_tag_type;
+  typedef TestUtils::SharedParamTag<Trans::Transpose, Trans::Transpose, BatchLayout::Right> param_tag_type;
 
   test_batched_gemm<TestDevice, ::Test::bhalfScalarType, ::Test::bhalfScalarType, param_tag_type>();
 }
@@ -55,43 +55,43 @@ TEST_F(TestCategory, batched_scalar_batched_gemm_t_t_bhalf_bhalf_right) {
     defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
 /********************* BatchLayout::Left *********************/
 TEST_F(TestCategory, batched_scalar_batched_gemm_nt_nt_half_half_left) {
-  typedef ::Test::SharedParamTag<Trans::NoTranspose, Trans::NoTranspose, BatchLayout::Left> param_tag_type;
+  typedef TestUtils::SharedParamTag<Trans::NoTranspose, Trans::NoTranspose, BatchLayout::Left> param_tag_type;
 
   test_batched_gemm<TestDevice, ::Test::halfScalarType, ::Test::halfScalarType, param_tag_type>();
 }
 TEST_F(TestCategory, batched_scalar_batched_gemm_t_nt_half_half_left) {
-  typedef ::Test::SharedParamTag<Trans::Transpose, Trans::NoTranspose, BatchLayout::Left> param_tag_type;
+  typedef TestUtils::SharedParamTag<Trans::Transpose, Trans::NoTranspose, BatchLayout::Left> param_tag_type;
 
   test_batched_gemm<TestDevice, ::Test::halfScalarType, ::Test::halfScalarType, param_tag_type>();
 }
 TEST_F(TestCategory, batched_scalar_batched_gemm_nt_t_half_half_left) {
-  typedef ::Test::SharedParamTag<Trans::NoTranspose, Trans::Transpose, BatchLayout::Left> param_tag_type;
+  typedef TestUtils::SharedParamTag<Trans::NoTranspose, Trans::Transpose, BatchLayout::Left> param_tag_type;
 
   test_batched_gemm<TestDevice, ::Test::halfScalarType, ::Test::halfScalarType, param_tag_type>();
 }
 TEST_F(TestCategory, batched_scalar_batched_gemm_t_t_half_half_left) {
-  typedef ::Test::SharedParamTag<Trans::Transpose, Trans::Transpose, BatchLayout::Left> param_tag_type;
+  typedef TestUtils::SharedParamTag<Trans::Transpose, Trans::Transpose, BatchLayout::Left> param_tag_type;
 
   test_batched_gemm<TestDevice, ::Test::halfScalarType, ::Test::halfScalarType, param_tag_type>();
 }
 /********************* BatchLayout::Right *********************/
 TEST_F(TestCategory, batched_scalar_batched_gemm_nt_nt_half_half_right) {
-  typedef ::Test::SharedParamTag<Trans::NoTranspose, Trans::NoTranspose, BatchLayout::Right> param_tag_type;
+  typedef TestUtils::SharedParamTag<Trans::NoTranspose, Trans::NoTranspose, BatchLayout::Right> param_tag_type;
 
   test_batched_gemm<TestDevice, ::Test::halfScalarType, ::Test::halfScalarType, param_tag_type>();
 }
 TEST_F(TestCategory, batched_scalar_batched_gemm_t_nt_half_half_right) {
-  typedef ::Test::SharedParamTag<Trans::Transpose, Trans::NoTranspose, BatchLayout::Right> param_tag_type;
+  typedef TestUtils::SharedParamTag<Trans::Transpose, Trans::NoTranspose, BatchLayout::Right> param_tag_type;
 
   test_batched_gemm<TestDevice, ::Test::halfScalarType, ::Test::halfScalarType, param_tag_type>();
 }
 TEST_F(TestCategory, batched_scalar_batched_gemm_nt_t_half_half_right) {
-  typedef ::Test::SharedParamTag<Trans::NoTranspose, Trans::Transpose, BatchLayout::Right> param_tag_type;
+  typedef TestUtils::SharedParamTag<Trans::NoTranspose, Trans::Transpose, BatchLayout::Right> param_tag_type;
 
   test_batched_gemm<TestDevice, ::Test::halfScalarType, ::Test::halfScalarType, param_tag_type>();
 }
 TEST_F(TestCategory, batched_scalar_batched_gemm_t_t_half_half_right) {
-  typedef ::Test::SharedParamTag<Trans::Transpose, Trans::Transpose, BatchLayout::Right> param_tag_type;
+  typedef TestUtils::SharedParamTag<Trans::Transpose, Trans::Transpose, BatchLayout::Right> param_tag_type;
 
   test_batched_gemm<TestDevice, ::Test::halfScalarType, ::Test::halfScalarType, param_tag_type>();
 }
@@ -100,43 +100,43 @@ TEST_F(TestCategory, batched_scalar_batched_gemm_t_t_half_half_right) {
 #if defined(KOKKOSKERNELS_INST_FLOAT)
 /********************* BatchLayout::Left *********************/
 TEST_F(TestCategory, batched_scalar_batched_gemm_nt_nt_float_float_left) {
-  typedef ::Test::SharedParamTag<Trans::NoTranspose, Trans::NoTranspose, BatchLayout::Left> param_tag_type;
+  typedef TestUtils::SharedParamTag<Trans::NoTranspose, Trans::NoTranspose, BatchLayout::Left> param_tag_type;
 
   test_batched_gemm<TestDevice, float, float, param_tag_type>();
 }
 TEST_F(TestCategory, batched_scalar_batched_gemm_t_nt_float_float_left) {
-  typedef ::Test::SharedParamTag<Trans::Transpose, Trans::NoTranspose, BatchLayout::Left> param_tag_type;
+  typedef TestUtils::SharedParamTag<Trans::Transpose, Trans::NoTranspose, BatchLayout::Left> param_tag_type;
 
   test_batched_gemm<TestDevice, float, float, param_tag_type>();
 }
 TEST_F(TestCategory, batched_scalar_batched_gemm_nt_t_float_float_left) {
-  typedef ::Test::SharedParamTag<Trans::NoTranspose, Trans::Transpose, BatchLayout::Left> param_tag_type;
+  typedef TestUtils::SharedParamTag<Trans::NoTranspose, Trans::Transpose, BatchLayout::Left> param_tag_type;
 
   test_batched_gemm<TestDevice, float, float, param_tag_type>();
 }
 TEST_F(TestCategory, batched_scalar_batched_gemm_t_t_float_float_left) {
-  typedef ::Test::SharedParamTag<Trans::Transpose, Trans::Transpose, BatchLayout::Left> param_tag_type;
+  typedef TestUtils::SharedParamTag<Trans::Transpose, Trans::Transpose, BatchLayout::Left> param_tag_type;
 
   test_batched_gemm<TestDevice, float, float, param_tag_type>();
 }
 /********************* BatchLayout::Right *********************/
 TEST_F(TestCategory, batched_scalar_batched_gemm_nt_nt_float_float_right) {
-  typedef ::Test::SharedParamTag<Trans::NoTranspose, Trans::NoTranspose, BatchLayout::Right> param_tag_type;
+  typedef TestUtils::SharedParamTag<Trans::NoTranspose, Trans::NoTranspose, BatchLayout::Right> param_tag_type;
 
   test_batched_gemm<TestDevice, float, float, param_tag_type>();
 }
 TEST_F(TestCategory, batched_scalar_batched_gemm_t_nt_float_float_right) {
-  typedef ::Test::SharedParamTag<Trans::Transpose, Trans::NoTranspose, BatchLayout::Right> param_tag_type;
+  typedef TestUtils::SharedParamTag<Trans::Transpose, Trans::NoTranspose, BatchLayout::Right> param_tag_type;
 
   test_batched_gemm<TestDevice, float, float, param_tag_type>();
 }
 TEST_F(TestCategory, batched_scalar_batched_gemm_nt_t_float_float_right) {
-  typedef ::Test::SharedParamTag<Trans::NoTranspose, Trans::Transpose, BatchLayout::Right> param_tag_type;
+  typedef TestUtils::SharedParamTag<Trans::NoTranspose, Trans::Transpose, BatchLayout::Right> param_tag_type;
 
   test_batched_gemm<TestDevice, float, float, param_tag_type>();
 }
 TEST_F(TestCategory, batched_scalar_batched_gemm_t_t_float_float_right) {
-  typedef ::Test::SharedParamTag<Trans::Transpose, Trans::Transpose, BatchLayout::Right> param_tag_type;
+  typedef TestUtils::SharedParamTag<Trans::Transpose, Trans::Transpose, BatchLayout::Right> param_tag_type;
 
   test_batched_gemm<TestDevice, float, float, param_tag_type>();
 }
@@ -145,43 +145,43 @@ TEST_F(TestCategory, batched_scalar_batched_gemm_t_t_float_float_right) {
 #if defined(KOKKOSKERNELS_INST_DOUBLE)
 /********************* BatchLayout::Left *********************/
 TEST_F(TestCategory, batched_scalar_batched_gemm_nt_nt_double_double_left) {
-  using param_tag_type = ::Test::SharedParamTag<Trans::NoTranspose, Trans::NoTranspose, BatchLayout::Left>;
+  using param_tag_type = TestUtils::SharedParamTag<Trans::NoTranspose, Trans::NoTranspose, BatchLayout::Left>;
 
   test_batched_gemm<TestDevice, double, double, param_tag_type>();
 }
 TEST_F(TestCategory, batched_scalar_batched_gemm_t_nt_double_double_left) {
-  typedef ::Test::SharedParamTag<Trans::Transpose, Trans::NoTranspose, BatchLayout::Left> param_tag_type;
+  typedef TestUtils::SharedParamTag<Trans::Transpose, Trans::NoTranspose, BatchLayout::Left> param_tag_type;
 
   test_batched_gemm<TestDevice, double, double, param_tag_type>();
 }
 TEST_F(TestCategory, batched_scalar_batched_gemm_nt_t_double_double_left) {
-  typedef ::Test::SharedParamTag<Trans::NoTranspose, Trans::Transpose, BatchLayout::Left> param_tag_type;
+  typedef TestUtils::SharedParamTag<Trans::NoTranspose, Trans::Transpose, BatchLayout::Left> param_tag_type;
 
   test_batched_gemm<TestDevice, double, double, param_tag_type>();
 }
 TEST_F(TestCategory, batched_scalar_batched_gemm_t_t_double_double_left) {
-  typedef ::Test::SharedParamTag<Trans::Transpose, Trans::Transpose, BatchLayout::Left> param_tag_type;
+  typedef TestUtils::SharedParamTag<Trans::Transpose, Trans::Transpose, BatchLayout::Left> param_tag_type;
 
   test_batched_gemm<TestDevice, double, double, param_tag_type>();
 }
 /********************* BatchLayout::Right *********************/
 TEST_F(TestCategory, batched_scalar_batched_gemm_nt_nt_double_double_right) {
-  typedef ::Test::SharedParamTag<Trans::NoTranspose, Trans::NoTranspose, BatchLayout::Right> param_tag_type;
+  typedef TestUtils::SharedParamTag<Trans::NoTranspose, Trans::NoTranspose, BatchLayout::Right> param_tag_type;
 
   test_batched_gemm<TestDevice, double, double, param_tag_type>();
 }
 TEST_F(TestCategory, batched_scalar_batched_gemm_t_nt_double_double_right) {
-  typedef ::Test::SharedParamTag<Trans::Transpose, Trans::NoTranspose, BatchLayout::Right> param_tag_type;
+  typedef TestUtils::SharedParamTag<Trans::Transpose, Trans::NoTranspose, BatchLayout::Right> param_tag_type;
 
   test_batched_gemm<TestDevice, double, double, param_tag_type>();
 }
 TEST_F(TestCategory, batched_scalar_batched_gemm_nt_t_double_double_right) {
-  typedef ::Test::SharedParamTag<Trans::NoTranspose, Trans::Transpose, BatchLayout::Right> param_tag_type;
+  typedef TestUtils::SharedParamTag<Trans::NoTranspose, Trans::Transpose, BatchLayout::Right> param_tag_type;
 
   test_batched_gemm<TestDevice, double, double, param_tag_type>();
 }
 TEST_F(TestCategory, batched_scalar_batched_gemm_t_t_double_double_right) {
-  typedef ::Test::SharedParamTag<Trans::Transpose, Trans::Transpose, BatchLayout::Right> param_tag_type;
+  typedef TestUtils::SharedParamTag<Trans::Transpose, Trans::Transpose, BatchLayout::Right> param_tag_type;
 
   test_batched_gemm<TestDevice, double, double, param_tag_type>();
 }

--- a/batched/dense/unit_test/Test_Batched_Copy.hpp
+++ b/batched/dense/unit_test/Test_Batched_Copy.hpp
@@ -36,7 +36,7 @@ struct Functor_TestBatchedSerialCopy {
   inline int run() {
     using value_type = typename AViewType::non_const_value_type;
     std::string name_region("KokkosBatched::Test::SerialCopy");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     int info_sum                      = 0;
     Kokkos::Profiling::pushRegion(name.c_str());
@@ -83,7 +83,7 @@ struct Functor_TestBatchedTeamCopy {
     std::string name_region           = std::is_same_v<ArgMode, KokkosBatched::Mode::Team>
                                             ? "KokkosBatched::Test::TeamCopy"
                                             : "KokkosBatched::Test::TeamVectorCopy";
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
     const int league_size = m_A.extent_int(0);

--- a/batched/dense/unit_test/Test_Batched_Dot.hpp
+++ b/batched/dense/unit_test/Test_Batched_Dot.hpp
@@ -42,7 +42,7 @@ struct Functor_BatchedSerialDot {
   inline int run() {
     using value_type = typename XViewType::non_const_value_type;
     std::string name_region("KokkosBatched::Test::SerialDot");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     int info_sum                      = 0;
     Kokkos::Profiling::pushRegion(name.c_str());
@@ -94,7 +94,7 @@ struct Functor_BatchedTeamDot {
     using value_type        = typename XViewType::non_const_value_type;
     std::string name_region = std::is_same_v<ArgMode, KokkosBatched::Mode::Team> ? "KokkosBatched::Test::TeamDot"
                                                                                  : "KokkosBatched::Test::TeamVectorDot";
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
     const int league_size = m_x.extent_int(0);

--- a/batched/dense/unit_test/Test_Batched_Iamax.hpp
+++ b/batched/dense/unit_test/Test_Batched_Iamax.hpp
@@ -44,7 +44,7 @@ struct Functor_BatchedIamax {
                               : std::is_same_v<ArgMode, KokkosBatched::Mode::Team>
                                   ? "KokkosBatched::Test::TeamIamax"
                                   : "KokkosBatched::Test::TeamVectorIamax";
-    std::string name_value_type = Test::value_type_name<value_type>();
+    std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name            = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
     const int league_size = m_x.extent_int(0);

--- a/batched/dense/unit_test/Test_Batched_Nrm.hpp
+++ b/batched/dense/unit_test/Test_Batched_Nrm.hpp
@@ -39,7 +39,7 @@ struct Functor_BatchedNrm {
                               : std::is_same_v<ArgMode, KokkosBatched::Mode::Team>
                                   ? "KokkosBatched::Test::TeamNrm"
                                   : "KokkosBatched::Test::TeamVectorNrm";
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     int info_sum                      = 0;
     Kokkos::Profiling::pushRegion(name.c_str());

--- a/batched/dense/unit_test/Test_Batched_Rot.hpp
+++ b/batched/dense/unit_test/Test_Batched_Rot.hpp
@@ -33,7 +33,7 @@ struct Functor_BatchedSerialRot {
   inline int run() {
     using value_type = typename XViewType::non_const_value_type;
     std::string name_region("KokkosBatched::Test::SerialRot");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     int info_sum                      = 0;
     Kokkos::Profiling::pushRegion(name.c_str());
@@ -72,7 +72,7 @@ struct Functor_BatchedTeamRot {
     using value_type        = typename XViewType::non_const_value_type;
     std::string name_region = std::is_same_v<ArgMode, KokkosBatched::Mode::Team> ? "KokkosBatched::Test::TeamRot"
                                                                                  : "KokkosBatched::Test::TeamVectorRot";
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
     const int league_size = m_x.extent_int(0);

--- a/batched/dense/unit_test/Test_Batched_Rotg.hpp
+++ b/batched/dense/unit_test/Test_Batched_Rotg.hpp
@@ -32,7 +32,7 @@ struct Functor_BatchedRotg {
   inline void run() {
     using value_type = typename SViewType::non_const_value_type;
     std::string name_region("KokkosBatched::Test::Rotg");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
     Kokkos::RangePolicy<execution_space> policy(0, m_a.extent(0));

--- a/batched/dense/unit_test/Test_Batched_Rotm.hpp
+++ b/batched/dense/unit_test/Test_Batched_Rotm.hpp
@@ -33,7 +33,7 @@ struct Functor_BatchedSerialRotm {
   inline int run() {
     using value_type = typename XViewType::non_const_value_type;
     std::string name_region("KokkosBatched::Test::SerialRotm");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     int info_sum                      = 0;
     Kokkos::Profiling::pushRegion(name.c_str());
@@ -72,7 +72,7 @@ struct Functor_BatchedTeamRotm {
     std::string name_region           = std::is_same_v<ArgMode, KokkosBatched::Mode::Team>
                                             ? "KokkosBatched::Test::TeamRotm"
                                             : "KokkosBatched::Test::TeamVectorRotm";
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
     const int league_size = m_x.extent_int(0);

--- a/batched/dense/unit_test/Test_Batched_Rotmg.hpp
+++ b/batched/dense/unit_test/Test_Batched_Rotmg.hpp
@@ -35,7 +35,7 @@ struct Functor_BatchedRotmg {
   inline void run() {
     using value_type = typename DXViewType::non_const_value_type;
     std::string name_region("KokkosBatched::Test::Rotmg");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
     Kokkos::RangePolicy<execution_space> policy(0, m_d1.extent(0));
@@ -71,14 +71,14 @@ void impl_test_batched_rotmg_analytical(const std::size_t Nb, DXType d1_in, DXTy
 
   typename ats::mag_type eps = 1.0e1 * ats::epsilon();
   for (std::size_t i = 0; i < Nb; i++) {
-    EXPECT_NEAR_KK_REL(h_d1(i), ref[0], eps, "rotmg: d1 does not match reference");
-    EXPECT_NEAR_KK_REL(h_d2(i), ref[1], eps, "rotmg: d2 does not match reference");
-    EXPECT_NEAR_KK_REL(h_x1(i), ref[2], eps, "rotmg: x1 does not match reference");
-    EXPECT_NEAR_KK_REL(h_param(i, 0), ref[3], eps, "rotmg: param[0] (flag) does not match reference");
-    EXPECT_NEAR_KK_REL(h_param(i, 1), ref[4], eps, "rotmg: param[1] (h11) does not match reference");
-    EXPECT_NEAR_KK_REL(h_param(i, 2), ref[5], eps, "rotmg: param[2] (h21) does not match reference");
-    EXPECT_NEAR_KK_REL(h_param(i, 3), ref[6], eps, "rotmg: param[3] (h12) does not match reference");
-    EXPECT_NEAR_KK_REL(h_param(i, 4), ref[7], eps, "rotmg: param[4] (h22) does not match reference");
+    EXPECT_NEAR_KK_REL(h_d1(i), ref[0], eps) << "rotmg: d1 does not match reference";
+    EXPECT_NEAR_KK_REL(h_d2(i), ref[1], eps) << "rotmg: d2 does not match reference";
+    EXPECT_NEAR_KK_REL(h_x1(i), ref[2], eps) << "rotmg: x1 does not match reference";
+    EXPECT_NEAR_KK_REL(h_param(i, 0), ref[3], eps) << "rotmg: param[0] (flag) does not match reference";
+    EXPECT_NEAR_KK_REL(h_param(i, 1), ref[4], eps) << "rotmg: param[1] (h11) does not match reference";
+    EXPECT_NEAR_KK_REL(h_param(i, 2), ref[5], eps) << "rotmg: param[2] (h21) does not match reference";
+    EXPECT_NEAR_KK_REL(h_param(i, 3), ref[6], eps) << "rotmg: param[3] (h12) does not match reference";
+    EXPECT_NEAR_KK_REL(h_param(i, 4), ref[7], eps) << "rotmg: param[4] (h22) does not match reference";
   }
 }
 

--- a/batched/dense/unit_test/Test_Batched_SerialAxpy.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialAxpy.hpp
@@ -44,7 +44,7 @@ struct Functor_TestBatchedSerialAxpy {
   inline void run() {
     using value_type = typename ViewType::value_type;
     std::string name_region("KokkosBatched::Test::SerialAxpy");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
     Kokkos::RangePolicy<execution_space> policy(0, m_X.extent(0));

--- a/batched/dense/unit_test/Test_Batched_SerialGbtrf.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialGbtrf.hpp
@@ -34,7 +34,7 @@ struct Functor_BatchedSerialGbtrf {
   inline int run() {
     using value_type = typename ABViewType::non_const_value_type;
     std::string name_region("KokkosBatched::Test::SerialGbtrf");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     int info_sum                      = 0;
     Kokkos::Profiling::pushRegion(name.c_str());
@@ -65,7 +65,7 @@ struct Functor_BatchedSerialGetrf {
   void run() {
     using value_type = typename AViewType::non_const_value_type;
     std::string name_region("KokkosBatched::Test::SerialGbtrf");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::RangePolicy<execution_space> policy(0, m_a.extent(0));
     Kokkos::parallel_for(name.c_str(), policy, *this);

--- a/batched/dense/unit_test/Test_Batched_SerialGbtrs.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialGbtrs.hpp
@@ -40,7 +40,7 @@ struct Functor_BatchedSerialGbtrf {
   inline void run() {
     using value_type = typename ABViewType::non_const_value_type;
     std::string name_region("KokkosBatched::Test::SerialGbtrs");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::RangePolicy<execution_space> policy(0, m_ab.extent(0));
     Kokkos::parallel_for(name.c_str(), policy, *this);
@@ -72,7 +72,7 @@ struct Functor_BatchedSerialGbtrs {
   inline int run() {
     using value_type = typename AViewType::non_const_value_type;
     std::string name_region("KokkosBatched::Test::SerialGbtrs");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     int info_sum                      = 0;
     Kokkos::Profiling::pushRegion(name.c_str());
@@ -109,7 +109,7 @@ struct Functor_BatchedSerialGemv {
   inline void run() {
     using value_type = typename AViewType::non_const_value_type;
     std::string name_region("KokkosBatched::Test::SerialGbtrs");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::RangePolicy<execution_space, ParamTagType> policy(0, m_x.extent(0));
     Kokkos::parallel_for(name.c_str(), policy, *this);

--- a/batched/dense/unit_test/Test_Batched_SerialGemm.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialGemm.hpp
@@ -46,7 +46,7 @@ struct Functor_TestBatchedSerialGemm {
   inline int run() {
     using value_type = typename ViewType::non_const_value_type;
     std::string name_region("KokkosBatched::Test::SerialGemm");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     int info_sum                      = 0;
     Kokkos::Profiling::pushRegion(name.c_str());

--- a/batched/dense/unit_test/Test_Batched_SerialGemm_Real.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialGemm_Real.hpp
@@ -4,33 +4,33 @@
 TEST_F(TestCategory, batched_scalar_serial_gemm_nt_nt_bhalf_bhalf) {
   using param_tag_type = ::Test::Gemm::ParamTag<KokkosBatched::Trans::NoTranspose, KokkosBatched::Trans::NoTranspose>;
 
-  test_batched_gemm<TestDevice, ::Test::bhalfScalarType, ::Test::bhalfScalarType, param_tag_type,
+  test_batched_gemm<TestDevice, TestUtils::bhalfScalarType, TestUtils::bhalfScalarType, param_tag_type,
                     KokkosBatched::Algo::Gemm::Blocked>();
-  test_batched_gemm<TestDevice, ::Test::bhalfScalarType, ::Test::bhalfScalarType, param_tag_type,
+  test_batched_gemm<TestDevice, TestUtils::bhalfScalarType, TestUtils::bhalfScalarType, param_tag_type,
                     KokkosBatched::Algo::Gemm::Unblocked>();
 }
 TEST_F(TestCategory, batched_scalar_serial_gemm_t_nt_bhalf_bhalf) {
   using param_tag_type = ::Test::Gemm::ParamTag<KokkosBatched::Trans::Transpose, KokkosBatched::Trans::NoTranspose>;
 
-  test_batched_gemm<TestDevice, ::Test::bhalfScalarType, ::Test::bhalfScalarType, param_tag_type,
+  test_batched_gemm<TestDevice, TestUtils::bhalfScalarType, TestUtils::bhalfScalarType, param_tag_type,
                     KokkosBatched::Algo::Gemm::Blocked>();
-  test_batched_gemm<TestDevice, ::Test::bhalfScalarType, ::Test::bhalfScalarType, param_tag_type,
+  test_batched_gemm<TestDevice, TestUtils::bhalfScalarType, TestUtils::bhalfScalarType, param_tag_type,
                     KokkosBatched::Algo::Gemm::Unblocked>();
 }
 TEST_F(TestCategory, batched_scalar_serial_gemm_nt_t_bhalf_bhalf) {
   using param_tag_type = ::Test::Gemm::ParamTag<KokkosBatched::Trans::NoTranspose, KokkosBatched::Trans::Transpose>;
 
-  test_batched_gemm<TestDevice, ::Test::bhalfScalarType, ::Test::bhalfScalarType, param_tag_type,
+  test_batched_gemm<TestDevice, TestUtils::bhalfScalarType, TestUtils::bhalfScalarType, param_tag_type,
                     KokkosBatched::Algo::Gemm::Blocked>();
-  test_batched_gemm<TestDevice, ::Test::bhalfScalarType, ::Test::bhalfScalarType, param_tag_type,
+  test_batched_gemm<TestDevice, TestUtils::bhalfScalarType, TestUtils::bhalfScalarType, param_tag_type,
                     KokkosBatched::Algo::Gemm::Unblocked>();
 }
 TEST_F(TestCategory, batched_scalar_serial_gemm_t_t_bhalf_bhalf) {
   using param_tag_type = ::Test::Gemm::ParamTag<KokkosBatched::Trans::Transpose, KokkosBatched::Trans::Transpose>;
 
-  test_batched_gemm<TestDevice, ::Test::bhalfScalarType, ::Test::bhalfScalarType, param_tag_type,
+  test_batched_gemm<TestDevice, TestUtils::bhalfScalarType, TestUtils::bhalfScalarType, param_tag_type,
                     KokkosBatched::Algo::Gemm::Blocked>();
-  test_batched_gemm<TestDevice, ::Test::bhalfScalarType, ::Test::bhalfScalarType, param_tag_type,
+  test_batched_gemm<TestDevice, TestUtils::bhalfScalarType, TestUtils::bhalfScalarType, param_tag_type,
                     KokkosBatched::Algo::Gemm::Unblocked>();
 }
 #endif  // KOKKOS_BHALF_T_IS_FLOAT
@@ -39,33 +39,33 @@ TEST_F(TestCategory, batched_scalar_serial_gemm_t_t_bhalf_bhalf) {
 TEST_F(TestCategory, batched_scalar_serial_gemm_nt_nt_half_half) {
   using param_tag_type = ::Test::Gemm::ParamTag<KokkosBatched::Trans::NoTranspose, KokkosBatched::Trans::NoTranspose>;
 
-  test_batched_gemm<TestDevice, ::Test::halfScalarType, ::Test::halfScalarType, param_tag_type,
+  test_batched_gemm<TestDevice, TestUtils::halfScalarType, TestUtils::halfScalarType, param_tag_type,
                     KokkosBatched::Algo::Gemm::Blocked>();
-  test_batched_gemm<TestDevice, ::Test::halfScalarType, ::Test::halfScalarType, param_tag_type,
+  test_batched_gemm<TestDevice, TestUtils::halfScalarType, TestUtils::halfScalarType, param_tag_type,
                     KokkosBatched::Algo::Gemm::Unblocked>();
 }
 TEST_F(TestCategory, batched_scalar_serial_gemm_t_nt_half_half) {
   using param_tag_type = ::Test::Gemm::ParamTag<KokkosBatched::Trans::Transpose, KokkosBatched::Trans::NoTranspose>;
 
-  test_batched_gemm<TestDevice, ::Test::halfScalarType, ::Test::halfScalarType, param_tag_type,
+  test_batched_gemm<TestDevice, TestUtils::halfScalarType, TestUtils::halfScalarType, param_tag_type,
                     KokkosBatched::Algo::Gemm::Blocked>();
-  test_batched_gemm<TestDevice, ::Test::halfScalarType, ::Test::halfScalarType, param_tag_type,
+  test_batched_gemm<TestDevice, TestUtils::halfScalarType, TestUtils::halfScalarType, param_tag_type,
                     KokkosBatched::Algo::Gemm::Unblocked>();
 }
 TEST_F(TestCategory, batched_scalar_serial_gemm_nt_t_half_half) {
   using param_tag_type = ::Test::Gemm::ParamTag<KokkosBatched::Trans::NoTranspose, KokkosBatched::Trans::Transpose>;
 
-  test_batched_gemm<TestDevice, ::Test::halfScalarType, ::Test::halfScalarType, param_tag_type,
+  test_batched_gemm<TestDevice, TestUtils::halfScalarType, TestUtils::halfScalarType, param_tag_type,
                     KokkosBatched::Algo::Gemm::Blocked>();
-  test_batched_gemm<TestDevice, ::Test::halfScalarType, ::Test::halfScalarType, param_tag_type,
+  test_batched_gemm<TestDevice, TestUtils::halfScalarType, TestUtils::halfScalarType, param_tag_type,
                     KokkosBatched::Algo::Gemm::Unblocked>();
 }
 TEST_F(TestCategory, batched_scalar_serial_gemm_t_t_half_half) {
   using param_tag_type = ::Test::Gemm::ParamTag<KokkosBatched::Trans::Transpose, KokkosBatched::Trans::Transpose>;
 
-  test_batched_gemm<TestDevice, ::Test::halfScalarType, ::Test::halfScalarType, param_tag_type,
+  test_batched_gemm<TestDevice, TestUtils::halfScalarType, TestUtils::halfScalarType, param_tag_type,
                     KokkosBatched::Algo::Gemm::Blocked>();
-  test_batched_gemm<TestDevice, ::Test::halfScalarType, ::Test::halfScalarType, param_tag_type,
+  test_batched_gemm<TestDevice, TestUtils::halfScalarType, TestUtils::halfScalarType, param_tag_type,
                     KokkosBatched::Algo::Gemm::Unblocked>();
 }
 #endif  // KOKKOS_HALF_T_IS_FLOAT

--- a/batched/dense/unit_test/Test_Batched_SerialGer.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialGer.hpp
@@ -41,7 +41,7 @@ struct Functor_BatchedSerialGer {
   inline int run() {
     using value_type = typename AViewType::non_const_value_type;
     std::string name_region("KokkosBatched::Test::SerialGer");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     int info_sum                      = 0;
     Kokkos::Profiling::pushRegion(name.c_str());

--- a/batched/dense/unit_test/Test_Batched_SerialGesv.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialGesv.hpp
@@ -44,7 +44,7 @@ struct Functor_TestBatchedSerialGesv {
   inline void run() {
     typedef typename VectorType::value_type value_type;
     std::string name_region("KokkosBatched::Test::SerialGesv");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
     Kokkos::RangePolicy<execution_space> policy(0, _X.extent(0));

--- a/batched/dense/unit_test/Test_Batched_SerialGetrf.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialGetrf.hpp
@@ -32,7 +32,7 @@ struct Functor_BatchedSerialGetrf {
   inline int run() {
     using value_type = typename AViewType::non_const_value_type;
     std::string name_region("KokkosBatched::Test::SerialGetrf");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     int info_sum                      = 0;
     Kokkos::Profiling::pushRegion(name.c_str());
@@ -69,7 +69,7 @@ struct Functor_BatchedSerialGemm {
   inline void run() {
     using value_type = typename AViewType::non_const_value_type;
     std::string name_region("KokkosBatched::Test::SerialGetrf");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::RangePolicy<execution_space> policy(0, m_a.extent(0));
     Kokkos::parallel_for(name.c_str(), policy, *this);

--- a/batched/dense/unit_test/Test_Batched_SerialGetrs.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialGetrs.hpp
@@ -37,7 +37,7 @@ struct Functor_BatchedSerialGetrf {
   inline void run() {
     using value_type = typename AViewType::non_const_value_type;
     std::string name_region("KokkosBatched::Test::SerialGetrs");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::RangePolicy<execution_space> policy(0, m_a.extent(0));
     Kokkos::parallel_for(name.c_str(), policy, *this);
@@ -67,7 +67,7 @@ struct Functor_BatchedSerialGetrs {
   inline int run() {
     using value_type = typename AViewType::non_const_value_type;
     std::string name_region("KokkosBatched::Test::SerialGetrs");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     int info_sum                      = 0;
     Kokkos::Profiling::pushRegion(name.c_str());
@@ -103,7 +103,7 @@ struct Functor_BatchedSerialGemv {
   inline void run() {
     using value_type = typename AViewType::non_const_value_type;
     std::string name_region("KokkosBatched::Test::SerialGetrs");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::RangePolicy<execution_space, ParamTagType> policy(0, m_x.extent(0));
     Kokkos::parallel_for(name.c_str(), policy, *this);

--- a/batched/dense/unit_test/Test_Batched_SerialHouseholder.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialHouseholder.hpp
@@ -55,11 +55,11 @@ void test_Householder_analytic_real() {
 
   // x = [4, 2, 2, 1]
   // output = [-5, 2/9, 2/9, 1/9]
-  Test::EXPECT_NEAR_KK_REL(reflector_h(0), Scalar(-5), tol);
-  Test::EXPECT_NEAR_KK_REL(reflector_h(1), Scalar(2.0 / 9), tol);
-  Test::EXPECT_NEAR_KK_REL(reflector_h(2), Scalar(2.0 / 9), tol);
-  Test::EXPECT_NEAR_KK_REL(reflector_h(3), Scalar(1.0 / 9), tol);
-  Test::EXPECT_NEAR_KK_REL(tau_h(0), Scalar(10.0 / 18), tol);
+  EXPECT_NEAR_KK_REL(reflector_h(0), Scalar(-5), tol);
+  EXPECT_NEAR_KK_REL(reflector_h(1), Scalar(2.0 / 9), tol);
+  EXPECT_NEAR_KK_REL(reflector_h(2), Scalar(2.0 / 9), tol);
+  EXPECT_NEAR_KK_REL(reflector_h(3), Scalar(1.0 / 9), tol);
+  EXPECT_NEAR_KK_REL(tau_h(0), Scalar(10.0 / 18), tol);
 
   vec_type workspace("workspace", 1);
   auto u = Kokkos::subview(reflector, Kokkos::pair<int, int>(1, 4));
@@ -70,10 +70,10 @@ void test_Householder_analytic_real() {
   ;
 
   Kokkos::deep_copy(vec_h, vec);
-  Test::EXPECT_NEAR_KK_REL(vec_h(0), reflector_h(0), tol);
-  Test::EXPECT_NEAR_KK(vec_h(1), 0.0, tol);
-  Test::EXPECT_NEAR_KK(vec_h(2), 0.0, tol);
-  Test::EXPECT_NEAR_KK(vec_h(3), 0.0, tol);
+  EXPECT_NEAR_KK_REL(vec_h(0), reflector_h(0), tol);
+  EXPECT_NEAR_KK(vec_h(1), 0.0, tol);
+  EXPECT_NEAR_KK(vec_h(2), 0.0, tol);
+  EXPECT_NEAR_KK(vec_h(3), 0.0, tol);
 }
 
 template <class Device, class Scalar>
@@ -111,11 +111,11 @@ void test_Householder_analytic_cplx() {
   // x = [4+3i, 2+5i, 2+5i, 1+4i]
   // tau  = (14+3i)/10, 1/tau = (14-3i)/20.5
   // output = [-10, (43 - 64i) / 205, (43 - 64i) / 205, (26 - 53i) / 205]
-  Test::EXPECT_NEAR_KK_REL(reflector_h(0), Scalar(-10, 0), tol);
-  Test::EXPECT_NEAR_KK_REL(reflector_h(1), Scalar(43.0 / 205, 64.0 / 205), tol);
-  Test::EXPECT_NEAR_KK_REL(reflector_h(2), Scalar(43.0 / 205, 64.0 / 205), tol);
-  Test::EXPECT_NEAR_KK_REL(reflector_h(3), Scalar(26.0 / 205, 53.0 / 205), tol);
-  Test::EXPECT_NEAR_KK_REL(tau_h(0), Scalar(10, 0) / Scalar(14, 3), tol);
+  EXPECT_NEAR_KK_REL(reflector_h(0), Scalar(-10, 0), tol);
+  EXPECT_NEAR_KK_REL(reflector_h(1), Scalar(43.0 / 205, 64.0 / 205), tol);
+  EXPECT_NEAR_KK_REL(reflector_h(2), Scalar(43.0 / 205, 64.0 / 205), tol);
+  EXPECT_NEAR_KK_REL(reflector_h(3), Scalar(26.0 / 205, 53.0 / 205), tol);
+  EXPECT_NEAR_KK_REL(tau_h(0), Scalar(10, 0) / Scalar(14, 3), tol);
 
   vec_type workspace("workspace", 1);
   auto v = Kokkos::subview(reflector, Kokkos::pair<int, int>(1, 4));
@@ -125,10 +125,10 @@ void test_Householder_analytic_cplx() {
       });
 
   Kokkos::deep_copy(vec_h, vec);
-  Test::EXPECT_NEAR_KK_REL(vec_h(0), reflector_h(0), tol);
-  Test::EXPECT_NEAR_KK(vec_h(1), zero, tol);
-  Test::EXPECT_NEAR_KK(vec_h(2), zero, tol);
-  Test::EXPECT_NEAR_KK(vec_h(3), zero, tol);
+  EXPECT_NEAR_KK_REL(vec_h(0), reflector_h(0), tol);
+  EXPECT_NEAR_KK(vec_h(1), zero, tol);
+  EXPECT_NEAR_KK(vec_h(2), zero, tol);
+  EXPECT_NEAR_KK(vec_h(3), zero, tol);
 }
 
 }  // namespace Test

--- a/batched/dense/unit_test/Test_Batched_SerialInverseLU.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialInverseLU.hpp
@@ -54,7 +54,7 @@ struct Functor_BatchedSerialGemm {
   inline void run() {
     typedef typename ViewType::value_type value_type;
     std::string name_region("KokkosBatched::Test::SerialInverseLU");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
     Kokkos::RangePolicy<execution_space, ParamTagType> policy(0, _c.extent(0));
@@ -83,7 +83,7 @@ struct Functor_BatchedSerialLU {
   inline void run() {
     typedef typename ViewType::value_type value_type;
     std::string name_region("KokkosBatched::Test::SerialInverseLU");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
     Kokkos::RangePolicy<execution_space> policy(0, _a.extent(0));
@@ -112,7 +112,7 @@ struct Functor_TestBatchedSerialInverseLU {
   inline void run() {
     typedef typename AViewType::value_type value_type;
     std::string name_region("KokkosBatched::Test::SerialInverseLU");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
     Kokkos::RangePolicy<execution_space> policy(0, _a.extent(0));

--- a/batched/dense/unit_test/Test_Batched_SerialLU.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialLU.hpp
@@ -37,7 +37,7 @@ struct Functor_TestBatchedSerialLU {
   inline void run() {
     typedef typename ViewType::value_type value_type;
     std::string name_region("KokkosBatched::Test::SerialLU");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
     Kokkos::RangePolicy<execution_space> policy(0, _a.extent(0));

--- a/batched/dense/unit_test/Test_Batched_SerialLacgv.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialLacgv.hpp
@@ -27,7 +27,7 @@ struct Functor_BatchedSerialLacgv {
   inline int run() {
     using value_type = typename XViewType::non_const_value_type;
     std::string name_region("KokkosBatched::Test::SerialLacgv");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     int info_sum                      = 0;
     Kokkos::Profiling::pushRegion(name.c_str());

--- a/batched/dense/unit_test/Test_Batched_SerialLaswp.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialLaswp.hpp
@@ -37,7 +37,7 @@ struct Functor_BatchedSerialLaswp {
   inline int run() {
     using value_type = typename AViewType::non_const_value_type;
     std::string name_region("KokkosBatched::Test::SerialLaswp");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     int info_sum                      = 0;
     Kokkos::Profiling::pushRegion(name.c_str());

--- a/batched/dense/unit_test/Test_Batched_SerialPbtrf.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialPbtrf.hpp
@@ -35,7 +35,7 @@ struct Functor_BatchedSerialPbtrf {
   inline int run() {
     using value_type = typename ABViewType::non_const_value_type;
     std::string name_region("KokkosBatched::Test::SerialPbtrf");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     int info_sum                      = 0;
     Kokkos::Profiling::pushRegion(name.c_str());
@@ -72,7 +72,7 @@ struct Functor_BatchedSerialGemm {
   inline void run() {
     using value_type = typename AViewType::non_const_value_type;
     std::string name_region("KokkosBatched::Test::SerialPbtrf");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::RangePolicy<execution_space> policy(0, m_a.extent(0));
     Kokkos::parallel_for(name.c_str(), policy, *this);

--- a/batched/dense/unit_test/Test_Batched_SerialPbtrs.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialPbtrs.hpp
@@ -36,7 +36,7 @@ struct Functor_BatchedSerialPbtrf {
   inline void run() {
     using value_type = typename ABViewType::non_const_value_type;
     std::string name_region("KokkosBatched::Test::SerialPbtrs");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::RangePolicy<execution_space, ParamTagType> policy(0, m_ab.extent(0));
     Kokkos::parallel_for(name.c_str(), policy, *this);
@@ -63,7 +63,7 @@ struct Functor_BatchedSerialPbtrs {
   inline int run() {
     using value_type = typename ABViewType::non_const_value_type;
     std::string name_region("KokkosBatched::Test::SerialPbtrs");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     int info_sum                      = 0;
     Kokkos::Profiling::pushRegion(name.c_str());
@@ -99,7 +99,7 @@ struct Functor_BatchedSerialGemv {
   inline void run() {
     using value_type = typename AViewType::non_const_value_type;
     std::string name_region("KokkosBatched::Test::SerialPbtrs");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::RangePolicy<execution_space> policy(0, m_x.extent(0));
     Kokkos::parallel_for(name.c_str(), policy, *this);
@@ -184,7 +184,7 @@ void impl_test_batched_pbtrs_analytical(const int N) {
   // Check x0 = x1
   for (int ib = 0; ib < N; ib++) {
     for (int i = 0; i < BlkSize; i++) {
-      Test::EXPECT_NEAR_KK_REL(h_x0(ib, i), h_x_ref(ib, i), eps);
+      EXPECT_NEAR_KK_REL(h_x0(ib, i), h_x_ref(ib, i), eps);
     }
   }
 }
@@ -254,7 +254,7 @@ void impl_test_batched_pbtrs(const int N, const int k, const int BlkSize) {
   // Check A * x0 = x_ref
   for (int ib = 0; ib < N; ib++) {
     for (int i = 0; i < BlkSize; i++) {
-      Test::EXPECT_NEAR_KK_REL(h_y0(ib, i), h_x_ref(ib, i), eps);
+      EXPECT_NEAR_KK_REL(h_y0(ib, i), h_x_ref(ib, i), eps);
     }
   }
 }

--- a/batched/dense/unit_test/Test_Batched_SerialPttrf.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialPttrf.hpp
@@ -32,7 +32,7 @@ struct Functor_BatchedSerialPttrf {
   inline int run() {
     using value_type = typename EViewType::non_const_value_type;
     std::string name_region("KokkosBatched::Test::SerialPttrf");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     int info_sum                      = 0;
     Kokkos::Profiling::pushRegion(name.c_str());
@@ -70,7 +70,7 @@ struct Functor_BatchedSerialGemm {
   inline void run() {
     using value_type = typename AViewType::non_const_value_type;
     std::string name_region("KokkosBatched::Test::SerialPttrf");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::RangePolicy<execution_space> policy(0, m_a.extent(0));
     Kokkos::parallel_for(name.c_str(), policy, *this);

--- a/batched/dense/unit_test/Test_Batched_SerialPttrs.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialPttrs.hpp
@@ -38,7 +38,7 @@ struct Functor_BatchedSerialPttrf {
   inline void run() {
     using value_type = typename EViewType::non_const_value_type;
     std::string name_region("KokkosBatched::Test::SerialPttrs");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::RangePolicy<execution_space> policy(0, m_d.extent(0));
     Kokkos::parallel_for(name.c_str(), policy, *this);
@@ -68,7 +68,7 @@ struct Functor_BatchedSerialPttrs {
   inline int run() {
     using value_type = typename BViewType::non_const_value_type;
     std::string name_region("KokkosBatched::Test::SerialPttrs");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     int info_sum                      = 0;
     Kokkos::Profiling::pushRegion(name.c_str());
@@ -104,7 +104,7 @@ struct Functor_BatchedSerialGemv {
   inline void run() {
     using value_type = typename AViewType::non_const_value_type;
     std::string name_region("KokkosBatched::Test::SerialPttrs");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::RangePolicy<execution_space> policy(0, m_a.extent(0));
     Kokkos::parallel_for(name.c_str(), policy, *this);
@@ -138,7 +138,7 @@ struct Functor_BatchedSerialGemm {
   inline void run() {
     using value_type = typename AViewType::non_const_value_type;
     std::string name_region("KokkosBatched::Test::SerialPttrf");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::RangePolicy<execution_space> policy(0, m_a.extent(0));
     Kokkos::parallel_for(name.c_str(), policy, *this);

--- a/batched/dense/unit_test/Test_Batched_SerialQR.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialQR.hpp
@@ -196,19 +196,19 @@ void test_QR_square() {
   Kokkos::deep_copy(A_h, A);
   auto tau_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, t);
 
-  Test::EXPECT_NEAR_KK_REL(A_h(0, 0), static_cast<Scalar>(-14), tol);
-  Test::EXPECT_NEAR_KK_REL(A_h(0, 1), static_cast<Scalar>(-21), tol);
-  Test::EXPECT_NEAR_KK_REL(A_h(0, 2), static_cast<Scalar>(14), tol);
-  Test::EXPECT_NEAR_KK_REL(A_h(1, 0), static_cast<Scalar>(6. / 26.), tol);
-  Test::EXPECT_NEAR_KK_REL(A_h(1, 1), static_cast<Scalar>(-175), tol);
-  Test::EXPECT_NEAR_KK_REL(A_h(1, 2), static_cast<Scalar>(70), tol);
-  Test::EXPECT_NEAR_KK_REL(A_h(2, 0), static_cast<Scalar>(-4.0 / 26.0), tol);
-  // Test::EXPECT_NEAR_KK_REL(A_h(2, 1),   35.0, tol);      // Analytical expression too painful to compute...
-  Test::EXPECT_NEAR_KK_REL(A_h(2, 2), static_cast<Scalar>(35), tol);
+  EXPECT_NEAR_KK_REL(A_h(0, 0), static_cast<Scalar>(-14), tol);
+  EXPECT_NEAR_KK_REL(A_h(0, 1), static_cast<Scalar>(-21), tol);
+  EXPECT_NEAR_KK_REL(A_h(0, 2), static_cast<Scalar>(14), tol);
+  EXPECT_NEAR_KK_REL(A_h(1, 0), static_cast<Scalar>(6. / 26.), tol);
+  EXPECT_NEAR_KK_REL(A_h(1, 1), static_cast<Scalar>(-175), tol);
+  EXPECT_NEAR_KK_REL(A_h(1, 2), static_cast<Scalar>(70), tol);
+  EXPECT_NEAR_KK_REL(A_h(2, 0), static_cast<Scalar>(-4.0 / 26.0), tol);
+  // EXPECT_NEAR_KK_REL(A_h(2, 1),   35.0, tol);      // Analytical expression too painful to compute...
+  EXPECT_NEAR_KK_REL(A_h(2, 2), static_cast<Scalar>(35), tol);
 
-  Test::EXPECT_NEAR_KK_REL(tau_h(0), static_cast<Scalar>(7. / 13.), tol);
-  // Test::EXPECT_NEAR_KK_REL(tau_h(1), 25. / 32., tol);      // Analytical expression too painful to compute...
-  Test::EXPECT_NEAR_KK_REL(tau_h(2), static_cast<Scalar>(1. / 2.), tol);
+  EXPECT_NEAR_KK_REL(tau_h(0), static_cast<Scalar>(7. / 13.), tol);
+  // EXPECT_NEAR_KK_REL(tau_h(1), 25. / 32., tol);      // Analytical expression too painful to compute...
+  EXPECT_NEAR_KK_REL(tau_h(2), static_cast<Scalar>(1. / 2.), tol);
 
   Kokkos::parallel_for(
       "serialApplyQ", 1, KOKKOS_LAMBDA(int) {
@@ -216,15 +216,15 @@ void test_QR_square() {
       });
   auto B_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, B);
 
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-14), B_h(0, 0), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-21), B_h(0, 1), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(14), B_h(0, 2), tol);
-  Test::EXPECT_NEAR_KK(static_cast<Scalar>(0), B_h(1, 0), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-175), B_h(1, 1), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(70), B_h(1, 2), tol);
-  Test::EXPECT_NEAR_KK(static_cast<Scalar>(0), B_h(2, 0), tol);
-  Test::EXPECT_NEAR_KK(static_cast<Scalar>(0), B_h(2, 1), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(35), B_h(2, 2), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(-14), B_h(0, 0), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(-21), B_h(0, 1), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(14), B_h(0, 2), tol);
+  EXPECT_NEAR_KK(static_cast<Scalar>(0), B_h(1, 0), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(-175), B_h(1, 1), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(70), B_h(1, 2), tol);
+  EXPECT_NEAR_KK(static_cast<Scalar>(0), B_h(2, 0), tol);
+  EXPECT_NEAR_KK(static_cast<Scalar>(0), B_h(2, 1), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(35), B_h(2, 2), tol);
 
   Kokkos::parallel_for(
       "serialFormQ", 1, KOKKOS_LAMBDA(int) {
@@ -233,15 +233,15 @@ void test_QR_square() {
       });
   auto Q_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, Q);
 
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-6. / 7.), Q_h(0, 0), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(69. / 175.), Q_h(0, 1), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-58. / 175.), Q_h(0, 2), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-3. / 7.), Q_h(1, 0), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-158. / 175.), Q_h(1, 1), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(6. / 175.), Q_h(1, 2), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(2. / 7.), Q_h(2, 0), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-6. / 35.), Q_h(2, 1), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-33. / 35.), Q_h(2, 2), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(-6. / 7.), Q_h(0, 0), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(69. / 175.), Q_h(0, 1), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(-58. / 175.), Q_h(0, 2), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(-3. / 7.), Q_h(1, 0), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(-158. / 175.), Q_h(1, 1), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(6. / 175.), Q_h(1, 2), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(2. / 7.), Q_h(2, 0), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(-6. / 35.), Q_h(2, 1), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(-33. / 35.), Q_h(2, 2), tol);
 
   Kokkos::parallel_for(
       "serialApplyQ", 1, KOKKOS_LAMBDA(int) {
@@ -249,16 +249,16 @@ void test_QR_square() {
       });
   Kokkos::deep_copy(Q_h, Q);
 
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(1.), Q_h(0, 0), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(1.), Q_h(1, 1), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(1.), Q_h(2, 2), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(1.), Q_h(0, 0), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(1.), Q_h(1, 1), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(1.), Q_h(2, 2), tol);
 
-  Test::EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(0, 1), tol);
-  Test::EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(0, 2), tol);
-  Test::EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(1, 0), tol);
-  Test::EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(1, 2), tol);
-  Test::EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(2, 0), tol);
-  Test::EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(2, 1), tol);
+  EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(0, 1), tol);
+  EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(0, 2), tol);
+  EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(1, 0), tol);
+  EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(1, 2), tol);
+  EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(2, 0), tol);
+  EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(2, 1), tol);
 
   Kokkos::deep_copy(Q_h, 0);
   Q_h(0, 0) = 1.0;
@@ -271,15 +271,15 @@ void test_QR_square() {
       });
   Kokkos::deep_copy(Q_h, Q);
 
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-6. / 7.), Q_h(0, 0), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(69. / 175.), Q_h(0, 1), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-58. / 175.), Q_h(0, 2), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-3. / 7.), Q_h(1, 0), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-158. / 175.), Q_h(1, 1), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(6. / 175.), Q_h(1, 2), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(2. / 7.), Q_h(2, 0), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-6. / 35.), Q_h(2, 1), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-33. / 35.), Q_h(2, 2), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(-6. / 7.), Q_h(0, 0), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(69. / 175.), Q_h(0, 1), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(-58. / 175.), Q_h(0, 2), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(-3. / 7.), Q_h(1, 0), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(-158. / 175.), Q_h(1, 1), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(6. / 175.), Q_h(1, 2), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(2. / 7.), Q_h(2, 0), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(-6. / 35.), Q_h(2, 1), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(-33. / 35.), Q_h(2, 2), tol);
 }
 
 template <class Device, class Scalar, class AlgoTagType>
@@ -329,15 +329,15 @@ void test_QR_rectangular() {
   Kokkos::deep_copy(A_h, A);
   auto tau_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, t);
 
-  Test::EXPECT_NEAR_KK_REL(A_h(0, 0), static_cast<Scalar>(-5.0), tol);
-  Test::EXPECT_NEAR_KK_REL(A_h(0, 1), static_cast<Scalar>(-3.0), tol);
-  Test::EXPECT_NEAR_KK_REL(A_h(1, 0), static_cast<Scalar>(0.5), tol);
-  Test::EXPECT_NEAR_KK_REL(A_h(1, 1), static_cast<Scalar>(5.0), tol);
-  Test::EXPECT_NEAR_KK(A_h(2, 0), static_cast<Scalar>(0.), tol);
-  Test::EXPECT_NEAR_KK_REL(A_h(2, 1), static_cast<Scalar>(1. / 3.), tol);
+  EXPECT_NEAR_KK_REL(A_h(0, 0), static_cast<Scalar>(-5.0), tol);
+  EXPECT_NEAR_KK_REL(A_h(0, 1), static_cast<Scalar>(-3.0), tol);
+  EXPECT_NEAR_KK_REL(A_h(1, 0), static_cast<Scalar>(0.5), tol);
+  EXPECT_NEAR_KK_REL(A_h(1, 1), static_cast<Scalar>(5.0), tol);
+  EXPECT_NEAR_KK(A_h(2, 0), static_cast<Scalar>(0.), tol);
+  EXPECT_NEAR_KK_REL(A_h(2, 1), static_cast<Scalar>(1. / 3.), tol);
 
-  Test::EXPECT_NEAR_KK_REL(tau_h(0), static_cast<Scalar>(5. / 8.), tol);
-  Test::EXPECT_NEAR_KK_REL(tau_h(1), static_cast<Scalar>(10. / 18.), tol);
+  EXPECT_NEAR_KK_REL(tau_h(0), static_cast<Scalar>(5. / 8.), tol);
+  EXPECT_NEAR_KK_REL(tau_h(1), static_cast<Scalar>(10. / 18.), tol);
 
   Kokkos::parallel_for(
       "serialApplyQ", 1, KOKKOS_LAMBDA(int) {
@@ -345,12 +345,12 @@ void test_QR_rectangular() {
       });
   auto B_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, B);
 
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-5.0), B_h(0, 0), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-3.0), B_h(0, 1), tol);
-  Test::EXPECT_NEAR_KK(static_cast<Scalar>(0.), B_h(1, 0), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(5.0), B_h(1, 1), tol);
-  Test::EXPECT_NEAR_KK(static_cast<Scalar>(0.), B_h(2, 0), tol);
-  Test::EXPECT_NEAR_KK(static_cast<Scalar>(0.), B_h(2, 1), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(-5.0), B_h(0, 0), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(-3.0), B_h(0, 1), tol);
+  EXPECT_NEAR_KK(static_cast<Scalar>(0.), B_h(1, 0), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(5.0), B_h(1, 1), tol);
+  EXPECT_NEAR_KK(static_cast<Scalar>(0.), B_h(2, 0), tol);
+  EXPECT_NEAR_KK(static_cast<Scalar>(0.), B_h(2, 1), tol);
 
   Kokkos::parallel_for(
       "serialFormQ", 1, KOKKOS_LAMBDA(int) {
@@ -359,15 +359,15 @@ void test_QR_rectangular() {
       });
   auto Q_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, Q);
 
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.60), Q_h(0, 0), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.64), Q_h(0, 1), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.48), Q_h(0, 2), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.80), Q_h(1, 0), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.48), Q_h(1, 1), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.36), Q_h(1, 2), tol);
-  Test::EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(2, 0), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.60), Q_h(2, 1), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.80), Q_h(2, 2), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.60), Q_h(0, 0), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.64), Q_h(0, 1), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.48), Q_h(0, 2), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.80), Q_h(1, 0), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.48), Q_h(1, 1), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.36), Q_h(1, 2), tol);
+  EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(2, 0), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.60), Q_h(2, 1), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.80), Q_h(2, 2), tol);
 
   Kokkos::deep_copy(Q_h, 0.0);
   Q_h(0, 0) = 1.0;
@@ -381,15 +381,15 @@ void test_QR_rectangular() {
       });
   Kokkos::deep_copy(Q_h, Q);
 
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.60), Q_h(0, 0), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.64), Q_h(1, 0), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.48), Q_h(2, 0), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.80), Q_h(0, 1), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.48), Q_h(1, 1), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.36), Q_h(2, 1), tol);
-  Test::EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(0, 2), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.60), Q_h(1, 2), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.80), Q_h(2, 2), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.60), Q_h(0, 0), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.64), Q_h(1, 0), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.48), Q_h(2, 0), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.80), Q_h(0, 1), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.48), Q_h(1, 1), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.36), Q_h(2, 1), tol);
+  EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(0, 2), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.60), Q_h(1, 2), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.80), Q_h(2, 2), tol);
 
   Kokkos::deep_copy(Q_h, 0.0);
   Q_h(0, 0) = 1.0;
@@ -403,15 +403,15 @@ void test_QR_rectangular() {
       });
   Kokkos::deep_copy(Q_h, Q);
 
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.60), Q_h(0, 0), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.64), Q_h(0, 1), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.48), Q_h(0, 2), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.80), Q_h(1, 0), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.48), Q_h(1, 1), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.36), Q_h(1, 2), tol);
-  Test::EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(2, 0), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.60), Q_h(2, 1), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.80), Q_h(2, 2), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.60), Q_h(0, 0), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.64), Q_h(0, 1), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.48), Q_h(0, 2), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.80), Q_h(1, 0), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.48), Q_h(1, 1), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.36), Q_h(1, 2), tol);
+  EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(2, 0), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.60), Q_h(2, 1), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.80), Q_h(2, 2), tol);
 
   Kokkos::parallel_for(
       "serialApplyQ", 1, KOKKOS_LAMBDA(int) {
@@ -419,16 +419,16 @@ void test_QR_rectangular() {
       });
   Kokkos::deep_copy(Q_h, Q);
 
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(1.0), Q_h(0, 0), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(1.0), Q_h(1, 1), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(1.0), Q_h(2, 2), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(1.0), Q_h(0, 0), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(1.0), Q_h(1, 1), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(1.0), Q_h(2, 2), tol);
 
-  Test::EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(0, 1), tol);
-  Test::EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(0, 2), tol);
-  Test::EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(1, 0), tol);
-  Test::EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(1, 2), tol);
-  Test::EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(2, 0), tol);
-  Test::EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(2, 1), tol);
+  EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(0, 1), tol);
+  EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(0, 2), tol);
+  EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(1, 0), tol);
+  EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(1, 2), tol);
+  EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(2, 0), tol);
+  EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(2, 1), tol);
 
   Kokkos::deep_copy(Q_h, 0);
   Q_h(0, 0) = 1.0;
@@ -441,15 +441,15 @@ void test_QR_rectangular() {
       });
   Kokkos::deep_copy(Q_h, Q);
 
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.60), Q_h(0, 0), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.64), Q_h(0, 1), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.48), Q_h(0, 2), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.80), Q_h(1, 0), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.48), Q_h(1, 1), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.36), Q_h(1, 2), tol);
-  Test::EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(2, 0), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.60), Q_h(2, 1), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.80), Q_h(2, 2), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.60), Q_h(0, 0), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.64), Q_h(0, 1), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.48), Q_h(0, 2), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.80), Q_h(1, 0), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.48), Q_h(1, 1), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.36), Q_h(1, 2), tol);
+  EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(2, 0), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.60), Q_h(2, 1), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.80), Q_h(2, 2), tol);
 }
 
 template <class Device, class Scalar, class AlgoTagType>
@@ -507,15 +507,15 @@ void test_QR_rectangular_cplx() {
 
   const mag_type norm_y = Kokkos::sqrt(170 * 170 + 68 * 68 + 80 * 80 + 54 * 54) / 18;
 
-  Test::EXPECT_NEAR_KK_REL(A_h(0, 0), Scalar(-6, 0), tol);
-  Test::EXPECT_NEAR_KK_REL(A_h(0, 1), Scalar(-22. / 3, 21. / 3), tol);
-  Test::EXPECT_NEAR_KK_REL(A_h(1, 0), Scalar(13, -1) / 30, tol);
-  Test::EXPECT_NEAR_KK_REL(A_h(1, 1), norm_y, tol);
-  Test::EXPECT_NEAR_KK_REL(A_h(2, 0), Scalar(1, 3) / 30, tol);
-  Test::EXPECT_NEAR_KK_REL(A_h(2, 1), Scalar(-80, -54) / Scalar(-170 - 18 * norm_y, 68), tol);
+  EXPECT_NEAR_KK_REL(A_h(0, 0), Scalar(-6, 0), tol);
+  EXPECT_NEAR_KK_REL(A_h(0, 1), Scalar(-22. / 3, 21. / 3), tol);
+  EXPECT_NEAR_KK_REL(A_h(1, 0), Scalar(13, -1) / 30, tol);
+  EXPECT_NEAR_KK_REL(A_h(1, 1), norm_y, tol);
+  EXPECT_NEAR_KK_REL(A_h(2, 0), Scalar(1, 3) / 30, tol);
+  EXPECT_NEAR_KK_REL(A_h(2, 1), Scalar(-80, -54) / Scalar(-170 - 18 * norm_y, 68), tol);
 
-  Test::EXPECT_NEAR_KK_REL(tau_h(0), KAT::one() / Scalar(3. / 2., 1. / 2.), tol);
-  Test::EXPECT_NEAR_KK_REL(tau_h(1), norm_y / (norm_y - Scalar(-170, 68) / 18), tol);
+  EXPECT_NEAR_KK_REL(tau_h(0), KAT::one() / Scalar(3. / 2., 1. / 2.), tol);
+  EXPECT_NEAR_KK_REL(tau_h(1), norm_y / (norm_y - Scalar(-170, 68) / 18), tol);
 
   Kokkos::parallel_for(
       "serialApplyQ", 1, KOKKOS_LAMBDA(int) {
@@ -523,12 +523,12 @@ void test_QR_rectangular_cplx() {
       });
   auto B_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, B);
 
-  Test::EXPECT_NEAR_KK_REL(Scalar(-6, 0), B_h(0, 0), tol);
-  Test::EXPECT_NEAR_KK_REL(Scalar(-22, 21) / 3, B_h(0, 1), tol);
-  Test::EXPECT_NEAR_KK(Scalar(0, 0), B_h(1, 0), tol);
-  Test::EXPECT_NEAR_KK_REL(Scalar(norm_y, 0), B_h(1, 1), tol);
-  Test::EXPECT_NEAR_KK(Scalar(0, 0), B_h(2, 0), tol);
-  Test::EXPECT_NEAR_KK(Scalar(0, 0), B_h(2, 1), tol);
+  EXPECT_NEAR_KK_REL(Scalar(-6, 0), B_h(0, 0), tol);
+  EXPECT_NEAR_KK_REL(Scalar(-22, 21) / 3, B_h(0, 1), tol);
+  EXPECT_NEAR_KK(Scalar(0, 0), B_h(1, 0), tol);
+  EXPECT_NEAR_KK_REL(Scalar(norm_y, 0), B_h(1, 1), tol);
+  EXPECT_NEAR_KK(Scalar(0, 0), B_h(2, 0), tol);
+  EXPECT_NEAR_KK(Scalar(0, 0), B_h(2, 1), tol);
 
   Kokkos::parallel_for(
       "serialFormQ", 1, KOKKOS_LAMBDA(int) {
@@ -537,15 +537,15 @@ void test_QR_rectangular_cplx() {
       });
   auto Q_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, Q);
 
-  Test::EXPECT_NEAR_KK_REL(Scalar(-0.5, -0.5), Q_h(0, 0), tol);
-  // Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.64), Q_h(0, 1), tol);
-  // Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.48), Q_h(0, 2), tol);
-  Test::EXPECT_NEAR_KK_REL(Scalar(-2.0 / 3.0, -1.0 / 6.0), Q_h(1, 0), tol);
-  // Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.48), Q_h(1, 1), tol);
-  // Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.36), Q_h(1, 2), tol);
-  Test::EXPECT_NEAR_KK_REL(Scalar(0.0, -1.0 / 6.0), Q_h(2, 0), tol);
-  // Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.60), Q_h(2, 1), tol);
-  // Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.80), Q_h(2, 2), tol);
+  EXPECT_NEAR_KK_REL(Scalar(-0.5, -0.5), Q_h(0, 0), tol);
+  // EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.64), Q_h(0, 1), tol);
+  // EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.48), Q_h(0, 2), tol);
+  EXPECT_NEAR_KK_REL(Scalar(-2.0 / 3.0, -1.0 / 6.0), Q_h(1, 0), tol);
+  // EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.48), Q_h(1, 1), tol);
+  // EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.36), Q_h(1, 2), tol);
+  EXPECT_NEAR_KK_REL(Scalar(0.0, -1.0 / 6.0), Q_h(2, 0), tol);
+  // EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.60), Q_h(2, 1), tol);
+  // EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.80), Q_h(2, 2), tol);
 
   // Kokkos::deep_copy(Q_h, 0.0);
   // Q_h(0, 0) = 1.0;
@@ -559,15 +559,15 @@ void test_QR_rectangular_cplx() {
   //     });
   // Kokkos::deep_copy(Q_h, Q);
 
-  // Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.60), Q_h(0, 0), tol);
-  // Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.64), Q_h(1, 0), tol);
-  // Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.48), Q_h(2, 0), tol);
-  // Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.80), Q_h(0, 1), tol);
-  // Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.48), Q_h(1, 1), tol);
-  // Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.36), Q_h(2, 1), tol);
-  // Test::EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(0, 2), tol);
-  // Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.60), Q_h(1, 2), tol);
-  // Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.80), Q_h(2, 2), tol);
+  // EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.60), Q_h(0, 0), tol);
+  // EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.64), Q_h(1, 0), tol);
+  // EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.48), Q_h(2, 0), tol);
+  // EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.80), Q_h(0, 1), tol);
+  // EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.48), Q_h(1, 1), tol);
+  // EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.36), Q_h(2, 1), tol);
+  // EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(0, 2), tol);
+  // EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.60), Q_h(1, 2), tol);
+  // EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.80), Q_h(2, 2), tol);
 
   Kokkos::deep_copy(Q_h, 0.0);
   Q_h(0, 0) = 1.0;
@@ -581,15 +581,15 @@ void test_QR_rectangular_cplx() {
       });
   Kokkos::deep_copy(Q_h, Q);
 
-  Test::EXPECT_NEAR_KK_REL(Scalar(-0.5, -0.5), Q_h(0, 0), tol);
-  // Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.64), Q_h(0, 1), tol);
-  // Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.48), Q_h(0, 2), tol);
-  Test::EXPECT_NEAR_KK_REL(Scalar(-2.0 / 3.0, -1.0 / 6.0), Q_h(1, 0), tol);
-  // Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.48), Q_h(1, 1), tol);
-  // Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.36), Q_h(1, 2), tol);
-  Test::EXPECT_NEAR_KK_REL(Scalar(0.0, -1.0 / 6.0), Q_h(2, 0), tol);
-  // Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.60), Q_h(2, 1), tol);
-  // Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.80), Q_h(2, 2), tol);
+  EXPECT_NEAR_KK_REL(Scalar(-0.5, -0.5), Q_h(0, 0), tol);
+  // EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.64), Q_h(0, 1), tol);
+  // EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.48), Q_h(0, 2), tol);
+  EXPECT_NEAR_KK_REL(Scalar(-2.0 / 3.0, -1.0 / 6.0), Q_h(1, 0), tol);
+  // EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.48), Q_h(1, 1), tol);
+  // EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.36), Q_h(1, 2), tol);
+  EXPECT_NEAR_KK_REL(Scalar(0.0, -1.0 / 6.0), Q_h(2, 0), tol);
+  // EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.60), Q_h(2, 1), tol);
+  // EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.80), Q_h(2, 2), tol);
 
   Kokkos::parallel_for(
       "serialApplyQ", 1, KOKKOS_LAMBDA(int) {
@@ -597,16 +597,16 @@ void test_QR_rectangular_cplx() {
       });
   Kokkos::deep_copy(Q_h, Q);
 
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(1.0), Q_h(0, 0), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(1.0), Q_h(1, 1), tol);
-  Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(1.0), Q_h(2, 2), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(1.0), Q_h(0, 0), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(1.0), Q_h(1, 1), tol);
+  EXPECT_NEAR_KK_REL(static_cast<Scalar>(1.0), Q_h(2, 2), tol);
 
-  Test::EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(0, 1), tol);
-  Test::EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(0, 2), tol);
-  Test::EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(1, 0), tol);
-  Test::EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(1, 2), tol);
-  Test::EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(2, 0), tol);
-  Test::EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(2, 1), tol);
+  EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(0, 1), tol);
+  EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(0, 2), tol);
+  EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(1, 0), tol);
+  EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(1, 2), tol);
+  EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(2, 0), tol);
+  EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(2, 1), tol);
 
   // Kokkos::deep_copy(Q_h, 0);
   // Q_h(0, 0) = 1.0;
@@ -619,15 +619,15 @@ void test_QR_rectangular_cplx() {
   //     });
   // Kokkos::deep_copy(Q_h, Q);
 
-  // Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.60), Q_h(0, 0), tol);
-  // Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.64), Q_h(0, 1), tol);
-  // Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.48), Q_h(0, 2), tol);
-  // Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.80), Q_h(1, 0), tol);
-  // Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.48), Q_h(1, 1), tol);
-  // Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.36), Q_h(1, 2), tol);
-  // Test::EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(2, 0), tol);
-  // Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.60), Q_h(2, 1), tol);
-  // Test::EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.80), Q_h(2, 2), tol);
+  // EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.60), Q_h(0, 0), tol);
+  // EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.64), Q_h(0, 1), tol);
+  // EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.48), Q_h(0, 2), tol);
+  // EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.80), Q_h(1, 0), tol);
+  // EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.48), Q_h(1, 1), tol);
+  // EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.36), Q_h(1, 2), tol);
+  // EXPECT_NEAR_KK(static_cast<Scalar>(0.), Q_h(2, 0), tol);
+  // EXPECT_NEAR_KK_REL(static_cast<Scalar>(-0.60), Q_h(2, 1), tol);
+  // EXPECT_NEAR_KK_REL(static_cast<Scalar>(0.80), Q_h(2, 2), tol);
 }
 
 template <class Device, class Scalar, class AlgoTagType>
@@ -656,7 +656,7 @@ void test_QR_batch(const int numMat, const int numRows, const int numCols) {
     constexpr double max_val = 1000;
     {
       Scalar randStart, randEnd;
-      Test::getRandomBounds(max_val, randStart, randEnd);
+      TestUtils::getRandomBounds(max_val, randStart, randEnd);
       Kokkos::fill_random(ExecutionSpace{}, As, rand_pool, randStart, randEnd);
     }
     Kokkos::fence();

--- a/batched/dense/unit_test/Test_Batched_SerialSVD.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialSVD.hpp
@@ -50,11 +50,11 @@ void verifyOrthogonal(const Mat& X, const double epsilon = -1) {
   for (int i = 0; i < k; i++) {
     auto col1  = Kokkos::subview(X, Kokkos::ALL(), i);
     double len = simpleNorm2(col1);
-    Test::EXPECT_NEAR_KK(len, 1.0, tol);
+    EXPECT_NEAR_KK(len, 1.0, tol);
     for (int j = 0; j < i; j++) {
       auto col2 = Kokkos::subview(X, Kokkos::ALL(), j);
       double d  = KokkosKernels::ArithTraits<Scalar>::abs(simpleDot(col1, col2));
-      Test::EXPECT_NEAR_KK(d, 0.0, tol);
+      EXPECT_NEAR_KK(d, 0.0, tol);
     }
   }
 }
@@ -81,7 +81,7 @@ void verifySVD(const AView& A, const UView& U, const VtView& Vt, const SigmaView
   }
   for (int i = 0; i < m; i++) {
     for (int j = 0; j < n; j++) {
-      Test::EXPECT_NEAR_KK(usvt(i, j), A(i, j), tol);
+      EXPECT_NEAR_KK(usvt(i, j), A(i, j), tol);
     }
   }
   // Make sure all singular values are positive
@@ -236,7 +236,7 @@ void testSerialSVDSingularValuesOnly(int m, int n) {
   auto sigma2Host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), sigma2);
   // Make sure they match
   for (int i = 0; i < maxrank; i++) {
-    Test::EXPECT_NEAR_KK(sigma1Host(i), sigma2Host(i), Test::svdEpsilon<Scalar>());
+    EXPECT_NEAR_KK(sigma1Host(i), sigma2Host(i), Test::svdEpsilon<Scalar>());
   }
 }
 
@@ -270,18 +270,18 @@ void testSerialSVDZeroLastRow(int n) {
   for (int i = 0; i < n; i++) {
     for (int j = 0; j < n; j++) {
       if (i != j && i + 1 != j) {
-        Test::EXPECT_NEAR_KK(B(i, j), KAT::zero(), Test::svdEpsilon<Scalar>());
+        EXPECT_NEAR_KK(B(i, j), KAT::zero(), Test::svdEpsilon<Scalar>());
       }
     }
   }
   // Check that the last superdiagonal is now zero
-  Test::EXPECT_NEAR_KK(B(n - 2, n - 1), KAT::zero(), Test::svdEpsilon<Scalar>());
+  EXPECT_NEAR_KK(B(n - 2, n - 1), KAT::zero(), Test::svdEpsilon<Scalar>());
   // Check that the product is still maintained
   Matrix BVt2("UBVt", n, n);
   Test::vanillaGEMM(1.0, B, Vt, 0.0, BVt2);
   for (int i = 0; i < n; i++) {
     for (int j = 0; j < n; j++) {
-      Test::EXPECT_NEAR_KK(BVt(i, j), BVt2(i, j), Test::svdEpsilon<Scalar>());
+      EXPECT_NEAR_KK(BVt(i, j), BVt2(i, j), Test::svdEpsilon<Scalar>());
     }
   }
   // Check that Vt is still orthogonal
@@ -320,18 +320,18 @@ void testSerialSVDZeroDiagonal(int n, int row) {
   for (int i = 0; i < m; i++) {
     for (int j = 0; j < n; j++) {
       if (i != j && i + 1 != j) {
-        Test::EXPECT_NEAR_KK(B(i, j), KAT::zero(), Test::svdEpsilon<Scalar>());
+        EXPECT_NEAR_KK(B(i, j), KAT::zero(), Test::svdEpsilon<Scalar>());
       }
     }
   }
   // Check that row's diagonal is now zero
-  Test::EXPECT_NEAR_KK(B(row, row), KAT::zero(), Test::svdEpsilon<Scalar>());
+  EXPECT_NEAR_KK(B(row, row), KAT::zero(), Test::svdEpsilon<Scalar>());
   // Check that the product is still maintained
   Matrix UB2("UB", m, n);
   Test::vanillaGEMM(1.0, U, B, 0.0, UB2);
   for (int i = 0; i < m; i++) {
     for (int j = 0; j < n; j++) {
-      Test::EXPECT_NEAR_KK(UB(i, j), UB2(i, j), Test::svdEpsilon<Scalar>());
+      EXPECT_NEAR_KK(UB(i, j), UB2(i, j), Test::svdEpsilon<Scalar>());
     }
   }
   // Check that U is still orthogonal
@@ -601,8 +601,8 @@ void testTwoByTwoInternal() {
   Kokkos::parallel_for(Kokkos::RangePolicy<ExecSpace>(0, 1), tester);
   typename Vector::host_mirror_type evs_host = Kokkos::create_mirror_view(evs);
   Kokkos::deep_copy(evs_host, evs);
-  Test::EXPECT_NEAR_KK(evs_host(0), 0.000625, Test::svdEpsilon<Scalar>());
-  Test::EXPECT_NEAR_KK(evs_host(1), 0.000625, Test::svdEpsilon<Scalar>());
+  EXPECT_NEAR_KK(evs_host(0), 0.000625, Test::svdEpsilon<Scalar>());
+  EXPECT_NEAR_KK(evs_host(1), 0.000625, Test::svdEpsilon<Scalar>());
 }
 
 #if defined(KOKKOSKERNELS_INST_DOUBLE)

--- a/batched/dense/unit_test/Test_Batched_SerialSolveLU.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialSolveLU.hpp
@@ -55,7 +55,7 @@ struct Functor_BatchedSerialGemm {
   inline void run() {
     typedef typename ViewType::value_type value_type;
     std::string name_region("KokkosBatched::Test::SerialSolveLU");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
     Kokkos::RangePolicy<execution_space, ParamTagType> policy(0, _c.extent(0));
@@ -84,7 +84,7 @@ struct Functor_BatchedSerialLU {
   inline void run() {
     typedef typename ViewType::value_type value_type;
     std::string name_region("KokkosBatched::Test::SerialSolveLU");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
     Kokkos::RangePolicy<execution_space> policy(0, _a.extent(0));
@@ -113,7 +113,7 @@ struct Functor_TestBatchedSerialSolveLU {
   inline void run() {
     typedef typename ViewType::value_type value_type;
     std::string name_region("KokkosBatched::Test::SerialSolveLU");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
     Kokkos::RangePolicy<execution_space> policy(0, _a.extent(0));

--- a/batched/dense/unit_test/Test_Batched_SerialSyr.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialSyr.hpp
@@ -39,7 +39,7 @@ struct Functor_BatchedSerialSyr {
   inline int run() {
     using value_type = typename AViewType::non_const_value_type;
     std::string name_region("KokkosBatched::Test::SerialSyr");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     int info_sum                      = 0;
     Kokkos::Profiling::pushRegion(name.c_str());

--- a/batched/dense/unit_test/Test_Batched_SerialSyr2.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialSyr2.hpp
@@ -42,7 +42,7 @@ struct Functor_BatchedSerialSyr2 {
   inline int run() {
     using value_type = typename AViewType::non_const_value_type;
     std::string name_region("KokkosBatched::Test::SerialSyr2");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     int info_sum                      = 0;
     Kokkos::Profiling::pushRegion(name.c_str());

--- a/batched/dense/unit_test/Test_Batched_SerialTbsv.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialTbsv.hpp
@@ -44,7 +44,7 @@ struct Functor_BatchedSerialTrsv {
   inline void run() {
     using value_type = typename AViewType::non_const_value_type;
     std::string name_region("KokkosBatched::Test::SerialTbsv");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::RangePolicy<execution_space, ParamTagType> policy(0, m_b.extent(0));
     Kokkos::parallel_for(name.c_str(), policy, *this);
@@ -73,7 +73,7 @@ struct Functor_BatchedSerialTbsv {
   inline void run() {
     using value_type = typename AViewType::non_const_value_type;
     std::string name_region("KokkosBatched::Test::SerialTbsv");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
     Kokkos::RangePolicy<execution_space, ParamTagType> policy(0, m_b.extent(0));
@@ -100,7 +100,7 @@ void impl_test_batched_tbsv(const int N, const int k, const int BlkSize) {
 
   Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(13718);
   ScalarType randStart, randEnd;
-  Test::getRandomBounds(1.0, randStart, randEnd);
+  TestUtils::getRandomBounds(1.0, randStart, randEnd);
   Kokkos::fill_random(Ref, rand_pool, randStart, randEnd);
   Kokkos::fill_random(x0, rand_pool, randStart, randEnd);
 
@@ -130,7 +130,7 @@ void impl_test_batched_tbsv(const int N, const int k, const int BlkSize) {
   auto h_x1 = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), x1);
   for (int i = 0; i < N; i++) {
     for (int j = 0; j < BlkSize; j++) {
-      Test::EXPECT_NEAR_KK_REL(h_x0(i, j), h_x1(i, j), eps);
+      EXPECT_NEAR_KK_REL(h_x0(i, j), h_x1(i, j), eps);
     }
   }
 }

--- a/batched/dense/unit_test/Test_Batched_SerialTrmm.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialTrmm.hpp
@@ -116,7 +116,7 @@ struct Functor_TestBatchedSerialTrmm {
   inline void run() {
     typedef typename ViewType::value_type value_type;
     std::string name_region("KokkosBatched::Test::SerialTrmm");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
     Kokkos::RangePolicy<execution_space, ParamTagType> policy(0, _a.extent(0));

--- a/batched/dense/unit_test/Test_Batched_SerialTrsm.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialTrsm.hpp
@@ -48,7 +48,7 @@ struct Functor_TestBatchedSerialTrsm {
   inline void run() {
     typedef typename ViewType::value_type value_type;
     std::string name_region("KokkosBatched::Test::SerialTrsm");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
     Kokkos::RangePolicy<execution_space, ParamTagType> policy(0, m_b.extent(0));
@@ -83,7 +83,7 @@ struct Functor_BatchedSerialGemm {
   inline void run() {
     using value_type = typename AViewType::non_const_value_type;
     std::string name_region("KokkosBatched::Test::SerialTrsm");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::RangePolicy<execution_space> policy(0, m_a.extent(0));
     Kokkos::parallel_for(name.c_str(), policy, *this);

--- a/batched/dense/unit_test/Test_Batched_SerialTrsv.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialTrsv.hpp
@@ -50,7 +50,7 @@ struct Functor_BatchedSerialTrsv {
   inline int run() {
     using value_type = typename AViewType::non_const_value_type;
     std::string name_region("KokkosBatched::Test::SerialTrsv");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     int info_sum                      = 0;
     Kokkos::Profiling::pushRegion(name.c_str());
@@ -87,7 +87,7 @@ struct Functor_BatchedSerialGemv {
   inline void run() {
     using value_type = typename AViewType::non_const_value_type;
     std::string name_region("KokkosBatched::Test::SerialGemv");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::RangePolicy<execution_space, ParamTagType> policy(0, m_x.extent(0));
     Kokkos::parallel_for(name.c_str(), policy, *this);

--- a/batched/dense/unit_test/Test_Batched_SerialTrtri.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialTrtri.hpp
@@ -111,7 +111,7 @@ struct Functor_TestBatchedSerialTrtri {
   inline void run() {
     typedef typename ViewType::value_type value_type;
     std::string name_region("KokkosBatched::Test::SerialTrtri");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
     Kokkos::RangePolicy<execution_space, ParamTagType> policy(0, _a.extent(0));

--- a/batched/dense/unit_test/Test_Batched_Swap.hpp
+++ b/batched/dense/unit_test/Test_Batched_Swap.hpp
@@ -48,7 +48,7 @@ struct Functor_BatchedSwap {
                               : std::is_same_v<ArgMode, KokkosBatched::Mode::Team>
                                   ? "KokkosBatched::Test::TeamSwap"
                                   : "KokkosBatched::Test::TeamVectorSwap";
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     int info_sum                      = 0;
     Kokkos::Profiling::pushRegion(name.c_str());

--- a/batched/dense/unit_test/Test_Batched_TeamAxpy.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamAxpy.hpp
@@ -53,7 +53,7 @@ struct Functor_TestBatchedTeamAxpy {
   inline void run() {
     using value_type = typename ViewType::value_type;
     std::string name_region("KokkosBatched::Test::TeamAxpy");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
     Kokkos::TeamPolicy<execution_space> policy(m_X.extent(0) / m_N_team, Kokkos::AUTO(), Kokkos::AUTO());

--- a/batched/dense/unit_test/Test_Batched_TeamGemm.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamGemm.hpp
@@ -59,7 +59,7 @@ struct Functor_TestBatchedTeamGemm {
     std::string name_region           = std::is_same_v<typename ParamTagType::mode, KokkosBatched::Mode::Team>
                                             ? "KokkosBatched::Test::TeamGemm"
                                             : "KokkosBatched::Test::TeamVectorGemm";
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
     const int league_size = m_c.extent(0);

--- a/batched/dense/unit_test/Test_Batched_TeamGemm_Real.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamGemm_Real.hpp
@@ -5,36 +5,36 @@ TEST_F(TestCategory, batched_scalar_team_gemm_nt_nt_bhalf_bhalf) {
   using param_tag_type = ::Test::TeamGemm::ParamTag<KokkosBatched::Mode::Team, KokkosBatched::Trans::NoTranspose,
                                                     KokkosBatched::Trans::NoTranspose>;
 
-  test_batched_teamgemm<TestDevice, ::Test::bhalfScalarType, ::Test::bhalfScalarType, param_tag_type,
+  test_batched_teamgemm<TestDevice, TestUtils::bhalfScalarType, TestUtils::bhalfScalarType, param_tag_type,
                         Algo::Gemm::Blocked>();
-  test_batched_teamgemm<TestDevice, ::Test::bhalfScalarType, ::Test::bhalfScalarType, param_tag_type,
+  test_batched_teamgemm<TestDevice, TestUtils::bhalfScalarType, TestUtils::bhalfScalarType, param_tag_type,
                         Algo::Gemm::Unblocked>();
 }
 TEST_F(TestCategory, batched_scalar_team_gemm_t_nt_bhalf_bhalf) {
   using param_tag_type = ::Test::TeamGemm::ParamTag<KokkosBatched::Mode::Team, KokkosBatched::Trans::Transpose,
                                                     KokkosBatched::Trans::NoTranspose>;
 
-  test_batched_teamgemm<TestDevice, ::Test::bhalfScalarType, ::Test::bhalfScalarType, param_tag_type,
+  test_batched_teamgemm<TestDevice, TestUtils::bhalfScalarType, TestUtils::bhalfScalarType, param_tag_type,
                         Algo::Gemm::Blocked>();
-  test_batched_teamgemm<TestDevice, ::Test::bhalfScalarType, ::Test::bhalfScalarType, param_tag_type,
+  test_batched_teamgemm<TestDevice, TestUtils::bhalfScalarType, TestUtils::bhalfScalarType, param_tag_type,
                         Algo::Gemm::Unblocked>();
 }
 TEST_F(TestCategory, batched_scalar_team_gemm_nt_t_bhalf_bhalf) {
   using param_tag_type = ::Test::TeamGemm::ParamTag<KokkosBatched::Mode::Team, KokkosBatched::Trans::NoTranspose,
                                                     KokkosBatched::Trans::Transpose>;
 
-  test_batched_teamgemm<TestDevice, ::Test::bhalfScalarType, ::Test::bhalfScalarType, param_tag_type,
+  test_batched_teamgemm<TestDevice, TestUtils::bhalfScalarType, TestUtils::bhalfScalarType, param_tag_type,
                         Algo::Gemm::Blocked>();
-  test_batched_teamgemm<TestDevice, ::Test::bhalfScalarType, ::Test::bhalfScalarType, param_tag_type,
+  test_batched_teamgemm<TestDevice, TestUtils::bhalfScalarType, TestUtils::bhalfScalarType, param_tag_type,
                         Algo::Gemm::Unblocked>();
 }
 TEST_F(TestCategory, batched_scalar_team_gemm_t_t_bhalf_bhalf) {
   using param_tag_type = ::Test::TeamGemm::ParamTag<KokkosBatched::Mode::Team, KokkosBatched::Trans::Transpose,
                                                     KokkosBatched::Trans::Transpose>;
 
-  test_batched_teamgemm<TestDevice, ::Test::bhalfScalarType, ::Test::bhalfScalarType, param_tag_type,
+  test_batched_teamgemm<TestDevice, TestUtils::bhalfScalarType, TestUtils::bhalfScalarType, param_tag_type,
                         Algo::Gemm::Blocked>();
-  test_batched_teamgemm<TestDevice, ::Test::bhalfScalarType, ::Test::bhalfScalarType, param_tag_type,
+  test_batched_teamgemm<TestDevice, TestUtils::bhalfScalarType, TestUtils::bhalfScalarType, param_tag_type,
                         Algo::Gemm::Unblocked>();
 }
 #endif  // KOKKOS_BHALF_T_IS_FLOAT
@@ -44,36 +44,36 @@ TEST_F(TestCategory, batched_scalar_team_gemm_nt_nt_half_half) {
   using param_tag_type = ::Test::TeamGemm::ParamTag<KokkosBatched::Mode::Team, KokkosBatched::Trans::NoTranspose,
                                                     KokkosBatched::Trans::NoTranspose>;
 
-  test_batched_teamgemm<TestDevice, ::Test::halfScalarType, ::Test::halfScalarType, param_tag_type,
+  test_batched_teamgemm<TestDevice, TestUtils::halfScalarType, TestUtils::halfScalarType, param_tag_type,
                         Algo::Gemm::Blocked>();
-  test_batched_teamgemm<TestDevice, ::Test::halfScalarType, ::Test::halfScalarType, param_tag_type,
+  test_batched_teamgemm<TestDevice, TestUtils::halfScalarType, TestUtils::halfScalarType, param_tag_type,
                         Algo::Gemm::Unblocked>();
 }
 TEST_F(TestCategory, batched_scalar_team_gemm_t_nt_half_half) {
   using param_tag_type = ::Test::TeamGemm::ParamTag<KokkosBatched::Mode::Team, KokkosBatched::Trans::Transpose,
                                                     KokkosBatched::Trans::NoTranspose>;
 
-  test_batched_teamgemm<TestDevice, ::Test::halfScalarType, ::Test::halfScalarType, param_tag_type,
+  test_batched_teamgemm<TestDevice, TestUtils::halfScalarType, TestUtils::halfScalarType, param_tag_type,
                         Algo::Gemm::Blocked>();
-  test_batched_teamgemm<TestDevice, ::Test::halfScalarType, ::Test::halfScalarType, param_tag_type,
+  test_batched_teamgemm<TestDevice, TestUtils::halfScalarType, TestUtils::halfScalarType, param_tag_type,
                         Algo::Gemm::Unblocked>();
 }
 TEST_F(TestCategory, batched_scalar_team_gemm_nt_t_half_half) {
   using param_tag_type = ::Test::TeamGemm::ParamTag<KokkosBatched::Mode::Team, KokkosBatched::Trans::NoTranspose,
                                                     KokkosBatched::Trans::Transpose>;
 
-  test_batched_teamgemm<TestDevice, ::Test::halfScalarType, ::Test::halfScalarType, param_tag_type,
+  test_batched_teamgemm<TestDevice, TestUtils::halfScalarType, TestUtils::halfScalarType, param_tag_type,
                         Algo::Gemm::Blocked>();
-  test_batched_teamgemm<TestDevice, ::Test::halfScalarType, ::Test::halfScalarType, param_tag_type,
+  test_batched_teamgemm<TestDevice, TestUtils::halfScalarType, TestUtils::halfScalarType, param_tag_type,
                         Algo::Gemm::Unblocked>();
 }
 TEST_F(TestCategory, batched_scalar_team_gemm_t_t_half_half) {
   using param_tag_type = ::Test::TeamGemm::ParamTag<KokkosBatched::Mode::Team, KokkosBatched::Trans::Transpose,
                                                     KokkosBatched::Trans::Transpose>;
 
-  test_batched_teamgemm<TestDevice, ::Test::halfScalarType, ::Test::halfScalarType, param_tag_type,
+  test_batched_teamgemm<TestDevice, TestUtils::halfScalarType, TestUtils::halfScalarType, param_tag_type,
                         Algo::Gemm::Blocked>();
-  test_batched_teamgemm<TestDevice, ::Test::halfScalarType, ::Test::halfScalarType, param_tag_type,
+  test_batched_teamgemm<TestDevice, TestUtils::halfScalarType, TestUtils::halfScalarType, param_tag_type,
                         Algo::Gemm::Unblocked>();
 }
 #endif  // KOKKOS_HALF_T_IS_FLOAT

--- a/batched/dense/unit_test/Test_Batched_TeamGesv.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamGesv.hpp
@@ -44,7 +44,7 @@ struct Functor_TestBatchedTeamGesv {
   inline void run() {
     typedef typename VectorType::value_type value_type;
     std::string name_region("KokkosBatched::Test::TeamGesv");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
     Kokkos::TeamPolicy<execution_space> policy(_X.extent(0), Kokkos::AUTO(), Kokkos::AUTO());

--- a/batched/dense/unit_test/Test_Batched_TeamInverseLU.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamInverseLU.hpp
@@ -60,7 +60,7 @@ struct Functor_BatchedTeamGemm {
   inline void run() {
     typedef typename ViewType::value_type value_type;
     std::string name_region("KokkosBatched::Test::TeamInverseLU");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
 
@@ -94,7 +94,7 @@ struct Functor_BatchedTeamLU {
   inline void run() {
     typedef typename ViewType::value_type value_type;
     std::string name_region("KokkosBatched::Test::TeamInverseLU");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
 
@@ -125,7 +125,7 @@ struct Functor_TestBatchedTeamInverseLU {
   inline void run() {
     typedef typename AViewType::value_type value_type;
     std::string name_region("KokkosBatched::Test::TeamInverseLU");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
 

--- a/batched/dense/unit_test/Test_Batched_TeamLU.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamLU.hpp
@@ -44,7 +44,7 @@ struct Functor_TestBatchedTeamLU {
   inline void run() {
     typedef typename ViewType::value_type value_type;
     std::string name_region("KokkosBatched::Test::TeamLU");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
 

--- a/batched/dense/unit_test/Test_Batched_TeamSolveLU.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamSolveLU.hpp
@@ -60,7 +60,7 @@ struct Functor_BatchedTeamGemm {
   inline void run() {
     typedef typename ViewType::value_type value_type;
     std::string name_region("KokkosBatched::Test::TeamSolveLU");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
     const int league_size = _c.extent(0);
@@ -92,7 +92,7 @@ struct Functor_BatchedTeamLU {
   inline void run() {
     typedef typename ViewType::value_type value_type;
     std::string name_region("KokkosBatched::Test::TeamSolveLU");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
     const int league_size = _a.extent(0);
@@ -122,7 +122,7 @@ struct Functor_TestBatchedTeamSolveLU {
   inline void run() {
     typedef typename ViewType::value_type value_type;
     std::string name_region("KokkosBatched::Test::TeamSolveLU");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
 

--- a/batched/dense/unit_test/Test_Batched_TeamTrsm.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamTrsm.hpp
@@ -54,7 +54,7 @@ struct Functor_TestBatchedTeamTrsm {
   inline void run() {
     typedef typename ViewType::value_type value_type;
     std::string name_region("KokkosBatched::Test::TeamTrsm");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
 

--- a/batched/dense/unit_test/Test_Batched_TeamTrsv.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamTrsv.hpp
@@ -50,7 +50,7 @@ struct Functor_TestBatchedTeamTrsv {
   inline void run() {
     typedef typename ViewType::value_type value_type;
     std::string name_region("KokkosBatched::Test::TeamTrsv");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
 

--- a/batched/dense/unit_test/Test_Batched_TeamVectorAxpy.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamVectorAxpy.hpp
@@ -54,7 +54,7 @@ struct Functor_TestBatchedTeamVectorAxpy {
   inline void run() {
     using value_type = typename ViewType::value_type;
     std::string name_region("KokkosBatched::Test::TeamVectorAxpy");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
     Kokkos::TeamPolicy<execution_space> policy(m_X.extent(0) / m_N_team, Kokkos::AUTO(), Kokkos::AUTO());

--- a/batched/dense/unit_test/Test_Batched_TeamVectorGemm_Real.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamVectorGemm_Real.hpp
@@ -5,36 +5,36 @@ TEST_F(TestCategory, batched_scalar_team_vector_gemm_nt_nt_bhalf_bhalf) {
   using param_tag_type = ::Test::TeamGemm::ParamTag<KokkosBatched::Mode::TeamVector, KokkosBatched::Trans::NoTranspose,
                                                     KokkosBatched::Trans::NoTranspose>;
 
-  test_batched_teamgemm<TestDevice, ::Test::bhalfScalarType, ::Test::bhalfScalarType, param_tag_type,
+  test_batched_teamgemm<TestDevice, TestUtils::bhalfScalarType, TestUtils::bhalfScalarType, param_tag_type,
                         Algo::Gemm::Blocked>();
-  test_batched_teamgemm<TestDevice, ::Test::bhalfScalarType, ::Test::bhalfScalarType, param_tag_type,
+  test_batched_teamgemm<TestDevice, TestUtils::bhalfScalarType, TestUtils::bhalfScalarType, param_tag_type,
                         Algo::Gemm::Unblocked>();
 }
 TEST_F(TestCategory, batched_scalar_team_vector_gemm_t_nt_bhalf_bhalf) {
   using param_tag_type = ::Test::TeamGemm::ParamTag<KokkosBatched::Mode::TeamVector, KokkosBatched::Trans::Transpose,
                                                     KokkosBatched::Trans::NoTranspose>;
 
-  test_batched_teamgemm<TestDevice, ::Test::bhalfScalarType, ::Test::bhalfScalarType, param_tag_type,
+  test_batched_teamgemm<TestDevice, TestUtils::bhalfScalarType, TestUtils::bhalfScalarType, param_tag_type,
                         Algo::Gemm::Blocked>();
-  test_batched_teamgemm<TestDevice, ::Test::bhalfScalarType, ::Test::bhalfScalarType, param_tag_type,
+  test_batched_teamgemm<TestDevice, TestUtils::bhalfScalarType, TestUtils::bhalfScalarType, param_tag_type,
                         Algo::Gemm::Unblocked>();
 }
 TEST_F(TestCategory, batched_scalar_team_vector_gemm_nt_t_bhalf_bhalf) {
   using param_tag_type = ::Test::TeamGemm::ParamTag<KokkosBatched::Mode::TeamVector, KokkosBatched::Trans::NoTranspose,
                                                     KokkosBatched::Trans::Transpose>;
 
-  test_batched_teamgemm<TestDevice, ::Test::bhalfScalarType, ::Test::bhalfScalarType, param_tag_type,
+  test_batched_teamgemm<TestDevice, TestUtils::bhalfScalarType, TestUtils::bhalfScalarType, param_tag_type,
                         Algo::Gemm::Blocked>();
-  test_batched_teamgemm<TestDevice, ::Test::bhalfScalarType, ::Test::bhalfScalarType, param_tag_type,
+  test_batched_teamgemm<TestDevice, TestUtils::bhalfScalarType, TestUtils::bhalfScalarType, param_tag_type,
                         Algo::Gemm::Unblocked>();
 }
 TEST_F(TestCategory, batched_scalar_team_vector_gemm_t_t_bhalf_bhalf) {
   using param_tag_type = ::Test::TeamGemm::ParamTag<KokkosBatched::Mode::TeamVector, KokkosBatched::Trans::Transpose,
                                                     KokkosBatched::Trans::Transpose>;
 
-  test_batched_teamgemm<TestDevice, ::Test::bhalfScalarType, ::Test::bhalfScalarType, param_tag_type,
+  test_batched_teamgemm<TestDevice, TestUtils::bhalfScalarType, TestUtils::bhalfScalarType, param_tag_type,
                         Algo::Gemm::Blocked>();
-  test_batched_teamgemm<TestDevice, ::Test::bhalfScalarType, ::Test::bhalfScalarType, param_tag_type,
+  test_batched_teamgemm<TestDevice, TestUtils::bhalfScalarType, TestUtils::bhalfScalarType, param_tag_type,
                         Algo::Gemm::Unblocked>();
 }
 #endif  // KOKKOS_BHALF_T_IS_FLOAT
@@ -44,36 +44,36 @@ TEST_F(TestCategory, batched_scalar_team_vector_gemm_nt_nt_half_half) {
   using param_tag_type = ::Test::TeamGemm::ParamTag<KokkosBatched::Mode::TeamVector, KokkosBatched::Trans::NoTranspose,
                                                     KokkosBatched::Trans::NoTranspose>;
 
-  test_batched_teamgemm<TestDevice, ::Test::halfScalarType, ::Test::halfScalarType, param_tag_type,
+  test_batched_teamgemm<TestDevice, TestUtils::halfScalarType, TestUtils::halfScalarType, param_tag_type,
                         Algo::Gemm::Blocked>();
-  test_batched_teamgemm<TestDevice, ::Test::halfScalarType, ::Test::halfScalarType, param_tag_type,
+  test_batched_teamgemm<TestDevice, TestUtils::halfScalarType, TestUtils::halfScalarType, param_tag_type,
                         Algo::Gemm::Unblocked>();
 }
 TEST_F(TestCategory, batched_scalar_team_vector_gemm_t_nt_half_half) {
   using param_tag_type = ::Test::TeamGemm::ParamTag<KokkosBatched::Mode::TeamVector, KokkosBatched::Trans::Transpose,
                                                     KokkosBatched::Trans::NoTranspose>;
 
-  test_batched_teamgemm<TestDevice, ::Test::halfScalarType, ::Test::halfScalarType, param_tag_type,
+  test_batched_teamgemm<TestDevice, TestUtils::halfScalarType, TestUtils::halfScalarType, param_tag_type,
                         Algo::Gemm::Blocked>();
-  test_batched_teamgemm<TestDevice, ::Test::halfScalarType, ::Test::halfScalarType, param_tag_type,
+  test_batched_teamgemm<TestDevice, TestUtils::halfScalarType, TestUtils::halfScalarType, param_tag_type,
                         Algo::Gemm::Unblocked>();
 }
 TEST_F(TestCategory, batched_scalar_team_vector_gemm_nt_t_half_half) {
   using param_tag_type = ::Test::TeamGemm::ParamTag<KokkosBatched::Mode::TeamVector, KokkosBatched::Trans::NoTranspose,
                                                     KokkosBatched::Trans::Transpose>;
 
-  test_batched_teamgemm<TestDevice, ::Test::halfScalarType, ::Test::halfScalarType, param_tag_type,
+  test_batched_teamgemm<TestDevice, TestUtils::halfScalarType, TestUtils::halfScalarType, param_tag_type,
                         Algo::Gemm::Blocked>();
-  test_batched_teamgemm<TestDevice, ::Test::halfScalarType, ::Test::halfScalarType, param_tag_type,
+  test_batched_teamgemm<TestDevice, TestUtils::halfScalarType, TestUtils::halfScalarType, param_tag_type,
                         Algo::Gemm::Unblocked>();
 }
 TEST_F(TestCategory, batched_scalar_team_vector_gemm_t_t_half_half) {
   using param_tag_type = ::Test::TeamGemm::ParamTag<KokkosBatched::Mode::TeamVector, KokkosBatched::Trans::Transpose,
                                                     KokkosBatched::Trans::Transpose>;
 
-  test_batched_teamgemm<TestDevice, ::Test::halfScalarType, ::Test::halfScalarType, param_tag_type,
+  test_batched_teamgemm<TestDevice, TestUtils::halfScalarType, TestUtils::halfScalarType, param_tag_type,
                         Algo::Gemm::Blocked>();
-  test_batched_teamgemm<TestDevice, ::Test::halfScalarType, ::Test::halfScalarType, param_tag_type,
+  test_batched_teamgemm<TestDevice, TestUtils::halfScalarType, TestUtils::halfScalarType, param_tag_type,
                         Algo::Gemm::Unblocked>();
 }
 #endif  // KOKKOS_HALF_T_IS_FLOAT

--- a/batched/dense/unit_test/Test_Batched_TeamVectorGesv.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamVectorGesv.hpp
@@ -45,7 +45,7 @@ struct Functor_TestBatchedTeamVectorGesv {
   inline void run() {
     typedef typename VectorType::value_type value_type;
     std::string name_region("KokkosBatched::Test::TeamVectorGesv");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
     Kokkos::TeamPolicy<execution_space> policy(_X.extent(0), Kokkos::AUTO(), Kokkos::AUTO());

--- a/batched/dense/unit_test/Test_Batched_TeamVectorQR.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamVectorQR.hpp
@@ -76,7 +76,7 @@ struct Functor_TestBatchedTeamVectorQR {
   inline void run() {
     typedef typename MatrixViewType::non_const_value_type value_type;
     std::string name_region("KokkosBatched::Test::TeamVectorQR");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
 

--- a/batched/dense/unit_test/Test_Batched_TeamVectorQR_WithColumnPivoting.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamVectorQR_WithColumnPivoting.hpp
@@ -86,7 +86,7 @@ struct Functor_TestBatchedTeamVectorQR_WithColumnPivoting {
   inline void run() {
     typedef typename MatrixViewType::non_const_value_type value_type;
     std::string name_region("KokkosBatched::Test::TeamVectorQR_WithColumnPivoting");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
 

--- a/batched/dense/unit_test/Test_Batched_TeamVectorSolveUTV.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamVectorSolveUTV.hpp
@@ -95,7 +95,7 @@ struct Functor_TestBatchedTeamVectorSolveUTV {
   inline void run() {
     typedef typename MatrixViewType::non_const_value_type value_type;
     std::string name_region("KokkosBatched::Test::TeamVectorSolveUTV");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
 

--- a/batched/dense/unit_test/Test_Batched_TeamVectorSolveUTV2.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamVectorSolveUTV2.hpp
@@ -97,7 +97,7 @@ struct Functor_TestBatchedTeamVectorSolveUTV2 {
   inline void run() {
     typedef typename MatrixViewType::non_const_value_type value_type;
     std::string name_region("KokkosBatched::Test::TeamVectorSolveUTV");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
 

--- a/batched/dense/unit_test/Test_Batched_TeamVectorUTV.hpp
+++ b/batched/dense/unit_test/Test_Batched_TeamVectorUTV.hpp
@@ -126,7 +126,7 @@ struct Functor_TestBatchedTeamVectorUTV {
   inline void run() {
     typedef typename MatrixViewType::non_const_value_type value_type;
     std::string name_region("KokkosBatched::Test::TeamVectorUTV");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
 

--- a/batched/dense/unit_test/Test_Batched_VectorMath.hpp
+++ b/batched/dense/unit_test/Test_Batched_VectorMath.hpp
@@ -125,8 +125,8 @@ int test_batched_vector_math() {
 //   Kokkos::complex<mag_type> a0(3.2, -1.4), a1(1.2, 2.3);
 //   std::complex<mag_type> b0(3.2, -1.4), b1(1.2, 2.3);
 
-//   Test::EXPECT_NEAR_KK( ats::pow(a0,a1), std::pow(b0,b1), eps );
-//   Test::EXPECT_NEAR_KK( ats::pow(a0,a2), std::pow(b0,a2), eps );
+//   EXPECT_NEAR_KK( ats::pow(a0,a1), std::pow(b0,b1), eps );
+//   EXPECT_NEAR_KK( ats::pow(a0,a2), std::pow(b0,a2), eps );
 
 //   return 0;
 // }

--- a/batched/sparse/unit_test/Test_Batched_SerialGMRES.hpp
+++ b/batched/sparse/unit_test/Test_Batched_SerialGMRES.hpp
@@ -56,7 +56,7 @@ struct Functor_TestBatchedSerialGMRES {
   inline void run() {
     typedef typename ValuesViewType::value_type value_type;
     std::string name_region("KokkosBatched::Test::SerialGMRES");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
     Kokkos::RangePolicy<execution_space> policy(0, _D.extent(0) / _N_team);

--- a/batched/sparse/unit_test/Test_Batched_SerialSpmv.hpp
+++ b/batched/sparse/unit_test/Test_Batched_SerialSpmv.hpp
@@ -57,7 +57,7 @@ struct Functor_TestBatchedSerialSpmv {
   inline void run() {
     typedef typename ValuesViewType::value_type value_type;
     std::string name_region("KokkosBatched::Test::SerialSpmv");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
     Kokkos::RangePolicy<execution_space, ParamTagType> policy(0, _D.extent(0));

--- a/batched/sparse/unit_test/Test_Batched_TeamCG.hpp
+++ b/batched/sparse/unit_test/Test_Batched_TeamCG.hpp
@@ -53,7 +53,7 @@ struct Functor_TestBatchedTeamCG {
   inline void run() {
     typedef typename ValuesViewType::value_type value_type;
     std::string name_region("KokkosBatched::Test::TeamCG");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
     Kokkos::TeamPolicy<execution_space> policy(_D.extent(0) / _N_team, Kokkos::AUTO(), Kokkos::AUTO());

--- a/batched/sparse/unit_test/Test_Batched_TeamGMRES.hpp
+++ b/batched/sparse/unit_test/Test_Batched_TeamGMRES.hpp
@@ -60,7 +60,7 @@ struct Functor_TestBatchedTeamGMRES {
   inline void run() {
     typedef typename ValuesViewType::value_type value_type;
     std::string name_region("KokkosBatched::Test::TeamGMRES");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
     Kokkos::TeamPolicy<execution_space> policy(_D.extent(0) / _N_team, Kokkos::AUTO(), Kokkos::AUTO());

--- a/batched/sparse/unit_test/Test_Batched_TeamSpmv.hpp
+++ b/batched/sparse/unit_test/Test_Batched_TeamSpmv.hpp
@@ -65,7 +65,7 @@ struct Functor_TestBatchedTeamSpmv {
   inline void run() {
     typedef typename ValuesViewType::value_type value_type;
     std::string name_region("KokkosBatched::Test::TeamSpmv");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
     Kokkos::TeamPolicy<execution_space, ParamTagType> policy(_D.extent(0) / _N_team, Kokkos::AUTO(), Kokkos::AUTO());

--- a/batched/sparse/unit_test/Test_Batched_TeamVectorCG.hpp
+++ b/batched/sparse/unit_test/Test_Batched_TeamVectorCG.hpp
@@ -53,7 +53,7 @@ struct Functor_TestBatchedTeamVectorCG {
   inline void run() {
     typedef typename ValuesViewType::value_type value_type;
     std::string name_region("KokkosBatched::Test::TeamVectorCG");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
     Kokkos::TeamPolicy<execution_space> policy(_D.extent(0) / _N_team, Kokkos::AUTO(), Kokkos::AUTO());

--- a/batched/sparse/unit_test/Test_Batched_TeamVectorGMRES.hpp
+++ b/batched/sparse/unit_test/Test_Batched_TeamVectorGMRES.hpp
@@ -60,7 +60,7 @@ struct Functor_TestBatchedTeamVectorGMRES {
   inline void run() {
     typedef typename ValuesViewType::value_type value_type;
     std::string name_region("KokkosBatched::Test::TeamVectorGMRES");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
     Kokkos::TeamPolicy<execution_space> policy(_D.extent(0) / _N_team, Kokkos::AUTO(), Kokkos::AUTO());

--- a/batched/sparse/unit_test/Test_Batched_TeamVectorSpmv.hpp
+++ b/batched/sparse/unit_test/Test_Batched_TeamVectorSpmv.hpp
@@ -71,7 +71,7 @@ struct Functor_TestBatchedTeamVectorSpmv {
   inline void run() {
     typedef typename ValuesViewType::value_type value_type;
     std::string name_region("KokkosBatched::Test::TeamVectorSpmv");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     Kokkos::Profiling::pushRegion(name.c_str());
     Kokkos::TeamPolicy<execution_space, ParamTagType> policy(ceil(static_cast<double>(_D.extent(0)) / _N_team),

--- a/blas/unit_test/Test_Blas1_abs.hpp
+++ b/blas/unit_test/Test_Blas1_abs.hpp
@@ -15,20 +15,20 @@ void impl_test_abs(int N) {
 
   typename AT::mag_type eps = AT::epsilon() * 10;
 
-  view_stride_adapter<ViewTypeA> x("X", N);
-  view_stride_adapter<ViewTypeB> y("Y", N);
-  view_stride_adapter<ViewTypeB> org_y("Org_Y", N);
+  TestUtils::view_stride_adapter<ViewTypeA> x("X", N);
+  TestUtils::view_stride_adapter<ViewTypeB> y("Y", N);
+  TestUtils::view_stride_adapter<ViewTypeB> org_y("Org_Y", N);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
   {
     ScalarA randStart, randEnd;
-    Test::getRandomBounds(1.0, randStart, randEnd);
+    TestUtils::getRandomBounds(1.0, randStart, randEnd);
     Kokkos::fill_random(x.d_view, rand_pool, randStart, randEnd);
   }
   {
     ScalarB randStart, randEnd;
-    Test::getRandomBounds(1.0, randStart, randEnd);
+    TestUtils::getRandomBounds(1.0, randStart, randEnd);
     Kokkos::fill_random(y.d_view, rand_pool, randStart, randEnd);
   }
 
@@ -59,20 +59,20 @@ void impl_test_abs_mv(int N, int K) {
   typedef typename ViewTypeB::value_type ScalarB;
   typedef KokkosKernels::ArithTraits<ScalarA> AT;
 
-  view_stride_adapter<ViewTypeA> x("X", N, K);
-  view_stride_adapter<ViewTypeB> y("Y", N, K);
-  view_stride_adapter<ViewTypeB> org_y("Org_Y", N, K);
+  TestUtils::view_stride_adapter<ViewTypeA> x("X", N, K);
+  TestUtils::view_stride_adapter<ViewTypeB> y("Y", N, K);
+  TestUtils::view_stride_adapter<ViewTypeB> org_y("Org_Y", N, K);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
   {
     ScalarA randStart, randEnd;
-    Test::getRandomBounds(1.0, randStart, randEnd);
+    TestUtils::getRandomBounds(1.0, randStart, randEnd);
     Kokkos::fill_random(x.d_view, rand_pool, randStart, randEnd);
   }
   {
     ScalarB randStart, randEnd;
-    Test::getRandomBounds(1.0, randStart, randEnd);
+    TestUtils::getRandomBounds(1.0, randStart, randEnd);
     Kokkos::fill_random(y.d_view, rand_pool, randStart, randEnd);
   }
 

--- a/blas/unit_test/Test_Blas1_asum.hpp
+++ b/blas/unit_test/Test_Blas1_asum.hpp
@@ -13,12 +13,12 @@ void impl_test_asum(int N) {
   using AT      = KokkosKernels::ArithTraits<ScalarA>;
   using MAT     = KokkosKernels::ArithTraits<typename AT::mag_type>;
 
-  view_stride_adapter<ViewTypeA> a("A", N);
+  TestUtils::view_stride_adapter<ViewTypeA> a("A", N);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
   ScalarA randStart, randEnd;
-  Test::getRandomBounds(10.0, randStart, randEnd);
+  TestUtils::getRandomBounds(10.0, randStart, randEnd);
   Kokkos::fill_random(a.d_view, rand_pool, randStart, randEnd);
 
   Kokkos::deep_copy(a.h_base, a.d_base);

--- a/blas/unit_test/Test_Blas1_axpby.hpp
+++ b/blas/unit_test/Test_Blas1_axpby.hpp
@@ -24,15 +24,15 @@ void impl_test_axpby(int N) {
                                 KokkosKernels::ArithTraits<ScalarB>::abs(b)) *
                                max_val * eps;
 
-  view_stride_adapter<ViewTypeA> x("X", N);
-  view_stride_adapter<ViewTypeB> y("Y", N);
-  view_stride_adapter<ViewTypeB> org_y("Org_Y", N);
+  TestUtils::view_stride_adapter<ViewTypeA> x("X", N);
+  TestUtils::view_stride_adapter<ViewTypeB> y("Y", N);
+  TestUtils::view_stride_adapter<ViewTypeB> org_y("Org_Y", N);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
   {
     ScalarA randStart, randEnd;
-    Test::getRandomBounds(max_val, randStart, randEnd);
+    TestUtils::getRandomBounds(max_val, randStart, randEnd);
     Kokkos::fill_random(x.d_view, rand_pool, randStart, randEnd);
   }
 
@@ -62,9 +62,9 @@ void impl_test_axpby_mv(int N, int K) {
   using ScalarB    = typename ViewTypeB::value_type;
   using MagnitudeB = typename KokkosKernels::ArithTraits<ScalarB>::mag_type;
 
-  view_stride_adapter<ViewTypeA> x("X", N, K);
-  view_stride_adapter<ViewTypeB> y("Y", N, K);
-  view_stride_adapter<ViewTypeB> org_y("Org_Y", N, K);
+  TestUtils::view_stride_adapter<ViewTypeA> x("X", N, K);
+  TestUtils::view_stride_adapter<ViewTypeB> y("Y", N, K);
+  TestUtils::view_stride_adapter<ViewTypeB> org_y("Org_Y", N, K);
 
   ScalarA a                  = 3;
   ScalarB b                  = 5;
@@ -78,12 +78,12 @@ void impl_test_axpby_mv(int N, int K) {
 
   {
     ScalarA randStart, randEnd;
-    Test::getRandomBounds(10.0, randStart, randEnd);
+    TestUtils::getRandomBounds(10.0, randStart, randEnd);
     Kokkos::fill_random(x.d_view, rand_pool, randStart, randEnd);
   }
   {
     ScalarB randStart, randEnd;
-    Test::getRandomBounds(10.0, randStart, randEnd);
+    TestUtils::getRandomBounds(10.0, randStart, randEnd);
     Kokkos::fill_random(y.d_view, rand_pool, randStart, randEnd);
   }
 

--- a/blas/unit_test/Test_Blas1_axpby_unification.hpp
+++ b/blas/unit_test/Test_Blas1_axpby_unification.hpp
@@ -43,6 +43,8 @@
 
 static constexpr int numVecsAxpbyTest = 15;
 
+using TestUtils::view_stride_adapter;
+
 namespace Test {
 
 template <typename T, bool Enable = false>
@@ -76,14 +78,14 @@ void impl_test_axpby_unification_compare(tA const& a, tX const& x, tB const& b, 
 
   {
     ScalarTypeX randStart, randEnd;
-    Test::getRandomBounds(max_val, randStart, randEnd);
+    TestUtils::getRandomBounds(max_val, randStart, randEnd);
     Kokkos::fill_random(x.d_view, rand_pool, randStart, randEnd);
   }
   Kokkos::deep_copy(x.h_base, x.d_base);
 
   {
     ScalarTypeY randStart, randEnd;
-    Test::getRandomBounds(max_val, randStart, randEnd);
+    TestUtils::getRandomBounds(max_val, randStart, randEnd);
     if (testWithNanY) {
       Kokkos::deep_copy(y.d_view, KokkosKernels::ArithTraits<ScalarTypeY>::nan());
     } else {
@@ -215,14 +217,14 @@ void impl_test_axpby_mv_unification_compare(tA const& a, tX const& x, tB const& 
 
   {
     ScalarTypeX randStart, randEnd;
-    Test::getRandomBounds(max_val, randStart, randEnd);
+    TestUtils::getRandomBounds(max_val, randStart, randEnd);
     Kokkos::fill_random(x.d_view, rand_pool, randStart, randEnd);
   }
   Kokkos::deep_copy(x.h_base, x.d_base);
 
   {
     ScalarTypeY randStart, randEnd;
-    Test::getRandomBounds(max_val, randStart, randEnd);
+    TestUtils::getRandomBounds(max_val, randStart, randEnd);
     if (testWithNanY) {
       Kokkos::deep_copy(y.d_view, KokkosKernels::ArithTraits<ScalarTypeY>::nan());
     } else {

--- a/blas/unit_test/Test_Blas1_axpy.hpp
+++ b/blas/unit_test/Test_Blas1_axpy.hpp
@@ -20,20 +20,20 @@ void impl_test_axpy(int N) {
   const MagnitudeB max_error =
       (static_cast<MagnitudeB>(KokkosKernels::ArithTraits<ScalarA>::abs(a)) * max_val + max_val) * eps;
 
-  view_stride_adapter<ViewTypeA> x("X", N);
-  view_stride_adapter<ViewTypeB> y("Y", N);
-  view_stride_adapter<ViewTypeB> org_y("Org_Y", N);
+  TestUtils::view_stride_adapter<ViewTypeA> x("X", N);
+  TestUtils::view_stride_adapter<ViewTypeB> y("Y", N);
+  TestUtils::view_stride_adapter<ViewTypeB> org_y("Org_Y", N);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
   {
     ScalarA randStart, randEnd;
-    Test::getRandomBounds(max_val, randStart, randEnd);
+    TestUtils::getRandomBounds(max_val, randStart, randEnd);
     Kokkos::fill_random(x.d_view, rand_pool, randStart, randEnd);
   }
   {
     ScalarB randStart, randEnd;
-    Test::getRandomBounds(max_val, randStart, randEnd);
+    TestUtils::getRandomBounds(max_val, randStart, randEnd);
     Kokkos::fill_random(y.d_view, rand_pool, randStart, randEnd);
   }
 
@@ -64,9 +64,9 @@ void impl_test_axpy_mv(int N, int K) {
   using ScalarB    = typename ViewTypeB::value_type;
   using MagnitudeB = typename KokkosKernels::ArithTraits<ScalarB>::mag_type;
 
-  view_stride_adapter<ViewTypeA> x("X", N, K);
-  view_stride_adapter<ViewTypeB> y("Y", N, K);
-  view_stride_adapter<ViewTypeB> org_y("Org_Y", N, K);
+  TestUtils::view_stride_adapter<ViewTypeA> x("X", N, K);
+  TestUtils::view_stride_adapter<ViewTypeB> y("Y", N, K);
+  TestUtils::view_stride_adapter<ViewTypeB> org_y("Org_Y", N, K);
 
   ScalarA a                = 3;
   const MagnitudeB eps     = KokkosKernels::ArithTraits<ScalarB>::epsilon();
@@ -78,12 +78,12 @@ void impl_test_axpy_mv(int N, int K) {
 
   {
     ScalarA randStart, randEnd;
-    Test::getRandomBounds(max_val, randStart, randEnd);
+    TestUtils::getRandomBounds(max_val, randStart, randEnd);
     Kokkos::fill_random(x.d_view, rand_pool, randStart, randEnd);
   }
   {
     ScalarB randStart, randEnd;
-    Test::getRandomBounds(max_val, randStart, randEnd);
+    TestUtils::getRandomBounds(max_val, randStart, randEnd);
     Kokkos::fill_random(y.d_view, rand_pool, randStart, randEnd);
   }
 

--- a/blas/unit_test/Test_Blas1_dot.hpp
+++ b/blas/unit_test/Test_Blas1_dot.hpp
@@ -14,19 +14,19 @@ void impl_test_dot(int N) {
   typedef typename ViewTypeB::value_type ScalarB;
   typedef KokkosKernels::ArithTraits<ScalarA> ats;
 
-  view_stride_adapter<ViewTypeA> a("a", N);
-  view_stride_adapter<ViewTypeB> b("b", N);
+  TestUtils::view_stride_adapter<ViewTypeA> a("a", N);
+  TestUtils::view_stride_adapter<ViewTypeB> b("b", N);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
   {
     ScalarA randStart, randEnd;
-    Test::getRandomBounds(10.0, randStart, randEnd);
+    TestUtils::getRandomBounds(10.0, randStart, randEnd);
     Kokkos::fill_random(a.d_view, rand_pool, randStart, randEnd);
   }
   {
     ScalarB randStart, randEnd;
-    Test::getRandomBounds(10.0, randStart, randEnd);
+    TestUtils::getRandomBounds(10.0, randStart, randEnd);
     Kokkos::fill_random(b.d_view, rand_pool, randStart, randEnd);
   }
 
@@ -56,19 +56,19 @@ void impl_test_dot_mv(int N, int K) {
   typedef typename ViewTypeB::value_type ScalarB;
   typedef KokkosKernels::ArithTraits<ScalarA> ats;
 
-  view_stride_adapter<ViewTypeA> a("A", N, K);
-  view_stride_adapter<ViewTypeB> b("B", N, K);
+  TestUtils::view_stride_adapter<ViewTypeA> a("A", N, K);
+  TestUtils::view_stride_adapter<ViewTypeB> b("B", N, K);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
   {
     ScalarA randStart, randEnd;
-    Test::getRandomBounds(10.0, randStart, randEnd);
+    TestUtils::getRandomBounds(10.0, randStart, randEnd);
     Kokkos::fill_random(a.d_view, rand_pool, randStart, randEnd);
   }
   {
     ScalarB randStart, randEnd;
-    Test::getRandomBounds(10.0, randStart, randEnd);
+    TestUtils::getRandomBounds(10.0, randStart, randEnd);
     Kokkos::fill_random(b.d_view, rand_pool, randStart, randEnd);
   }
 

--- a/blas/unit_test/Test_Blas1_iamax.hpp
+++ b/blas/unit_test/Test_Blas1_iamax.hpp
@@ -15,12 +15,12 @@ void impl_test_iamax(int N) {
   using mag_type  = typename AT::mag_type;
   using size_type = typename ViewTypeA::size_type;
 
-  view_stride_adapter<ViewTypeA> a("X", N);
+  TestUtils::view_stride_adapter<ViewTypeA> a("X", N);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
   ScalarA randStart, randEnd;
-  Test::getRandomBounds(10.0, randStart, randEnd);
+  TestUtils::getRandomBounds(10.0, randStart, randEnd);
   Kokkos::fill_random(a.d_view, rand_pool, randStart, randEnd);
 
   Kokkos::deep_copy(a.h_base, a.d_base);
@@ -98,12 +98,12 @@ void impl_test_iamax_mv(int N, int K) {
   typedef typename AT::mag_type mag_type;
   typedef typename ViewTypeA::size_type size_type;
 
-  view_stride_adapter<ViewTypeA> a("A", N, K);
+  TestUtils::view_stride_adapter<ViewTypeA> a("A", N, K);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
   ScalarA randStart, randEnd;
-  Test::getRandomBounds(10.0, randStart, randEnd);
+  TestUtils::getRandomBounds(10.0, randStart, randEnd);
   Kokkos::fill_random(a.d_view, rand_pool, randStart, randEnd);
 
   Kokkos::deep_copy(a.h_base, a.d_base);

--- a/blas/unit_test/Test_Blas1_mult.hpp
+++ b/blas/unit_test/Test_Blas1_mult.hpp
@@ -18,26 +18,26 @@ void impl_test_mult(int N) {
   ScalarB b  = 5;
   double eps = std::is_same<ScalarC, float>::value ? 1e-4 : 1e-7;
 
-  view_stride_adapter<ViewTypeA> x("X", N);
-  view_stride_adapter<ViewTypeB> y("Y", N);
-  view_stride_adapter<ViewTypeC> z("Z", N);
-  view_stride_adapter<ViewTypeC> org_z("Org_Z", N);
+  TestUtils::view_stride_adapter<ViewTypeA> x("X", N);
+  TestUtils::view_stride_adapter<ViewTypeB> y("Y", N);
+  TestUtils::view_stride_adapter<ViewTypeC> z("Z", N);
+  TestUtils::view_stride_adapter<ViewTypeC> org_z("Org_Z", N);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
   {
     ScalarA randStart, randEnd;
-    Test::getRandomBounds(10.0, randStart, randEnd);
+    TestUtils::getRandomBounds(10.0, randStart, randEnd);
     Kokkos::fill_random(x.d_view, rand_pool, randStart, randEnd);
   }
   {
     ScalarB randStart, randEnd;
-    Test::getRandomBounds(10.0, randStart, randEnd);
+    TestUtils::getRandomBounds(10.0, randStart, randEnd);
     Kokkos::fill_random(y.d_view, rand_pool, randStart, randEnd);
   }
   {
     ScalarC randStart, randEnd;
-    Test::getRandomBounds(10.0, randStart, randEnd);
+    TestUtils::getRandomBounds(10.0, randStart, randEnd);
     Kokkos::fill_random(z.d_view, rand_pool, randStart, randEnd);
   }
 
@@ -74,26 +74,26 @@ void impl_test_mult_mv(int N, int K) {
   typedef typename ViewTypeC::value_type ScalarC;
 
   // x is rank-1, all others are rank-2
-  view_stride_adapter<ViewTypeA> x("X", N);
-  view_stride_adapter<ViewTypeB> y("Y", N, K);
-  view_stride_adapter<ViewTypeC> z("Z", N, K);
-  view_stride_adapter<ViewTypeC> org_z("Org_Z", N, K);
+  TestUtils::view_stride_adapter<ViewTypeA> x("X", N);
+  TestUtils::view_stride_adapter<ViewTypeB> y("Y", N, K);
+  TestUtils::view_stride_adapter<ViewTypeC> z("Z", N, K);
+  TestUtils::view_stride_adapter<ViewTypeC> org_z("Org_Z", N, K);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
   {
     ScalarA randStart, randEnd;
-    Test::getRandomBounds(10.0, randStart, randEnd);
+    TestUtils::getRandomBounds(10.0, randStart, randEnd);
     Kokkos::fill_random(x.d_view, rand_pool, randStart, randEnd);
   }
   {
     ScalarB randStart, randEnd;
-    Test::getRandomBounds(10.0, randStart, randEnd);
+    TestUtils::getRandomBounds(10.0, randStart, randEnd);
     Kokkos::fill_random(y.d_view, rand_pool, randStart, randEnd);
   }
   {
     ScalarC randStart, randEnd;
-    Test::getRandomBounds(10.0, randStart, randEnd);
+    TestUtils::getRandomBounds(10.0, randStart, randEnd);
     Kokkos::fill_random(z.d_view, rand_pool, randStart, randEnd);
   }
 

--- a/blas/unit_test/Test_Blas1_nrm1.hpp
+++ b/blas/unit_test/Test_Blas1_nrm1.hpp
@@ -14,12 +14,12 @@ void impl_test_nrm1(int N) {
   using mag_type = typename AT::mag_type;
   using MAT      = KokkosKernels::ArithTraits<mag_type>;
 
-  view_stride_adapter<ViewTypeA> a("a", N);
+  TestUtils::view_stride_adapter<ViewTypeA> a("a", N);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
   ScalarA randStart, randEnd;
-  Test::getRandomBounds(10.0, randStart, randEnd);
+  TestUtils::getRandomBounds(10.0, randStart, randEnd);
   Kokkos::fill_random(a.d_view, rand_pool, randStart, randEnd);
 
   Kokkos::deep_copy(a.h_base, a.d_base);
@@ -50,12 +50,12 @@ void impl_test_nrm1_mv(int N, int K) {
   typedef typename AT::mag_type mag_type;
   typedef KokkosKernels::ArithTraits<mag_type> MAT;
 
-  view_stride_adapter<ViewTypeA> a("A", N, K);
+  TestUtils::view_stride_adapter<ViewTypeA> a("A", N, K);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
   ScalarA randStart, randEnd;
-  Test::getRandomBounds(10.0, randStart, randEnd);
+  TestUtils::getRandomBounds(10.0, randStart, randEnd);
   Kokkos::fill_random(a.d_view, rand_pool, randStart, randEnd);
 
   Kokkos::deep_copy(a.h_base, a.d_base);

--- a/blas/unit_test/Test_Blas1_nrm2.hpp
+++ b/blas/unit_test/Test_Blas1_nrm2.hpp
@@ -12,12 +12,12 @@ void impl_test_nrm2(int N) {
   typedef typename ViewTypeA::value_type ScalarA;
   typedef KokkosKernels::ArithTraits<ScalarA> AT;
 
-  view_stride_adapter<ViewTypeA> a("a", N);
+  TestUtils::view_stride_adapter<ViewTypeA> a("a", N);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
   ScalarA randStart, randEnd;
-  Test::getRandomBounds(1.0, randStart, randEnd);
+  TestUtils::getRandomBounds(1.0, randStart, randEnd);
   Kokkos::fill_random(a.d_view, rand_pool, randStart, randEnd);
 
   Kokkos::deep_copy(a.h_base, a.d_base);
@@ -42,12 +42,12 @@ void impl_test_nrm2_mv(int N, int K) {
   typedef typename ViewTypeA::value_type ScalarA;
   typedef KokkosKernels::ArithTraits<ScalarA> AT;
 
-  view_stride_adapter<ViewTypeA> a("A", N, K);
+  TestUtils::view_stride_adapter<ViewTypeA> a("A", N, K);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
   ScalarA randStart, randEnd;
-  Test::getRandomBounds(1.0, randStart, randEnd);
+  TestUtils::getRandomBounds(1.0, randStart, randEnd);
   Kokkos::fill_random(a.d_view, rand_pool, randStart, randEnd);
 
   Kokkos::deep_copy(a.h_base, a.d_base);

--- a/blas/unit_test/Test_Blas1_nrm2_squared.hpp
+++ b/blas/unit_test/Test_Blas1_nrm2_squared.hpp
@@ -12,12 +12,12 @@ void impl_test_nrm2_squared(int N) {
   typedef typename ViewTypeA::value_type ScalarA;
   typedef KokkosKernels::ArithTraits<ScalarA> AT;
 
-  view_stride_adapter<ViewTypeA> a("a", N);
+  TestUtils::view_stride_adapter<ViewTypeA> a("a", N);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
   ScalarA randStart, randEnd;
-  Test::getRandomBounds(1.0, randStart, randEnd);
+  TestUtils::getRandomBounds(1.0, randStart, randEnd);
   Kokkos::fill_random(a.d_view, rand_pool, randStart, randEnd);
 
   Kokkos::deep_copy(a.h_base, a.d_base);
@@ -41,12 +41,12 @@ void impl_test_nrm2_squared_mv(int N, int K) {
   typedef typename ViewTypeA::value_type ScalarA;
   typedef KokkosKernels::ArithTraits<ScalarA> AT;
 
-  view_stride_adapter<ViewTypeA> a("A", N, K);
+  TestUtils::view_stride_adapter<ViewTypeA> a("A", N, K);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
   ScalarA randStart, randEnd;
-  Test::getRandomBounds(1.0, randStart, randEnd);
+  TestUtils::getRandomBounds(1.0, randStart, randEnd);
   Kokkos::fill_random(a.d_view, rand_pool, randStart, randEnd);
 
   Kokkos::deep_copy(a.h_base, a.d_base);

--- a/blas/unit_test/Test_Blas1_nrm2w.hpp
+++ b/blas/unit_test/Test_Blas1_nrm2w.hpp
@@ -13,8 +13,8 @@ void impl_test_nrm2w(int N) {
   using AT         = KokkosKernels::ArithTraits<ScalarA>;
   using MagnitudeA = typename AT::mag_type;
 
-  view_stride_adapter<ViewTypeA> a("A", N);
-  view_stride_adapter<ViewTypeA> w("W", N);
+  TestUtils::view_stride_adapter<ViewTypeA> a("A", N);
+  TestUtils::view_stride_adapter<ViewTypeA> w("W", N);
 
   constexpr MagnitudeA max_val = 10;
   const MagnitudeA eps         = AT::epsilon();
@@ -23,7 +23,7 @@ void impl_test_nrm2w(int N) {
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
   ScalarA randStart, randEnd;
-  Test::getRandomBounds(max_val, randStart, randEnd);
+  TestUtils::getRandomBounds(max_val, randStart, randEnd);
   Kokkos::fill_random(a.d_view, rand_pool, randStart, randEnd);
   Kokkos::fill_random(w.d_view, rand_pool, AT::one(),
                       randEnd);  // Avoid divide by 0
@@ -48,8 +48,8 @@ void impl_test_nrm2w_mv(int N, int K) {
   using AT         = KokkosKernels::ArithTraits<ScalarA>;
   using MagnitudeA = typename AT::mag_type;
 
-  view_stride_adapter<ViewTypeA> a("A", N, K);
-  view_stride_adapter<ViewTypeA> w("W", N, K);
+  TestUtils::view_stride_adapter<ViewTypeA> a("A", N, K);
+  TestUtils::view_stride_adapter<ViewTypeA> w("W", N, K);
 
   constexpr MagnitudeA max_val = 10;
   const MagnitudeA eps         = AT::epsilon();
@@ -58,7 +58,7 @@ void impl_test_nrm2w_mv(int N, int K) {
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
   ScalarA randStart, randEnd;
-  Test::getRandomBounds(max_val, randStart, randEnd);
+  TestUtils::getRandomBounds(max_val, randStart, randEnd);
   Kokkos::fill_random(a.d_view, rand_pool, randStart, randEnd);
   Kokkos::fill_random(w.d_view, rand_pool, AT::one(),
                       randEnd);  // Avoid dividing by 0

--- a/blas/unit_test/Test_Blas1_nrm2w_squared.hpp
+++ b/blas/unit_test/Test_Blas1_nrm2w_squared.hpp
@@ -13,8 +13,8 @@ void impl_test_nrm2w_squared(int N) {
   using AT         = KokkosKernels::ArithTraits<ScalarA>;
   using MagnitudeA = typename AT::mag_type;
 
-  view_stride_adapter<ViewTypeA> a("A", N);
-  view_stride_adapter<ViewTypeA> w("W", N);
+  TestUtils::view_stride_adapter<ViewTypeA> a("A", N);
+  TestUtils::view_stride_adapter<ViewTypeA> w("W", N);
 
   constexpr MagnitudeA max_val = 10;
   const MagnitudeA eps         = AT::epsilon();
@@ -23,7 +23,7 @@ void impl_test_nrm2w_squared(int N) {
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
   ScalarA randStart, randEnd;
-  Test::getRandomBounds(max_val, randStart, randEnd);
+  TestUtils::getRandomBounds(max_val, randStart, randEnd);
   Kokkos::fill_random(a.d_view, rand_pool, randStart, randEnd);
   Kokkos::fill_random(w.d_view, rand_pool, AT::one(),
                       randEnd);  // Avoid divide by 0
@@ -47,8 +47,8 @@ void impl_test_nrm2w_squared_mv(int N, int K) {
   using AT         = KokkosKernels::ArithTraits<ScalarA>;
   using MagnitudeA = typename AT::mag_type;
 
-  view_stride_adapter<ViewTypeA> a("A", N, K);
-  view_stride_adapter<ViewTypeA> w("W", N, K);
+  TestUtils::view_stride_adapter<ViewTypeA> a("A", N, K);
+  TestUtils::view_stride_adapter<ViewTypeA> w("W", N, K);
 
   constexpr MagnitudeA max_val = 10;
   const MagnitudeA eps         = AT::epsilon();
@@ -57,7 +57,7 @@ void impl_test_nrm2w_squared_mv(int N, int K) {
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
   ScalarA randStart, randEnd;
-  Test::getRandomBounds(max_val, randStart, randEnd);
+  TestUtils::getRandomBounds(max_val, randStart, randEnd);
   Kokkos::fill_random(a.d_view, rand_pool, randStart, randEnd);
   Kokkos::fill_random(w.d_view, rand_pool, AT::one(), randEnd);
 

--- a/blas/unit_test/Test_Blas1_nrminf.hpp
+++ b/blas/unit_test/Test_Blas1_nrminf.hpp
@@ -12,12 +12,12 @@ void impl_test_nrminf(int N) {
   typedef typename ViewTypeA::non_const_value_type ScalarA;
   typedef KokkosKernels::ArithTraits<ScalarA> AT;
 
-  view_stride_adapter<ViewTypeA> a("A", N);
+  TestUtils::view_stride_adapter<ViewTypeA> a("A", N);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
   ScalarA randStart, randEnd;
-  Test::getRandomBounds(10.0, randStart, randEnd);
+  TestUtils::getRandomBounds(10.0, randStart, randEnd);
   Kokkos::fill_random(a.d_view, rand_pool, randStart, randEnd);
 
   Kokkos::deep_copy(a.h_base, a.d_base);
@@ -42,12 +42,12 @@ void impl_test_nrminf_mv(int N, int K) {
   typedef typename ViewTypeA::non_const_value_type ScalarA;
   typedef KokkosKernels::ArithTraits<ScalarA> AT;
 
-  view_stride_adapter<ViewTypeA> a("A", N, K);
+  TestUtils::view_stride_adapter<ViewTypeA> a("A", N, K);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
   ScalarA randStart, randEnd;
-  Test::getRandomBounds(10.0, randStart, randEnd);
+  TestUtils::getRandomBounds(10.0, randStart, randEnd);
   Kokkos::fill_random(a.d_view, rand_pool, randStart, randEnd);
 
   Kokkos::deep_copy(a.h_base, a.d_base);

--- a/blas/unit_test/Test_Blas1_reciprocal.hpp
+++ b/blas/unit_test/Test_Blas1_reciprocal.hpp
@@ -20,14 +20,14 @@ void impl_test_reciprocal(int N) {
   const MagnitudeA one     = AT::abs(AT::one());
   const MagnitudeA max_val = 10;
 
-  view_stride_adapter<ViewTypeA> x("X", N);
-  view_stride_adapter<ViewTypeB> y("Y", N);
+  TestUtils::view_stride_adapter<ViewTypeA> x("X", N);
+  TestUtils::view_stride_adapter<ViewTypeB> y("Y", N);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
   {
     ScalarA randStart, randEnd;
-    Test::getRandomBounds(max_val, randStart, randEnd);
+    TestUtils::getRandomBounds(max_val, randStart, randEnd);
     Kokkos::fill_random(x.d_view, rand_pool, one, randEnd);
   }
 
@@ -54,14 +54,14 @@ void impl_test_reciprocal_mv(int N, int K) {
   typedef typename ViewTypeA::value_type ScalarA;
   typedef typename ViewTypeB::value_type ScalarB;
 
-  view_stride_adapter<ViewTypeA> x("X", N, K);
-  view_stride_adapter<ViewTypeB> y("Y", N, K);
+  TestUtils::view_stride_adapter<ViewTypeA> x("X", N, K);
+  TestUtils::view_stride_adapter<ViewTypeB> y("Y", N, K);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
   {
     ScalarA randStart, randEnd;
-    Test::getRandomBounds(10, randStart, randEnd);
+    TestUtils::getRandomBounds(10, randStart, randEnd);
     Kokkos::fill_random(x.d_view, rand_pool, KokkosKernels::ArithTraits<ScalarA>::one(), randEnd);
   }
 

--- a/blas/unit_test/Test_Blas1_rot.hpp
+++ b/blas/unit_test/Test_Blas1_rot.hpp
@@ -52,8 +52,8 @@ int test_rot() {
 
   Scalar const tol = 10 * KokkosKernels::ArithTraits<Scalar>::eps();
   for (int idx = 0; idx < 4; ++idx) {
-    Test::EXPECT_NEAR_KK_REL(X_h(idx), Xref(idx), tol);
-    Test::EXPECT_NEAR_KK_REL(Y_h(idx), Yref(idx), tol);
+    EXPECT_NEAR_KK_REL(X_h(idx), Xref(idx), tol);
+    EXPECT_NEAR_KK_REL(Y_h(idx), Yref(idx), tol);
   }
 
   return 1;

--- a/blas/unit_test/Test_Blas1_rotm.hpp
+++ b/blas/unit_test/Test_Blas1_rotm.hpp
@@ -111,8 +111,8 @@ void check_results(vector_view_type &X, vector_view_type &Y, vector_ref_type &Xr
 
   Scalar const tol = 10 * KokkosKernels::ArithTraits<Scalar>::eps();
   for (int idx = 0; idx < 4; ++idx) {
-    Test::EXPECT_NEAR_KK_REL(X_h(idx), Xref(idx), tol);
-    Test::EXPECT_NEAR_KK_REL(Y_h(idx), Yref(idx), tol);
+    EXPECT_NEAR_KK_REL(X_h(idx), Xref(idx), tol);
+    EXPECT_NEAR_KK_REL(Y_h(idx), Yref(idx), tol);
   }
 
   return;

--- a/blas/unit_test/Test_Blas1_rotmg.hpp
+++ b/blas/unit_test/Test_Blas1_rotmg.hpp
@@ -21,27 +21,27 @@ void test_rotmg_impl(View0& d1, View0& d2, View0& x1, View0& y1, PView& param, R
 #endif
   auto d1_h = Kokkos::create_mirror_view(d1);
   Kokkos::deep_copy(d1_h, d1);
-  EXPECT_NEAR_KK_REL(d1_h(), ref_vals(0), tol, "rotmg: d1 is off");
+  EXPECT_NEAR_KK_REL(d1_h(), ref_vals(0), tol) << "rotmg: d1 is off";
 
   auto d2_h = Kokkos::create_mirror_view(d2);
   Kokkos::deep_copy(d2_h, d2);
-  EXPECT_NEAR_KK_REL(d2_h(), ref_vals(1), tol, "rotmg: d2 is off");
+  EXPECT_NEAR_KK_REL(d2_h(), ref_vals(1), tol) << "rotmg: d2 is off";
 
   auto x1_h = Kokkos::create_mirror_view(x1);
   Kokkos::deep_copy(x1_h, x1);
-  EXPECT_NEAR_KK_REL(x1_h(), ref_vals(2), tol, "rotmg: x1 is off");
+  EXPECT_NEAR_KK_REL(x1_h(), ref_vals(2), tol) << "rotmg: x1 is off";
 
   auto y1_h = Kokkos::create_mirror_view(y1_const);
   Kokkos::deep_copy(y1_h, y1_const);
-  EXPECT_NEAR_KK_REL(y1_h(), ref_vals(3), tol, "rotmg: y1 is off");
+  EXPECT_NEAR_KK_REL(y1_h(), ref_vals(3), tol) << "rotmg: y1 is off";
 
   auto param_h = Kokkos::create_mirror_view(param);
   Kokkos::deep_copy(param_h, param);
-  EXPECT_NEAR_KK_REL(param_h(0), ref_vals(4), tol, "rotmg: param(0) is off");
-  EXPECT_NEAR_KK_REL(param_h(1), ref_vals(5), tol, "rotmg: param(1) is off");
-  EXPECT_NEAR_KK_REL(param_h(2), ref_vals(6), tol, "rotmg: param(2) is off");
-  EXPECT_NEAR_KK_REL(param_h(3), ref_vals(7), tol, "rotmg: param(3) is off");
-  EXPECT_NEAR_KK_REL(param_h(4), ref_vals(8), tol, "rotmg: param(4) is off");
+  EXPECT_NEAR_KK_REL(param_h(0), ref_vals(4), tol) << "rotmg: param(0) is off";
+  EXPECT_NEAR_KK_REL(param_h(1), ref_vals(5), tol) << "rotmg: param(1) is off";
+  EXPECT_NEAR_KK_REL(param_h(2), ref_vals(6), tol) << "rotmg: param(2) is off";
+  EXPECT_NEAR_KK_REL(param_h(3), ref_vals(7), tol) << "rotmg: param(3) is off";
+  EXPECT_NEAR_KK_REL(param_h(4), ref_vals(8), tol) << "rotmg: param(4) is off";
 }
 
 template <class View0, class PView, class RView>

--- a/blas/unit_test/Test_Blas1_scal.hpp
+++ b/blas/unit_test/Test_Blas1_scal.hpp
@@ -17,14 +17,14 @@ void impl_test_scal(int N) {
   ScalarA a(3);
   typename AT::mag_type eps = AT::epsilon() * 1000;
 
-  view_stride_adapter<ViewTypeA> x("X", N);
-  view_stride_adapter<ViewTypeB> y("Y", N);
+  TestUtils::view_stride_adapter<ViewTypeA> x("X", N);
+  TestUtils::view_stride_adapter<ViewTypeB> y("Y", N);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
   {
     ScalarA randStart, randEnd;
-    Test::getRandomBounds(1.0, randStart, randEnd);
+    TestUtils::getRandomBounds(1.0, randStart, randEnd);
     Kokkos::fill_random(x.d_view, rand_pool, randStart, randEnd);
   }
 
@@ -51,14 +51,14 @@ void impl_test_scal_mv(int N, int K) {
   typedef typename ViewTypeB::value_type ScalarB;
   typedef KokkosKernels::ArithTraits<ScalarA> AT;
 
-  view_stride_adapter<ViewTypeA> x("X", N, K);
-  view_stride_adapter<ViewTypeB> y("Y", N, K);
+  TestUtils::view_stride_adapter<ViewTypeA> x("X", N, K);
+  TestUtils::view_stride_adapter<ViewTypeB> y("Y", N, K);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
   {
     ScalarA randStart, randEnd;
-    Test::getRandomBounds(1.0, randStart, randEnd);
+    TestUtils::getRandomBounds(1.0, randStart, randEnd);
     Kokkos::fill_random(x.d_view, rand_pool, randStart, randEnd);
   }
 

--- a/blas/unit_test/Test_Blas1_serial_setscal.hpp
+++ b/blas/unit_test/Test_Blas1_serial_setscal.hpp
@@ -60,7 +60,7 @@ struct Functor_TestBlasSerialMatUtil {
   inline int run() {
     typedef typename ViewType::value_type value_type;
     std::string name_region("KokkosBlas::Test::SerialMatUtil");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name_work_tag         = (std::is_same<AlgoTagType, KokkosKernelTag>::value ? "::KokkosBlas"
                                          : std::is_same<AlgoTagType, NaiveTag>::value      ? "::Naive"
                                                                                            : "::UnknownWorkTag");

--- a/blas/unit_test/Test_Blas1_sum.hpp
+++ b/blas/unit_test/Test_Blas1_sum.hpp
@@ -11,12 +11,12 @@ template <class ViewTypeA, class Device>
 void impl_test_sum(int N) {
   typedef typename ViewTypeA::value_type ScalarA;
 
-  view_stride_adapter<ViewTypeA> a("A", N);
+  TestUtils::view_stride_adapter<ViewTypeA> a("A", N);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
   ScalarA randStart, randEnd;
-  Test::getRandomBounds(10.0, randStart, randEnd);
+  TestUtils::getRandomBounds(10.0, randStart, randEnd);
   Kokkos::fill_random(a.d_view, rand_pool, randStart, randEnd);
 
   Kokkos::deep_copy(a.h_base, a.d_base);
@@ -37,12 +37,12 @@ template <class ViewTypeA, class Device>
 void impl_test_sum_mv(int N, int K) {
   typedef typename ViewTypeA::value_type ScalarA;
 
-  view_stride_adapter<ViewTypeA> a("A", N, K);
+  TestUtils::view_stride_adapter<ViewTypeA> a("A", N, K);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
   ScalarA randStart, randEnd;
-  Test::getRandomBounds(10.0, randStart, randEnd);
+  TestUtils::getRandomBounds(10.0, randStart, randEnd);
   Kokkos::fill_random(a.d_view, rand_pool, randStart, randEnd);
 
   Kokkos::deep_copy(a.h_base, a.d_base);

--- a/blas/unit_test/Test_Blas1_swap.hpp
+++ b/blas/unit_test/Test_Blas1_swap.hpp
@@ -36,8 +36,8 @@ void test_swap(int const vector_length) {
 
   const mag_type tol = 10 * KokkosKernels::ArithTraits<scalar_type>::eps();
   for (int idx = 0; idx < vector_length; ++idx) {
-    Test::EXPECT_NEAR_KK_REL(Xtest(idx), Xref(idx), tol);
-    Test::EXPECT_NEAR_KK_REL(Ytest(idx), Yref(idx), tol);
+    EXPECT_NEAR_KK_REL(Xtest(idx), Xref(idx), tol);
+    EXPECT_NEAR_KK_REL(Ytest(idx), Yref(idx), tol);
   }
 }
 

--- a/blas/unit_test/Test_Blas1_team_abs.hpp
+++ b/blas/unit_test/Test_Blas1_team_abs.hpp
@@ -26,8 +26,8 @@ void impl_test_team_abs(int N) {
 
   double eps = std::is_same<ScalarA, float>::value ? 2 * 1e-5 : 1e-7;
 
-  view_stride_adapter<ViewTypeA> x("X", N);
-  view_stride_adapter<ViewTypeB> y("Y", N);
+  TestUtils::view_stride_adapter<ViewTypeA> x("X", N);
+  TestUtils::view_stride_adapter<ViewTypeB> y("Y", N);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
@@ -86,8 +86,8 @@ void impl_test_team_abs_mv(int N, int K) {
   typedef typename ViewTypeB::value_type ScalarB;
   typedef KokkosKernels::ArithTraits<ScalarA> AT;
 
-  view_stride_adapter<ViewTypeA> x("X", N, K);
-  view_stride_adapter<ViewTypeB> y("Y", N, K);
+  TestUtils::view_stride_adapter<ViewTypeA> x("X", N, K);
+  TestUtils::view_stride_adapter<ViewTypeB> y("Y", N, K);
 
   Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(13718);
 

--- a/blas/unit_test/Test_Blas1_team_axpby.hpp
+++ b/blas/unit_test/Test_Blas1_team_axpby.hpp
@@ -27,9 +27,9 @@ void impl_test_team_axpby(int N) {
   ScalarB b  = 5;
   double eps = std::is_same<ScalarA, float>::value ? 2 * 1e-5 : 1e-7;
 
-  view_stride_adapter<ViewTypeA> x("X", N);
-  view_stride_adapter<ViewTypeB> y("Y", N);
-  view_stride_adapter<ViewTypeB> org_y("Y", N);
+  TestUtils::view_stride_adapter<ViewTypeA> x("X", N);
+  TestUtils::view_stride_adapter<ViewTypeB> y("Y", N);
+  TestUtils::view_stride_adapter<ViewTypeB> org_y("Y", N);
 
   Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(13718);
 
@@ -91,9 +91,9 @@ void impl_test_team_axpby_mv(int N, int K) {
   typedef typename ViewTypeA::value_type ScalarA;
   typedef typename ViewTypeB::value_type ScalarB;
 
-  view_stride_adapter<ViewTypeA> x("X", N, K);
-  view_stride_adapter<ViewTypeB> y("Y", N, K);
-  view_stride_adapter<ViewTypeB> org_y("Org_Y", N, K);
+  TestUtils::view_stride_adapter<ViewTypeA> x("X", N, K);
+  TestUtils::view_stride_adapter<ViewTypeB> y("Y", N, K);
+  TestUtils::view_stride_adapter<ViewTypeB> org_y("Org_Y", N, K);
 
   Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(13718);
 

--- a/blas/unit_test/Test_Blas1_team_axpy.hpp
+++ b/blas/unit_test/Test_Blas1_team_axpy.hpp
@@ -23,9 +23,9 @@ void impl_test_team_axpy(int N) {
   typedef typename ViewTypeA::value_type ScalarA;
   typedef typename ViewTypeB::value_type ScalarB;
 
-  view_stride_adapter<ViewTypeA> x("X", N);
-  view_stride_adapter<ViewTypeB> y("Y", N);
-  view_stride_adapter<ViewTypeB> org_y("Y", N);
+  TestUtils::view_stride_adapter<ViewTypeA> x("X", N);
+  TestUtils::view_stride_adapter<ViewTypeB> y("Y", N);
+  TestUtils::view_stride_adapter<ViewTypeB> org_y("Y", N);
 
   ScalarA a  = 3;
   double eps = std::is_same<ScalarA, float>::value ? 2 * 1e-5 : 1e-7;
@@ -88,9 +88,9 @@ void impl_test_team_axpy_mv(int N, int K) {
   typedef typename ViewTypeA::value_type ScalarA;
   typedef typename ViewTypeB::value_type ScalarB;
 
-  view_stride_adapter<ViewTypeA> x("X", N, K);
-  view_stride_adapter<ViewTypeB> y("Y", N, K);
-  view_stride_adapter<ViewTypeB> org_y("Org_Y", N, K);
+  TestUtils::view_stride_adapter<ViewTypeA> x("X", N, K);
+  TestUtils::view_stride_adapter<ViewTypeB> y("Y", N, K);
+  TestUtils::view_stride_adapter<ViewTypeB> org_y("Org_Y", N, K);
 
   Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(13718);
 

--- a/blas/unit_test/Test_Blas1_team_dot.hpp
+++ b/blas/unit_test/Test_Blas1_team_dot.hpp
@@ -22,8 +22,8 @@ void impl_test_team_dot(int N) {
   typedef typename ViewTypeA::value_type ScalarA;
   typedef typename ViewTypeB::value_type ScalarB;
 
-  view_stride_adapter<ViewTypeA> a("a", N);
-  view_stride_adapter<ViewTypeB> b("b", N);
+  TestUtils::view_stride_adapter<ViewTypeA> a("a", N);
+  TestUtils::view_stride_adapter<ViewTypeB> b("b", N);
 
   Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(13718);
 
@@ -124,8 +124,8 @@ void impl_test_team_dot_mv(int N, int K) {
   typedef typename ViewTypeA::value_type ScalarA;
   typedef typename ViewTypeB::value_type ScalarB;
 
-  view_stride_adapter<ViewTypeA> a("A", N, K);
-  view_stride_adapter<ViewTypeB> b("B", N, K);
+  TestUtils::view_stride_adapter<ViewTypeA> a("A", N, K);
+  TestUtils::view_stride_adapter<ViewTypeB> b("B", N, K);
 
   Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(13718);
 

--- a/blas/unit_test/Test_Blas1_team_mult.hpp
+++ b/blas/unit_test/Test_Blas1_team_mult.hpp
@@ -28,10 +28,10 @@ void impl_test_team_mult(int N) {
   ScalarB b  = 5;
   double eps = std::is_same<ScalarC, float>::value ? 2 * 1e-5 : 1e-7;
 
-  view_stride_adapter<ViewTypeA> x("X", N);
-  view_stride_adapter<ViewTypeB> y("Y", N);
-  view_stride_adapter<ViewTypeC> z("Z", N);
-  view_stride_adapter<ViewTypeC> org_z("Org_Z", N);
+  TestUtils::view_stride_adapter<ViewTypeA> x("X", N);
+  TestUtils::view_stride_adapter<ViewTypeB> y("Y", N);
+  TestUtils::view_stride_adapter<ViewTypeC> z("Z", N);
+  TestUtils::view_stride_adapter<ViewTypeC> org_z("Org_Z", N);
 
   Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(13718);
 
@@ -120,10 +120,10 @@ void impl_test_team_mult_mv(int N, int K) {
   typedef typename ViewTypeC::value_type ScalarC;
 
   // x is rank-1, all others are rank-2
-  view_stride_adapter<ViewTypeA> x("X", N);
-  view_stride_adapter<ViewTypeB> y("Y", N, K);
-  view_stride_adapter<ViewTypeC> z("Z", N, K);
-  view_stride_adapter<ViewTypeC> org_z("Org_Z", N, K);
+  TestUtils::view_stride_adapter<ViewTypeA> x("X", N);
+  TestUtils::view_stride_adapter<ViewTypeB> y("Y", N, K);
+  TestUtils::view_stride_adapter<ViewTypeC> z("Z", N, K);
+  TestUtils::view_stride_adapter<ViewTypeC> org_z("Org_Z", N, K);
 
   Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(13718);
 

--- a/blas/unit_test/Test_Blas1_team_nrm2.hpp
+++ b/blas/unit_test/Test_Blas1_team_nrm2.hpp
@@ -20,7 +20,7 @@ void impl_test_team_nrm2(int N, int K) {
   typedef typename ViewTypeA::value_type ScalarA;
   typedef KokkosKernels::ArithTraits<ScalarA> AT;
 
-  view_stride_adapter<ViewTypeA> a("A", N, K);
+  TestUtils::view_stride_adapter<ViewTypeA> a("A", N, K);
 
   Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(13718);
 

--- a/blas/unit_test/Test_Blas1_team_scal.hpp
+++ b/blas/unit_test/Test_Blas1_team_scal.hpp
@@ -24,8 +24,8 @@ void impl_test_team_scal(int N) {
   typedef typename ViewTypeB::value_type ScalarB;
   typedef KokkosKernels::ArithTraits<ScalarA> AT;
 
-  view_stride_adapter<ViewTypeA> x("X", N);
-  view_stride_adapter<ViewTypeB> y("Y", N);
+  TestUtils::view_stride_adapter<ViewTypeA> x("X", N);
+  TestUtils::view_stride_adapter<ViewTypeB> y("Y", N);
 
   ScalarA a(3);
   typename AT::mag_type eps  = AT::epsilon() * 1000;
@@ -97,8 +97,8 @@ void impl_test_team_scal_mv(int N, int K) {
   typedef typename ViewTypeB::value_type ScalarB;
   typedef KokkosKernels::ArithTraits<ScalarA> AT;
 
-  view_stride_adapter<ViewTypeA> x("X", N, K);
-  view_stride_adapter<ViewTypeB> y("Y", N, K);
+  TestUtils::view_stride_adapter<ViewTypeA> x("X", N, K);
+  TestUtils::view_stride_adapter<ViewTypeB> y("Y", N, K);
 
   Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(13718);
 

--- a/blas/unit_test/Test_Blas1_team_setscal.hpp
+++ b/blas/unit_test/Test_Blas1_team_setscal.hpp
@@ -63,7 +63,7 @@ struct Functor_TestBlasTeamMatUtil {
   inline int run() {
     typedef typename ViewType::value_type value_type;
     std::string name_region("KokkosBlas::Test::SerialMatUtil");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name_work_tag         = (std::is_same<AlgoTagType, KokkosKernelTag>::value ? "::KokkosBlas"
                                          : std::is_same<AlgoTagType, NaiveTag>::value      ? "::Naive"
                                                                                            : "::UnknownWorkTag");

--- a/blas/unit_test/Test_Blas1_team_update.hpp
+++ b/blas/unit_test/Test_Blas1_team_update.hpp
@@ -29,10 +29,10 @@ void impl_test_team_update(int N) {
   ScalarC c  = 7;
   double eps = std::is_same<ScalarC, float>::value ? 2 * 1e-5 : 1e-7;
 
-  view_stride_adapter<ViewTypeA> x("X", N);
-  view_stride_adapter<ViewTypeB> y("Y", N);
-  view_stride_adapter<ViewTypeC> z("Z", N);
-  view_stride_adapter<ViewTypeC> org_z("Org_Z", N);
+  TestUtils::view_stride_adapter<ViewTypeA> x("X", N);
+  TestUtils::view_stride_adapter<ViewTypeB> y("Y", N);
+  TestUtils::view_stride_adapter<ViewTypeC> z("Z", N);
+  TestUtils::view_stride_adapter<ViewTypeC> org_z("Org_Z", N);
 
   Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(13718);
 
@@ -121,10 +121,10 @@ void impl_test_team_update_mv(int N, int K) {
   typedef typename ViewTypeB::value_type ScalarB;
   typedef typename ViewTypeC::value_type ScalarC;
 
-  view_stride_adapter<ViewTypeA> x("X", N, K);
-  view_stride_adapter<ViewTypeB> y("Y", N, K);
-  view_stride_adapter<ViewTypeC> z("Z", N, K);
-  view_stride_adapter<ViewTypeC> org_z("Org_Z", N, K);
+  TestUtils::view_stride_adapter<ViewTypeA> x("X", N, K);
+  TestUtils::view_stride_adapter<ViewTypeB> y("Y", N, K);
+  TestUtils::view_stride_adapter<ViewTypeC> z("Z", N, K);
+  TestUtils::view_stride_adapter<ViewTypeC> org_z("Org_Z", N, K);
 
   Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(13718);
 

--- a/blas/unit_test/Test_Blas1_update.hpp
+++ b/blas/unit_test/Test_Blas1_update.hpp
@@ -19,26 +19,26 @@ void impl_test_update(int N) {
   ScalarC c  = 7;
   double eps = std::is_same<ScalarC, float>::value ? 2 * 1e-5 : 1e-7;
 
-  view_stride_adapter<ViewTypeA> x("X", N);
-  view_stride_adapter<ViewTypeB> y("Y", N);
-  view_stride_adapter<ViewTypeC> z("Z", N);
-  view_stride_adapter<ViewTypeC> org_z("Org_Z", N);
+  TestUtils::view_stride_adapter<ViewTypeA> x("X", N);
+  TestUtils::view_stride_adapter<ViewTypeB> y("Y", N);
+  TestUtils::view_stride_adapter<ViewTypeC> z("Z", N);
+  TestUtils::view_stride_adapter<ViewTypeC> org_z("Org_Z", N);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
   {
     ScalarA randStart, randEnd;
-    Test::getRandomBounds(10.0, randStart, randEnd);
+    TestUtils::getRandomBounds(10.0, randStart, randEnd);
     Kokkos::fill_random(x.d_view, rand_pool, randStart, randEnd);
   }
   {
     ScalarB randStart, randEnd;
-    Test::getRandomBounds(10.0, randStart, randEnd);
+    TestUtils::getRandomBounds(10.0, randStart, randEnd);
     Kokkos::fill_random(y.d_view, rand_pool, randStart, randEnd);
   }
   {
     ScalarC randStart, randEnd;
-    Test::getRandomBounds(10.0, randStart, randEnd);
+    TestUtils::getRandomBounds(10.0, randStart, randEnd);
     Kokkos::fill_random(z.d_view, rand_pool, randStart, randEnd);
   }
 
@@ -74,26 +74,26 @@ void impl_test_update_mv(int N, int K) {
   typedef typename ViewTypeB::value_type ScalarB;
   typedef typename ViewTypeC::value_type ScalarC;
 
-  view_stride_adapter<ViewTypeA> x("X", N, K);
-  view_stride_adapter<ViewTypeB> y("Y", N, K);
-  view_stride_adapter<ViewTypeC> z("Z", N, K);
-  view_stride_adapter<ViewTypeC> org_z("Org_Z", N, K);
+  TestUtils::view_stride_adapter<ViewTypeA> x("X", N, K);
+  TestUtils::view_stride_adapter<ViewTypeB> y("Y", N, K);
+  TestUtils::view_stride_adapter<ViewTypeC> z("Z", N, K);
+  TestUtils::view_stride_adapter<ViewTypeC> org_z("Org_Z", N, K);
 
   Kokkos::Random_XorShift64_Pool<typename Device::execution_space> rand_pool(13718);
 
   {
     ScalarA randStart, randEnd;
-    Test::getRandomBounds(10.0, randStart, randEnd);
+    TestUtils::getRandomBounds(10.0, randStart, randEnd);
     Kokkos::fill_random(x.d_view, rand_pool, randStart, randEnd);
   }
   {
     ScalarB randStart, randEnd;
-    Test::getRandomBounds(10.0, randStart, randEnd);
+    TestUtils::getRandomBounds(10.0, randStart, randEnd);
     Kokkos::fill_random(y.d_view, rand_pool, randStart, randEnd);
   }
   {
     ScalarC randStart, randEnd;
-    Test::getRandomBounds(10.0, randStart, randEnd);
+    TestUtils::getRandomBounds(10.0, randStart, randEnd);
     Kokkos::fill_random(z.d_view, rand_pool, randStart, randEnd);
   }
 

--- a/blas/unit_test/Test_Blas2_gemv.hpp
+++ b/blas/unit_test/Test_Blas2_gemv.hpp
@@ -30,10 +30,10 @@ void impl_test_gemv_streams(ExecutionSpace& space, const char* mode, int M, int 
     ldy = N;
   }
 
-  view_stride_adapter<ViewTypeA> A("A", M, N);
-  view_stride_adapter<ViewTypeX> x("X", ldx);
-  view_stride_adapter<ViewTypeY> y("Y", ldy);
-  view_stride_adapter<ViewTypeY> org_y("Org_Y", ldy);
+  TestUtils::view_stride_adapter<ViewTypeA> A("A", M, N);
+  TestUtils::view_stride_adapter<ViewTypeX> x("X", ldx);
+  TestUtils::view_stride_adapter<ViewTypeY> y("Y", ldy);
+  TestUtils::view_stride_adapter<ViewTypeY> org_y("Org_Y", ldy);
 
   Kokkos::Random_XorShift64_Pool<ExecutionSpace> rand_pool(13718);
 
@@ -42,17 +42,17 @@ void impl_test_gemv_streams(ExecutionSpace& space, const char* mode, int M, int 
   constexpr double max_valA = 1;
   {
     ScalarX randStart, randEnd;
-    Test::getRandomBounds(max_valX, randStart, randEnd);
+    TestUtils::getRandomBounds(max_valX, randStart, randEnd);
     Kokkos::fill_random(space, x.d_view, rand_pool, randStart, randEnd);
   }
   {
     ScalarY randStart, randEnd;
-    Test::getRandomBounds(max_valY, randStart, randEnd);
+    TestUtils::getRandomBounds(max_valY, randStart, randEnd);
     Kokkos::fill_random(space, y.d_view, rand_pool, randStart, randEnd);
   }
   {
     ScalarA randStart, randEnd;
-    Test::getRandomBounds(max_valA, randStart, randEnd);
+    TestUtils::getRandomBounds(max_valA, randStart, randEnd);
     Kokkos::fill_random(space, A.d_view, rand_pool, randStart, randEnd);
   }
 

--- a/blas/unit_test/Test_Blas2_ger.hpp
+++ b/blas/unit_test/Test_Blas2_ger.hpp
@@ -63,9 +63,10 @@ class GerTester {
   using _KAT_A   = KokkosKernels::ArithTraits<ScalarA>;
   using _AuxType = typename _KAT_A::mag_type;
 
-  void populateVariables(ScalarA& alpha, view_stride_adapter<_ViewTypeX, false>& x,
-                         view_stride_adapter<_ViewTypeY, false>& y, view_stride_adapter<_ViewTypeA, false>& A,
-                         _ViewTypeExpected& h_expected, bool& expectedResultIsKnown);
+  void populateVariables(ScalarA& alpha, TestUtils::view_stride_adapter<_ViewTypeX, false>& x,
+                         TestUtils::view_stride_adapter<_ViewTypeY, false>& y,
+                         TestUtils::view_stride_adapter<_ViewTypeA, false>& A, _ViewTypeExpected& h_expected,
+                         bool& expectedResultIsKnown);
 
   template <class T>
   typename std::enable_if<
@@ -117,7 +118,8 @@ class GerTester {
   T shrinkAngleToZeroTwoPiRange(const T input);
 
   template <class TX, class TY>
-  void callKkGerAndCompareAgainstExpected(const ScalarA& alpha, TX& x, TY& y, view_stride_adapter<_ViewTypeA, false>& A,
+  void callKkGerAndCompareAgainstExpected(const ScalarA& alpha, TX& x, TY& y,
+                                          TestUtils::view_stride_adapter<_ViewTypeA, false>& A,
                                           const _ViewTypeExpected& h_expected, const std::string& situation);
 
   const bool _A_is_complex;
@@ -213,11 +215,11 @@ void GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>:
     test_cx_cy = true;
   }
 
-  view_stride_adapter<_ViewTypeX, false> x("X", _M);
-  view_stride_adapter<_ViewTypeY, false> y("Y", _N);
-  view_stride_adapter<_ViewTypeA, false> A("A", _M, _N);
+  TestUtils::view_stride_adapter<_ViewTypeX, false> x("X", _M);
+  TestUtils::view_stride_adapter<_ViewTypeY, false> y("Y", _N);
+  TestUtils::view_stride_adapter<_ViewTypeA, false> A("A", _M, _N);
 
-  view_stride_adapter<_ViewTypeExpected, true> h_expected("expected A += alpha * x * y^{t,h}", _M, _N);
+  TestUtils::view_stride_adapter<_ViewTypeExpected, true> h_expected("expected A += alpha * x * y^{t,h}", _M, _N);
   bool expectedResultIsKnown = false;
 
   ScalarA alpha(0.);
@@ -230,7 +232,7 @@ void GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>:
   // ********************************************************************
   // Step 3 of 9: populate h_vanilla
   // ********************************************************************
-  view_stride_adapter<_ViewTypeExpected, true> h_vanilla("vanilla = A + alpha * x * y^{t,h}", _M, _N);
+  TestUtils::view_stride_adapter<_ViewTypeExpected, true> h_vanilla("vanilla = A + alpha * x * y^{t,h}", _M, _N);
 #ifndef NDEBUG
   Kokkos::printf("In Test_Blas2_ger.hpp, computing vanilla A with alpha type = %s\n", typeid(alpha).name());
 #endif
@@ -254,7 +256,7 @@ void GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>:
   // ********************************************************************
   // Step 5 of 9: test with 'non const x' and 'non const y'
   // ********************************************************************
-  view_stride_adapter<_ViewTypeA, false> org_A("Org_A", _M, _N);
+  TestUtils::view_stride_adapter<_ViewTypeA, false> org_A("Org_A", _M, _N);
   Kokkos::deep_copy(org_A.d_base, A.d_base);
 
   if (test_x_y) {
@@ -307,8 +309,9 @@ void GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>:
 
 template <class ScalarX, class tLayoutX, class ScalarY, class tLayoutY, class ScalarA, class tLayoutA, class Device>
 void GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::populateVariables(
-    ScalarA& alpha, view_stride_adapter<_ViewTypeX, false>& x, view_stride_adapter<_ViewTypeY, false>& y,
-    view_stride_adapter<_ViewTypeA, false>& A, _ViewTypeExpected& h_expected, bool& expectedResultIsKnown) {
+    ScalarA& alpha, TestUtils::view_stride_adapter<_ViewTypeX, false>& x,
+    TestUtils::view_stride_adapter<_ViewTypeY, false>& y, TestUtils::view_stride_adapter<_ViewTypeA, false>& A,
+    _ViewTypeExpected& h_expected, bool& expectedResultIsKnown) {
   expectedResultIsKnown = false;
 
   if (_useAnalyticalResults) {
@@ -381,19 +384,19 @@ void GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>:
 
     {
       ScalarX randStart, randEnd;
-      Test::getRandomBounds(1.0, randStart, randEnd);
+      TestUtils::getRandomBounds(1.0, randStart, randEnd);
       Kokkos::fill_random(x.d_view, rand_pool, randStart, randEnd);
     }
 
     {
       ScalarY randStart, randEnd;
-      Test::getRandomBounds(1.0, randStart, randEnd);
+      TestUtils::getRandomBounds(1.0, randStart, randEnd);
       Kokkos::fill_random(y.d_view, rand_pool, randStart, randEnd);
     }
 
     {
       ScalarA randStart, randEnd;
-      Test::getRandomBounds(1.0, randStart, randEnd);
+      TestUtils::getRandomBounds(1.0, randStart, randEnd);
       Kokkos::fill_random(A.d_view, rand_pool, randStart, randEnd);
     }
 
@@ -1112,8 +1115,8 @@ GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::comp
 template <class ScalarX, class tLayoutX, class ScalarY, class tLayoutY, class ScalarA, class tLayoutA, class Device>
 template <class TX, class TY>
 void GerTester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::callKkGerAndCompareAgainstExpected(
-    const ScalarA& alpha, TX& x, TY& y, view_stride_adapter<_ViewTypeA, false>& A, const _ViewTypeExpected& h_expected,
-    const std::string& situation) {
+    const ScalarA& alpha, TX& x, TY& y, TestUtils::view_stride_adapter<_ViewTypeA, false>& A,
+    const _ViewTypeExpected& h_expected, const std::string& situation) {
 #ifndef NDEBUG
   Kokkos::printf(
       "In Test_Blas2_ger.hpp, right before calling KokkosBlas::ger(): "

--- a/blas/unit_test/Test_Blas2_syr.hpp
+++ b/blas/unit_test/Test_Blas2_syr.hpp
@@ -59,8 +59,8 @@ class SyrTester {
   using _KAT_A   = KokkosKernels::ArithTraits<ScalarA>;
   using _AuxType = typename _KAT_A::mag_type;
 
-  void populateVariables(ScalarA& alpha, view_stride_adapter<_ViewTypeX, false>& x,
-                         view_stride_adapter<_ViewTypeA, false>& A, _ViewTypeExpected& h_expected,
+  void populateVariables(ScalarA& alpha, TestUtils::view_stride_adapter<_ViewTypeX, false>& x,
+                         TestUtils::view_stride_adapter<_ViewTypeA, false>& A, _ViewTypeExpected& h_expected,
                          bool& expectedResultIsKnown);
 
   template <class T>
@@ -111,11 +111,13 @@ class SyrTester {
   T shrinkAngleToZeroTwoPiRange(const T input);
 
   template <class TX>
-  void callKkSyrAndCompareAgainstExpected(const ScalarA& alpha, TX& x, view_stride_adapter<_ViewTypeA, false>& A,
+  void callKkSyrAndCompareAgainstExpected(const ScalarA& alpha, TX& x,
+                                          TestUtils::view_stride_adapter<_ViewTypeA, false>& A,
                                           const _ViewTypeExpected& h_expected, const std::string& situation);
 
   template <class TX>
-  void callKkGerAndCompareKkSyrAgainstIt(const ScalarA& alpha, TX& x, view_stride_adapter<_ViewTypeA, false>& org_A,
+  void callKkGerAndCompareKkSyrAgainstIt(const ScalarA& alpha, TX& x,
+                                         TestUtils::view_stride_adapter<_ViewTypeA, false>& org_A,
                                          const _HostViewTypeA& h_A_syr, const std::string& situation);
 
   const bool _A_is_complex;
@@ -220,10 +222,10 @@ void SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::test(const int N, 
     test_cx = true;
   }
 
-  view_stride_adapter<_ViewTypeX, false> x("X", _M);
-  view_stride_adapter<_ViewTypeA, false> A("A", _M, _N);
+  TestUtils::view_stride_adapter<_ViewTypeX, false> x("X", _M);
+  TestUtils::view_stride_adapter<_ViewTypeA, false> A("A", _M, _N);
 
-  view_stride_adapter<_ViewTypeExpected, true> h_expected("expected A += alpha * x * x^{t,h}", _M, _N);
+  TestUtils::view_stride_adapter<_ViewTypeExpected, true> h_expected("expected A += alpha * x * x^{t,h}", _M, _N);
   bool expectedResultIsKnown = false;
 
   ScalarA alpha(_KAT_A::zero());
@@ -236,7 +238,7 @@ void SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::test(const int N, 
   // ********************************************************************
   // Step 3 of 7: populate h_vanilla
   // ********************************************************************
-  view_stride_adapter<_ViewTypeExpected, true> h_vanilla("vanilla = A + alpha * x * x^{t,h}", _M, _N);
+  TestUtils::view_stride_adapter<_ViewTypeExpected, true> h_vanilla("vanilla = A + alpha * x * x^{t,h}", _M, _N);
 #ifndef NDEBUG
   Kokkos::printf("In Test_Blas2_syr.hpp, computing vanilla A with alpha type = %s\n", typeid(alpha).name());
 #endif
@@ -260,7 +262,7 @@ void SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::test(const int N, 
   // ********************************************************************
   // Step 5 of 7: test with 'non const x'
   // ********************************************************************
-  view_stride_adapter<_ViewTypeA, false> org_A("Org_A", _M, _N);
+  TestUtils::view_stride_adapter<_ViewTypeA, false> org_A("Org_A", _M, _N);
   Kokkos::deep_copy(org_A.d_base, A.d_base);
   Kokkos::deep_copy(org_A.h_view, A.h_view);
 
@@ -304,8 +306,8 @@ void SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::test(const int N, 
 
 template <class ScalarX, class tLayoutX, class ScalarA, class tLayoutA, class Device>
 void SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::populateVariables(
-    ScalarA& alpha, view_stride_adapter<_ViewTypeX, false>& x, view_stride_adapter<_ViewTypeA, false>& A,
-    _ViewTypeExpected& h_expected, bool& expectedResultIsKnown) {
+    ScalarA& alpha, TestUtils::view_stride_adapter<_ViewTypeX, false>& x,
+    TestUtils::view_stride_adapter<_ViewTypeA, false>& A, _ViewTypeExpected& h_expected, bool& expectedResultIsKnown) {
   expectedResultIsKnown = false;
 
   if (_useAnalyticalResults) {
@@ -359,13 +361,13 @@ void SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::populateVariables(
 
     {
       ScalarX randStart, randEnd;
-      Test::getRandomBounds(1.0, randStart, randEnd);
+      TestUtils::getRandomBounds(1.0, randStart, randEnd);
       Kokkos::fill_random(x.d_view, rand_pool, randStart, randEnd);
     }
 
     {
       ScalarA randStart, randEnd;
-      Test::getRandomBounds(1.0, randStart, randEnd);
+      TestUtils::getRandomBounds(1.0, randStart, randEnd);
       Kokkos::fill_random(A.d_view, rand_pool, randStart, randEnd);
     }
 
@@ -1197,8 +1199,8 @@ SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::compareKkSyrAgainstRefe
 template <class ScalarX, class tLayoutX, class ScalarA, class tLayoutA, class Device>
 template <class TX>
 void SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::callKkSyrAndCompareAgainstExpected(
-    const ScalarA& alpha, TX& x, view_stride_adapter<_ViewTypeA, false>& A, const _ViewTypeExpected& h_expected,
-    const std::string& situation) {
+    const ScalarA& alpha, TX& x, TestUtils::view_stride_adapter<_ViewTypeA, false>& A,
+    const _ViewTypeExpected& h_expected, const std::string& situation) {
 #ifndef NDEBUG
   std::cout << "In Test_Blas2_syr, '" << situation << "', alpha = " << alpha << std::endl;
   Kokkos::printf(
@@ -1240,9 +1242,9 @@ void SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::callKkSyrAndCompar
 template <class ScalarX, class tLayoutX, class ScalarA, class tLayoutA, class Device>
 template <class TX>
 void SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::callKkGerAndCompareKkSyrAgainstIt(
-    const ScalarA& alpha, TX& x, view_stride_adapter<_ViewTypeA, false>& org_A, const _HostViewTypeA& h_A_syr,
-    const std::string& situation) {
-  view_stride_adapter<_ViewTypeA, false> A_ger("A_ger", _M, _N);
+    const ScalarA& alpha, TX& x, TestUtils::view_stride_adapter<_ViewTypeA, false>& org_A,
+    const _HostViewTypeA& h_A_syr, const std::string& situation) {
+  TestUtils::view_stride_adapter<_ViewTypeA, false> A_ger("A_ger", _M, _N);
   Kokkos::deep_copy(A_ger.d_base, org_A.d_base);
 
   // ********************************************************************
@@ -1282,7 +1284,7 @@ void SyrTester<ScalarX, tLayoutX, ScalarA, tLayoutA, Device>::callKkGerAndCompar
   // ********************************************************************
   // Prepare h_ger_reference to be compared against h_A_syr
   // ********************************************************************
-  view_stride_adapter<_ViewTypeExpected, true> h_ger_reference("h_ger_reference", _M, _N);
+  TestUtils::view_stride_adapter<_ViewTypeExpected, true> h_ger_reference("h_ger_reference", _M, _N);
   Kokkos::deep_copy(h_ger_reference.d_base, A_ger.d_base);
 
   std::string uplo = _useUpOption ? "U" : "L";

--- a/blas/unit_test/Test_Blas2_syr2.hpp
+++ b/blas/unit_test/Test_Blas2_syr2.hpp
@@ -66,9 +66,10 @@ class Syr2Tester {
   using _KAT_A   = KokkosKernels::ArithTraits<ScalarA>;
   using _AuxType = typename _KAT_A::mag_type;
 
-  void populateVariables(ScalarA& alpha, view_stride_adapter<_ViewTypeX, false>& x,
-                         view_stride_adapter<_ViewTypeY, false>& y, view_stride_adapter<_ViewTypeA, false>& A,
-                         _ViewTypeExpected& h_expected, bool& expectedResultIsKnown);
+  void populateVariables(ScalarA& alpha, TestUtils::view_stride_adapter<_ViewTypeX, false>& x,
+                         TestUtils::view_stride_adapter<_ViewTypeY, false>& y,
+                         TestUtils::view_stride_adapter<_ViewTypeA, false>& A, _ViewTypeExpected& h_expected,
+                         bool& expectedResultIsKnown);
 
   template <class T>
   typename std::enable_if<
@@ -121,13 +122,13 @@ class Syr2Tester {
 
   template <class TX, class TY>
   void callKkSyr2AndCompareAgainstExpected(const ScalarA& alpha, TX& x, TY& y,
-                                           view_stride_adapter<_ViewTypeA, false>& A,
+                                           TestUtils::view_stride_adapter<_ViewTypeA, false>& A,
                                            const _ViewTypeExpected& h_expected, const std::string& situation);
 
   template <class TX, class TY>
   void callKkGerAndCompareKkSyr2AgainstIt(const ScalarA& alpha, TX& x, TY& y,
-                                          view_stride_adapter<_ViewTypeA, false>& org_A, const _HostViewTypeA& h_A_syr2,
-                                          const std::string& situation);
+                                          TestUtils::view_stride_adapter<_ViewTypeA, false>& org_A,
+                                          const _HostViewTypeA& h_A_syr2, const std::string& situation);
 
   const bool _A_is_complex;
   const bool _A_is_lr;
@@ -230,11 +231,11 @@ void Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>
     test_cx = true;
   }
 
-  view_stride_adapter<_ViewTypeX, false> x("X", _M);
-  view_stride_adapter<_ViewTypeY, false> y("Y", _N);
-  view_stride_adapter<_ViewTypeA, false> A("A", _M, _N);
+  TestUtils::view_stride_adapter<_ViewTypeX, false> x("X", _M);
+  TestUtils::view_stride_adapter<_ViewTypeY, false> y("Y", _N);
+  TestUtils::view_stride_adapter<_ViewTypeA, false> A("A", _M, _N);
 
-  view_stride_adapter<_ViewTypeExpected, true> h_expected("expected A += alpha * x * x^{t,h}", _M, _N);
+  TestUtils::view_stride_adapter<_ViewTypeExpected, true> h_expected("expected A += alpha * x * x^{t,h}", _M, _N);
   bool expectedResultIsKnown = false;
 
   using AlphaCoeffType = typename _ViewTypeA::non_const_value_type;
@@ -248,7 +249,7 @@ void Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>
   // ********************************************************************
   // Step 3 of 7: populate h_vanilla
   // ********************************************************************
-  view_stride_adapter<_ViewTypeExpected, true> h_vanilla("vanilla = A + alpha * x * x^{t,h}", _M, _N);
+  TestUtils::view_stride_adapter<_ViewTypeExpected, true> h_vanilla("vanilla = A + alpha * x * x^{t,h}", _M, _N);
 #ifndef NDEBUG
   std::cout << "In Test_Blas2_syr2.hpp, computing vanilla A with alpha type = " << typeid(alpha).name() << std::endl;
 #endif
@@ -272,7 +273,7 @@ void Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>
   // ********************************************************************
   // Step 5 of 7: test with 'non const x'
   // ********************************************************************
-  view_stride_adapter<_ViewTypeA, false> org_A("Org_A", _M, _N);
+  TestUtils::view_stride_adapter<_ViewTypeA, false> org_A("Org_A", _M, _N);
   Kokkos::deep_copy(org_A.d_base, A.d_base);
   Kokkos::deep_copy(org_A.h_view, A.h_view);
 
@@ -316,8 +317,9 @@ void Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>
 
 template <class ScalarX, class tLayoutX, class ScalarY, class tLayoutY, class ScalarA, class tLayoutA, class Device>
 void Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::populateVariables(
-    ScalarA& alpha, view_stride_adapter<_ViewTypeX, false>& x, view_stride_adapter<_ViewTypeY, false>& y,
-    view_stride_adapter<_ViewTypeA, false>& A, _ViewTypeExpected& h_expected, bool& expectedResultIsKnown) {
+    ScalarA& alpha, TestUtils::view_stride_adapter<_ViewTypeX, false>& x,
+    TestUtils::view_stride_adapter<_ViewTypeY, false>& y, TestUtils::view_stride_adapter<_ViewTypeA, false>& A,
+    _ViewTypeExpected& h_expected, bool& expectedResultIsKnown) {
   expectedResultIsKnown = false;
 
   if (_useAnalyticalResults) {
@@ -379,19 +381,19 @@ void Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>
 
     {
       ScalarX randStart, randEnd;
-      Test::getRandomBounds(1.0, randStart, randEnd);
+      TestUtils::getRandomBounds(1.0, randStart, randEnd);
       Kokkos::fill_random(x.d_view, rand_pool, randStart, randEnd);
     }
 
     {
       ScalarY randStart, randEnd;
-      Test::getRandomBounds(1.0, randStart, randEnd);
+      TestUtils::getRandomBounds(1.0, randStart, randEnd);
       Kokkos::fill_random(y.d_view, rand_pool, randStart, randEnd);
     }
 
     {
       ScalarA randStart, randEnd;
-      Test::getRandomBounds(1.0, randStart, randEnd);
+      TestUtils::getRandomBounds(1.0, randStart, randEnd);
       Kokkos::fill_random(A.d_view, rand_pool, randStart, randEnd);
     }
 
@@ -1252,8 +1254,8 @@ Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::com
 template <class ScalarX, class tLayoutX, class ScalarY, class tLayoutY, class ScalarA, class tLayoutA, class Device>
 template <class TX, class TY>
 void Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::callKkSyr2AndCompareAgainstExpected(
-    const ScalarA& alpha, TX& x, TY& y, view_stride_adapter<_ViewTypeA, false>& A, const _ViewTypeExpected& h_expected,
-    const std::string& situation) {
+    const ScalarA& alpha, TX& x, TY& y, TestUtils::view_stride_adapter<_ViewTypeA, false>& A,
+    const _ViewTypeExpected& h_expected, const std::string& situation) {
 #ifndef NDEBUG
   std::cout << "In Test_Blas2_syr2, '" << situation << "', alpha = " << alpha << std::endl;
   std::cout << "In Test_Blas2_syr2.hpp, right before calling KokkosBlas::syr2()"
@@ -1295,9 +1297,9 @@ void Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>
 template <class ScalarX, class tLayoutX, class ScalarY, class tLayoutY, class ScalarA, class tLayoutA, class Device>
 template <class TX, class TY>
 void Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>::callKkGerAndCompareKkSyr2AgainstIt(
-    const ScalarA& alpha, TX& x, TY& y, view_stride_adapter<_ViewTypeA, false>& org_A, const _HostViewTypeA& h_A_syr2,
-    const std::string& situation) {
-  view_stride_adapter<_ViewTypeA, false> A_ger("A_ger", _M, _N);
+    const ScalarA& alpha, TX& x, TY& y, TestUtils::view_stride_adapter<_ViewTypeA, false>& org_A,
+    const _HostViewTypeA& h_A_syr2, const std::string& situation) {
+  TestUtils::view_stride_adapter<_ViewTypeA, false> A_ger("A_ger", _M, _N);
   Kokkos::deep_copy(A_ger.d_base, org_A.d_base);
 
   // ********************************************************************
@@ -1369,7 +1371,7 @@ void Syr2Tester<ScalarX, tLayoutX, ScalarY, tLayoutY, ScalarA, tLayoutA, Device>
   // ********************************************************************
   // Prepare h_ger_reference to be compared against h_A_syr2
   // ********************************************************************
-  view_stride_adapter<_ViewTypeExpected, true> h_ger_reference("h_ger_reference", _M, _N);
+  TestUtils::view_stride_adapter<_ViewTypeExpected, true> h_ger_reference("h_ger_reference", _M, _N);
   Kokkos::deep_copy(h_ger_reference.d_base, A_ger.d_base);
   Kokkos::deep_copy(h_ger_reference.h_base, h_ger_reference.d_base);
 

--- a/blas/unit_test/Test_Blas_serial_axpy.hpp
+++ b/blas/unit_test/Test_Blas_serial_axpy.hpp
@@ -46,7 +46,7 @@ struct Functor_TestBlasSerialAxpy {
   inline void run() {
     using value_type = typename ViewType::value_type;
     std::string name_region("KokkosBlas::Test::SerialAxpy");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name_work_tag         = (std::is_same<AlgoTagType, KokkosKernelAxpyTag>::value ? "::KokkosBlas"
                                          : std::is_same<AlgoTagType, NaiveAxpyTag>::value      ? "::Naive"
                                                                                                : "::UnknownWorkTag");

--- a/blas/unit_test/Test_Blas_serial_nrm2.hpp
+++ b/blas/unit_test/Test_Blas_serial_nrm2.hpp
@@ -46,7 +46,7 @@ struct Functor_TestBlasSerialNrm2 {
 
   inline void run() {
     std::string name_region("KokkosBlas::Test::SerialNrm2");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name_work_tag         = (std::is_same<AlgoTagType, KokkosKernelTag>::value ? "::KokkosBlas"
                                          : std::is_same<AlgoTagType, NaiveTag>::value      ? "::Naive"
                                                                                            : "::UnknownWorkTag");
@@ -97,7 +97,7 @@ struct Functor_TestBlasSerialNrm2MV {
 
   inline void run() {
     std::string name_region("KokkosBlas::Test::SerialNrm2MV");
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name_work_tag         = (std::is_same<AlgoTagType, KokkosKernelTag>::value ? "::KokkosBlas"
                                          : std::is_same<AlgoTagType, NaiveTag>::value      ? "::Naive"
                                                                                            : "::UnknownWorkTag");

--- a/lapack/unit_test/Test_Lapack_gegqr.hpp
+++ b/lapack/unit_test/Test_Lapack_gegqr.hpp
@@ -186,8 +186,7 @@ void computeQ_analytic() {
   Kokkos::deep_copy(h_A, A);
   for (int rowIdx = 0; rowIdx < 3; ++rowIdx) {
     for (int colIdx = 0; colIdx < 3; ++colIdx) {
-      Test::EXPECT_NEAR_KK_REL(h_Qref(rowIdx, colIdx), h_A(rowIdx, colIdx),
-                               10 * KokkosKernels::ArithTraits<Scalar>::eps());
+      EXPECT_NEAR_KK_REL(h_Qref(rowIdx, colIdx), h_A(rowIdx, colIdx), 10 * KokkosKernels::ArithTraits<Scalar>::eps());
     }
   }
 }

--- a/lapack/unit_test/Test_Lapack_gemqr.hpp
+++ b/lapack/unit_test/Test_Lapack_gemqr.hpp
@@ -347,8 +347,7 @@ void applyQ_analytic() {
   Kokkos::deep_copy(h_Q, Q);
   for (int rowIdx = 0; rowIdx < 3; ++rowIdx) {
     for (int colIdx = 0; colIdx < 3; ++colIdx) {
-      Test::EXPECT_NEAR_KK_REL(h_Qref(rowIdx, colIdx), h_Q(rowIdx, colIdx),
-                               10 * KokkosKernels::ArithTraits<Scalar>::eps());
+      EXPECT_NEAR_KK_REL(h_Qref(rowIdx, colIdx), h_Q(rowIdx, colIdx), 10 * KokkosKernels::ArithTraits<Scalar>::eps());
     }
   }
 }

--- a/lapack/unit_test/Test_Lapack_svd.hpp
+++ b/lapack/unit_test/Test_Lapack_svd.hpp
@@ -44,11 +44,11 @@ void check_triple_product(const AMatrix& A, const SVector& S, const UMatrix& U, 
   for (int rowIdx = 0; rowIdx < A.extent_int(0); ++rowIdx) {
     for (int colIdx = 0; colIdx < A.extent_int(1); ++colIdx) {
       if (1000 * tol < Kokkos::abs(A_h(rowIdx, colIdx))) {
-        EXPECT_NEAR_KK_REL(A_h(rowIdx, colIdx), M_h(rowIdx, colIdx), tol,
-                           "Value in SVD triple product did not match original matrix");
+        EXPECT_NEAR_KK_REL(A_h(rowIdx, colIdx), M_h(rowIdx, colIdx), tol)
+            << "Value in SVD triple product did not match original matrix";
       } else {
-        EXPECT_NEAR_KK(A_h(rowIdx, colIdx), M_h(rowIdx, colIdx), tol,
-                       "Value in SVD triple product did not match original matrix");
+        EXPECT_NEAR_KK(A_h(rowIdx, colIdx), M_h(rowIdx, colIdx), tol)
+            << "Value in SVD triple product did not match original matrix";
       }
     }
   }
@@ -69,11 +69,11 @@ void check_unitary_orthogonal_matrix(
   for (int rowIdx = 0; rowIdx < M.extent_int(0); ++rowIdx) {
     for (int colIdx = 0; colIdx < M.extent_int(0); ++colIdx) {
       if (rowIdx == colIdx) {
-        EXPECT_NEAR_KK_REL(I0_h(rowIdx, colIdx), KokkosKernels::ArithTraits<scalar_type>::one(), tol,
-                           "Matrix of left or right singular vectors is not unitary; diagonal of MM^H is not 1");
+        EXPECT_NEAR_KK_REL(I0_h(rowIdx, colIdx), KokkosKernels::ArithTraits<scalar_type>::one(), tol)
+            << "Matrix of left or right singular vectors is not unitary; diagonal of MM^H is not 1";
       } else {
-        EXPECT_NEAR_KK(I0_h(rowIdx, colIdx), KokkosKernels::ArithTraits<scalar_type>::zero(), tol,
-                       "Matrix of left or right singular vectors is not unitary; off-diagonal of MM^H is not 0");
+        EXPECT_NEAR_KK(I0_h(rowIdx, colIdx), KokkosKernels::ArithTraits<scalar_type>::zero(), tol)
+            << "Matrix of left or right singular vectors is not unitary; off-diagonal of MM^H is not 0";
       }
     }
   }
@@ -85,11 +85,11 @@ void check_unitary_orthogonal_matrix(
   for (int rowIdx = 0; rowIdx < M.extent_int(1); ++rowIdx) {
     for (int colIdx = 0; colIdx < M.extent_int(1); ++colIdx) {
       if (rowIdx == colIdx) {
-        EXPECT_NEAR_KK_REL(I1_h(rowIdx, colIdx), KokkosKernels::ArithTraits<scalar_type>::one(), tol,
-                           "Matrix of left or right singular vectors is not unitary; diagonal of M^HM is not 1");
+        EXPECT_NEAR_KK_REL(I1_h(rowIdx, colIdx), KokkosKernels::ArithTraits<scalar_type>::one(), tol)
+            << "Matrix of left or right singular vectors is not unitary; diagonal of M^HM is not 1";
       } else {
-        EXPECT_NEAR_KK(I1_h(rowIdx, colIdx), KokkosKernels::ArithTraits<scalar_type>::zero(), tol,
-                       "Matrix of left or right singular vectors is not unitary; off-diagonal of M^HM is not 0");
+        EXPECT_NEAR_KK(I1_h(rowIdx, colIdx), KokkosKernels::ArithTraits<scalar_type>::zero(), tol)
+            << "Matrix of left or right singular vectors is not unitary; off-diagonal of M^HM is not 0";
       }
     }
   }
@@ -453,7 +453,7 @@ int impl_test_svd(const int m, const int n) {
 
   // Initialize A with random numbers
   scalar_type randStart = 0, randEnd = 0;
-  Test::getRandomBounds(max_val, randStart, randEnd);
+  TestUtils::getRandomBounds(max_val, randStart, randEnd);
   Kokkos::fill_random(A, rand_pool, randStart, randEnd);
   Kokkos::deep_copy(Aref, A);
 

--- a/sparse/unit_test/Test_Sparse_TestUtils_RandCsMat.hpp
+++ b/sparse/unit_test/Test_Sparse_TestUtils_RandCsMat.hpp
@@ -6,7 +6,7 @@
 namespace Test {
 template <class ScalarType, class LayoutType, class ExeSpaceType>
 void doCsMat(size_t m, size_t n, ScalarType min_val, ScalarType max_val) {
-  using RandCs           = RandCsMatrix<ScalarType, LayoutType, ExeSpaceType>;
+  using RandCs           = TestUtils::RandCsMatrix<ScalarType, LayoutType, ExeSpaceType>;
   using size_type        = typename RandCs::size_type;
   auto expected_min      = ScalarType(1.0);
   size_type expected_nnz = 0;
@@ -31,7 +31,7 @@ void doCsMat(size_t m, size_t n, ScalarType min_val, ScalarType max_val) {
 
   // No need to check data here. Kokkos unit-tests deep_copy.
   auto vals = cm.get_vals();
-  ASSERT_EQ(vals.extent(0), size_t(cm.get_nnz()) + 1) << cm.info;
+  ASSERT_EQ(vals.extent(0), size_t(cm.get_nnz())) << cm.info;
 
   auto row_ids = cm.get_ids();
   ASSERT_EQ(row_ids.extent(0), size_t(cm.get_nnz())) << cm.info;
@@ -54,8 +54,8 @@ void doAllCsMat(size_t m, size_t n) {
   doCsMat<double, Kokkos::LayoutRight, ExeSpaceType>(m, n, min, max);
 
   // Verify that CsMat can be instantiated with complex types.
-  RandCsMatrix<Kokkos::complex<float>, Kokkos::LayoutLeft, ExeSpaceType> cmcf(m, n, min, max);
-  RandCsMatrix<Kokkos::complex<double>, Kokkos::LayoutRight, ExeSpaceType> cmcd(m, n, min, max);
+  TestUtils::RandCsMatrix<Kokkos::complex<float>, Kokkos::LayoutLeft, ExeSpaceType> cmcf(m, n, min, max);
+  TestUtils::RandCsMatrix<Kokkos::complex<double>, Kokkos::LayoutRight, ExeSpaceType> cmcd(m, n, min, max);
 }
 
 // Test randomly generated Cs matrices

--- a/sparse/unit_test/Test_Sparse_Utils.hpp
+++ b/sparse/unit_test/Test_Sparse_Utils.hpp
@@ -7,7 +7,7 @@
 #include "KokkosSparse_spmv.hpp"
 #include "KokkosSparse_SortCrs.hpp"
 
-namespace Test {
+namespace TestUtils {
 
 template <typename crsMat_t, typename vector_t>
 vector_t create_random_y_vector(crsMat_t crsMat, vector_t x_vector) {
@@ -178,6 +178,7 @@ bool is_same_matrix(crsMat_t output_mat_actual, crsMat_t output_mat_reference) {
   }
   return true;
 }
-}  // namespace Test
+
+}  // namespace TestUtils
 
 #endif  // TEST_SPARSE_UTILS_HPP

--- a/sparse/unit_test/Test_Sparse_block_gauss_seidel.hpp
+++ b/sparse/unit_test/Test_Sparse_block_gauss_seidel.hpp
@@ -158,11 +158,11 @@ void test_block_gauss_seidel_rank1(lno_t numRows, size_type nnz, lno_t bandwidth
   lno_t nv = ((crsmat2.numRows() + block_size - 1) / block_size) * block_size;
 
   const scalar_view_t solution_x(Kokkos::view_alloc(Kokkos::WithoutInitializing, "X"), nv);
-  // create_random_x_vector operates on host mirror, then copies to device. But
+  // TestUtils::create_random_x_vector operates on host mirror, then copies to device. But
   // create_y does everything on device.
-  create_random_x_vector(solution_x);
+  TestUtils::create_random_x_vector(solution_x);
   exec_space().fence();
-  scalar_view_t y_vector = create_random_y_vector(crsmat2, solution_x);
+  scalar_view_t y_vector = TestUtils::create_random_y_vector(crsmat2, solution_x);
   mag_t initial_norm_res = KokkosBlas::nrm2(solution_x);
 
   for (const auto gs_algorithm : params.gs_algorithms) {
@@ -237,8 +237,8 @@ void test_block_gauss_seidel_rank2(lno_t numRows, size_type nnz, lno_t bandwidth
   const lno_t numVecs = params.numVecs;
 
   scalar_view2d_t solution_x(Kokkos::view_alloc(Kokkos::WithoutInitializing, "X"), nv, params.numVecs);
-  create_random_x_vector(solution_x);
-  scalar_view2d_t y_vector = create_random_y_vector_mv(crsmat2, solution_x);
+  TestUtils::create_random_x_vector(solution_x);
+  scalar_view2d_t y_vector = TestUtils::create_random_y_vector_mv(crsmat2, solution_x);
   exec_space().fence();
   auto solution_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), solution_x);
   // Need to fence before reading from solution_host
@@ -293,7 +293,6 @@ void test_block_gauss_seidel_rank2(lno_t numRows, size_type nnz, lno_t bandwidth
 template <KokkosSparse::SparseMatrixFormat mtx_format, typename scalar_t, typename lno_t, typename size_type,
           typename device>
 void test_block_gauss_seidel_empty() {
-  using namespace Test;
   typedef typename KokkosSparse::CrsMatrix<scalar_t, lno_t, device, void, size_type> crsMat_t;
   typedef typename crsMat_t::StaticCrsGraphType graph_t;
   typedef typename graph_t::row_map_type::non_const_type row_map_type;

--- a/sparse/unit_test/Test_Sparse_ccs2crs.hpp
+++ b/sparse/unit_test/Test_Sparse_ccs2crs.hpp
@@ -69,7 +69,7 @@ void check_crs_matrix(CrsType crsMat, IdType ccs_row_ids_d, MapType ccs_col_map_
 }
 template <class ScalarType, class LayoutType, class ExeSpaceType>
 void doCcs2Crs(size_t m, size_t n, ScalarType min_val, ScalarType max_val, bool fully_sparse = false) {
-  RandCsMatrix<ScalarType, LayoutType, ExeSpaceType> ccsMat(n, m, min_val, max_val, fully_sparse);
+  TestUtils::RandCsMatrix<ScalarType, LayoutType, ExeSpaceType> ccsMat(n, m, min_val, max_val, fully_sparse);
 
   auto crsMat = KokkosSparse::ccs2crs(ccsMat.get_dim2(), ccsMat.get_dim1(), ccsMat.get_nnz(), ccsMat.get_vals(),
                                       ccsMat.get_map(), ccsMat.get_ids());
@@ -135,7 +135,7 @@ TEST_F(TestCategory, sparse_ccs2crs) {
   doCcs2Crs<double, Kokkos::LayoutRight, TestDevice>(50, 10, 10, 100, true);
 
   // Test the convenience wrapper that accepts a ccs matrix
-  RandCsMatrix<double, Kokkos::LayoutRight, TestDevice> csMat(2, 2, 10, 10, false);
+  TestUtils::RandCsMatrix<double, Kokkos::LayoutRight, TestDevice> csMat(2, 2, 10, 10, false);
   auto ccsMatrix =
       crs2ccs(csMat.get_dim1(), csMat.get_dim2(), csMat.get_nnz(), csMat.get_vals(), csMat.get_map(), csMat.get_ids());
   auto crsMatrix = ccs2crs(ccsMatrix);

--- a/sparse/unit_test/Test_Sparse_coo2crs.hpp
+++ b/sparse/unit_test/Test_Sparse_coo2crs.hpp
@@ -159,14 +159,14 @@ void check_crs_matrix(CrsType crsMat, RowType row, ColType col, DataType data,
       // NOTE: ASSERT_EQ doesn't work -- values may be summed in different
       // orders We sum at most m x n values.
       auto eps = crsMatRef.numCols() * crsMatRef.numRows() * 10e1 * ats::epsilon();
-      EXPECT_NEAR_KK(crs_vals_ref(j), crs_vals(k), eps, fail_msg + " mismatched values!" + failure_info);
+      EXPECT_NEAR_KK(crs_vals_ref(j), crs_vals(k), eps) << fail_msg + " mismatched values!" + failure_info;
     }
   }
 }
 
 template <class ScalarType, class LayoutType, class Device>
 void doCoo2Crs(size_t m, size_t n, ScalarType min_val, ScalarType max_val) {
-  RandCooMat<ScalarType, LayoutType, Device> cooMat(m, n, m * n, min_val, max_val);
+  TestUtils::RandCooMat<ScalarType, LayoutType, Device> cooMat(m, n, m * n, min_val, max_val);
   auto randRow  = cooMat.get_row();
   auto randCol  = cooMat.get_col();
   auto randData = cooMat.get_data();
@@ -227,7 +227,7 @@ TEST_F(TestCategory, sparse_coo2crs) {
     doAllCoo2Crs<TestDevice>(m, n);
   }
 
-  RandCooMat<double, Kokkos::LayoutRight, TestDevice> cooMat(2, 2, 2 * 2, 10, 10);
+  TestUtils::RandCooMat<double, Kokkos::LayoutRight, TestDevice> cooMat(2, 2, 2 * 2, 10, 10);
   auto crsMatrix = KokkosSparse::coo2crs(2, 2, cooMat.get_row(), cooMat.get_col(), cooMat.get_data());
   auto cooMatrix = KokkosSparse::crs2coo(crsMatrix);
 

--- a/sparse/unit_test/Test_Sparse_crs2ccs.hpp
+++ b/sparse/unit_test/Test_Sparse_crs2ccs.hpp
@@ -68,7 +68,7 @@ void check_ccs_matrix(CcsType ccsMat, IdType crs_col_ids_d, MapType crs_row_map_
 
 template <class ScalarType, class LayoutType, class ExeSpaceType>
 void doCrs2Ccs(size_t m, size_t n, ScalarType min_val, ScalarType max_val, bool fully_sparse = false) {
-  RandCsMatrix<ScalarType, LayoutType, ExeSpaceType> crsMat(m, n, min_val, max_val, fully_sparse);
+  TestUtils::RandCsMatrix<ScalarType, LayoutType, ExeSpaceType> crsMat(m, n, min_val, max_val, fully_sparse);
 
   auto ccsMat = KokkosSparse::crs2ccs(crsMat.get_dim1(), crsMat.get_dim2(), crsMat.get_nnz(), crsMat.get_vals(),
                                       crsMat.get_map(), crsMat.get_ids());
@@ -133,7 +133,7 @@ TEST_F(TestCategory, sparse_crs2ccs) {
   doCrs2Ccs<double, Kokkos::LayoutRight, TestDevice>(50, 10, 10, 100, true);
 
   // Test the convenience wrapper that accepts a crs matrix
-  RandCsMatrix<float, Kokkos::LayoutLeft, TestDevice> csMat(2, 2, 10, 10, false);
+  TestUtils::RandCsMatrix<float, Kokkos::LayoutLeft, TestDevice> csMat(2, 2, 10, 10, false);
   auto crsMatrix =
       ccs2crs(csMat.get_dim2(), csMat.get_dim1(), csMat.get_nnz(), csMat.get_vals(), csMat.get_map(), csMat.get_ids());
   auto ccsMatrix = crs2ccs(crsMatrix);

--- a/sparse/unit_test/Test_Sparse_crs2coo.hpp
+++ b/sparse/unit_test/Test_Sparse_crs2coo.hpp
@@ -65,7 +65,7 @@ void check_coo_matrix(CrsType crsMatRef, RowType row, ColType col, DataType data
 
 template <class ScalarType, class LayoutType, class ExeSpaceType>
 void doCrs2Coo(size_t m, size_t n, ScalarType min_val, ScalarType max_val) {
-  using RandCrsMatType = RandCsMatrix<ScalarType, LayoutType, ExeSpaceType>;
+  using RandCrsMatType = TestUtils::RandCsMatrix<ScalarType, LayoutType, ExeSpaceType>;
   RandCrsMatType crsMat(m, n, min_val, max_val, m == 0 || n == 0);
 
   using CrsOT   = typename RandCrsMatType::IdViewTypeD::value_type;

--- a/sparse/unit_test/Test_Sparse_csc2csr.hpp
+++ b/sparse/unit_test/Test_Sparse_csc2csr.hpp
@@ -7,7 +7,7 @@
 namespace Test {
 template <class ScalarType, class LayoutType, class ExeSpaceType>
 void doCsc2Csr(size_t m, size_t n, ScalarType min_val, ScalarType max_val, bool fully_sparse = false) {
-  RandCsMatrix<ScalarType, LayoutType, ExeSpaceType> cscMat(n, m, min_val, max_val, fully_sparse);
+  TestUtils::RandCsMatrix<ScalarType, LayoutType, ExeSpaceType> cscMat(n, m, min_val, max_val, fully_sparse);
 
   auto csrMat = KokkosSparse::csc2csr(cscMat.get_dim2(), cscMat.get_dim1(), cscMat.get_nnz(), cscMat.get_vals(),
                                       cscMat.get_map(), cscMat.get_ids());

--- a/sparse/unit_test/Test_Sparse_gauss_seidel.hpp
+++ b/sparse/unit_test/Test_Sparse_gauss_seidel.hpp
@@ -181,9 +181,9 @@ void test_gauss_seidel_rank1(lno_t numRows, size_type nnz, lno_t bandwidth, lno_
   }
   lno_t nv = input_mat.numRows();
   scalar_view_t solution_x(Kokkos::view_alloc(Kokkos::WithoutInitializing, "X (correct)"), nv);
-  create_random_x_vector(solution_x);
+  TestUtils::create_random_x_vector(solution_x);
   mag_t initial_norm_res = KokkosBlas::nrm2(solution_x);
-  scalar_view_t y_vector = create_random_y_vector(input_mat, solution_x);
+  scalar_view_t y_vector = TestUtils::create_random_y_vector(input_mat, solution_x);
   // GS_DEFAULT is GS_TEAM on CUDA and GS_PERMUTED on other spaces, and the
   // behavior of each algorithm _should be_ the same on every execution space,
   // which is why we just test GS_DEFAULT.
@@ -257,10 +257,10 @@ void test_gauss_seidel_rank2(lno_t numRows, size_type nnz, lno_t bandwidth, lno_
   }
   lno_t nv = input_mat.numRows();
   host_scalar_view2d_t solution_x(Kokkos::view_alloc(Kokkos::WithoutInitializing, "X (correct)"), nv, numVecs);
-  create_random_x_vector(solution_x);
+  TestUtils::create_random_x_vector(solution_x);
   scalar_view2d_t x_vector(Kokkos::view_alloc(Kokkos::WithoutInitializing, "X"), nv, numVecs);
   Kokkos::deep_copy(x_vector, solution_x);
-  scalar_view2d_t y_vector = create_random_y_vector_mv(input_mat, x_vector);
+  scalar_view2d_t y_vector = TestUtils::create_random_y_vector_mv(input_mat, x_vector);
   auto x_host              = Kokkos::create_mirror_view(x_vector);
   std::vector<mag_t> initial_norms(numVecs);
   for (lno_t i = 0; i < numVecs; i++) {
@@ -371,7 +371,7 @@ void test_sequential_sor(lno_t numRows, size_type nnz, lno_t bandwidth, lno_t ro
   // record the correct solution, to compare against at the end
   vector_t xgold("X gold", numRows);
   Kokkos::deep_copy(xgold, x);
-  vector_t y = Test::create_random_y_vector(input_mat, x);
+  vector_t y = TestUtils::create_random_y_vector(input_mat, x);
   exec_space().fence();
   auto y_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), y);
   // initial solution is zero
@@ -515,7 +515,7 @@ void test_gauss_seidel_long_rows(lno_t numRows, lno_t numLongRows, lno_t nnzPerS
   scalar_t offDiagBase;
   {
     scalar_t unused;
-    Test::getRandomBounds(0.6, unused, offDiagBase);
+    TestUtils::getRandomBounds(0.6, unused, offDiagBase);
   }
   std::uniform_int_distribution<lno_t> colDist(0, numRows - 1);
   std::uniform_real_distribution<double> offDiagCoeffDist(-0.3, 0.3);
@@ -547,9 +547,9 @@ void test_gauss_seidel_long_rows(lno_t numRows, lno_t numLongRows, lno_t nnzPerS
   }
   lno_t nv = input_mat.numRows();
   scalar_view_t solution_x(Kokkos::view_alloc(Kokkos::WithoutInitializing, "X (correct)"), nv);
-  create_random_x_vector(solution_x);
+  TestUtils::create_random_x_vector(solution_x);
   mag_t initial_norm_res = KokkosBlas::nrm2(solution_x);
-  scalar_view_t y_vector = create_random_y_vector(input_mat, solution_x);
+  scalar_view_t y_vector = TestUtils::create_random_y_vector(input_mat, solution_x);
   // GS_DEFAULT is GS_TEAM on CUDA and GS_PERMUTED on other spaces, and the
   // behavior of each algorithm _should be_ the same on every execution space,
   // which is why we just test GS_DEFAULT.
@@ -586,9 +586,9 @@ void test_gauss_seidel_custom_coloring(lno_t numRows, lno_t nnzPerRow) {
   input_mat = Test::symmetrize<scalar_t, lno_t, size_type, device, crsMat_t>(input_mat);
   input_mat = KokkosSparse::sort_and_merge_matrix(input_mat);
   scalar_view_t solution_x(Kokkos::view_alloc(Kokkos::WithoutInitializing, "X (correct)"), numRows);
-  create_random_x_vector(solution_x);
+  TestUtils::create_random_x_vector(solution_x);
   mag_t initial_norm_res = KokkosBlas::nrm2(solution_x);
-  scalar_view_t y_vector = create_random_y_vector(input_mat, solution_x);
+  scalar_view_t y_vector = TestUtils::create_random_y_vector(input_mat, solution_x);
   scalar_view_t x_vector(Kokkos::view_alloc(Kokkos::WithoutInitializing, "x vector"), numRows);
   typedef KokkosKernelsHandle<size_type, lno_t, scalar_t, typename device::execution_space,
                               typename device::memory_space, typename device::memory_space>
@@ -661,9 +661,9 @@ void test_gauss_seidel_streams_rank1(lno_t numRows, size_type nnz, lno_t bandwid
     lno_t nv = input_mat_v[i].numRows();
     scalar_view_t solution_x_tmp(Kokkos::view_alloc(Kokkos::WithoutInitializing, "X (correct)"), nv);
     solution_x_v[i] = solution_x_tmp;
-    create_random_x_vector(solution_x_v[i]);
+    TestUtils::create_random_x_vector(solution_x_v[i]);
     initial_norm_res_v[i] = KokkosBlas::nrm2(solution_x_v[i]);
-    y_vector_v[i]         = create_random_y_vector(input_mat_v[i], solution_x_v[i]);
+    y_vector_v[i]         = TestUtils::create_random_y_vector(input_mat_v[i], solution_x_v[i]);
     // GS_DEFAULT is GS_TEAM on CUDA and GS_PERMUTED on other spaces, and the
     // behavior of each algorithm _should be_ the same on every execution space,
     // which is why we just test GS_DEFAULT.

--- a/sparse/unit_test/Test_Sparse_mdf.hpp
+++ b/sparse/unit_test/Test_Sparse_mdf.hpp
@@ -103,8 +103,8 @@ void run_test_mdf() {
     }
     for (int idx = 0; idx < 40; ++idx) {
       EXPECT_TRUE(entries_U_ref[idx] == entries_U(idx)) << "entries_U(" << idx << ") is wrong!";
-      EXPECT_NEAR_KK(values_U_ref[idx], values_U(idx), 10 * KokkosKernels::ArithTraits<scalar_type>::eps(),
-                     "An entry in U.values is wrong!");
+      EXPECT_NEAR_KK(values_U_ref[idx], values_U(idx), 10 * KokkosKernels::ArithTraits<scalar_type>::eps())
+          << "An entry in U.values is wrong!";
     }
 
     auto row_map_L = Kokkos::create_mirror(L.graph.row_map);
@@ -130,8 +130,8 @@ void run_test_mdf() {
       EXPECT_TRUE(entries_L_ref[idx] == entries_L(idx))
           << "entries_L(" << idx << ")=" << entries_L(idx) << " is wrong, entries_L_ref[" << idx
           << "]=" << entries_L_ref[idx] << "!";
-      EXPECT_NEAR_KK(values_L_ref[idx], values_L(idx), 10 * KokkosKernels::ArithTraits<scalar_type>::eps(),
-                     "An entry in L.values is wrong!");
+      EXPECT_NEAR_KK(values_L_ref[idx], values_L(idx), 10 * KokkosKernels::ArithTraits<scalar_type>::eps())
+          << "An entry in L.values is wrong!";
     }
   }
 }

--- a/sparse/unit_test/Test_Sparse_removeCrsMatrixZeros.hpp
+++ b/sparse/unit_test/Test_Sparse_removeCrsMatrixZeros.hpp
@@ -194,8 +194,9 @@ void getTestInput(int test, Matrix& A, Matrix& Afiltered_ref) {
   // If we have a hardcoded reference, check that the reference impl is correct
   // on this case
   if (haveHardcodedReference) {
-    Matrix Afiltered_refimpl           = removeMatrixZerosReference(A);
-    bool referenceImplMatchesHardcoded = Test::is_same_matrix<Matrix, TestDevice>(Afiltered_ref, Afiltered_refimpl);
+    Matrix Afiltered_refimpl = removeMatrixZerosReference(A);
+    bool referenceImplMatchesHardcoded =
+        TestUtils::is_same_matrix<Matrix, TestDevice>(Afiltered_ref, Afiltered_refimpl);
     ASSERT_TRUE(referenceImplMatchesHardcoded) << "Test case " << test << ": reference impl gave wrong answer!";
   }
 }
@@ -209,7 +210,7 @@ void testRemoveCrsMatrixZeros(int testCase) {
   Matrix A, Afiltered_ref;
   getTestInput<Matrix>(testCase, A, Afiltered_ref);
   Matrix Afiltered_actual = KokkosSparse::removeCrsMatrixZeros(A);
-  bool matches            = Test::is_same_matrix<Matrix, TestDevice>(Afiltered_actual, Afiltered_ref);
+  bool matches            = TestUtils::is_same_matrix<Matrix, TestDevice>(Afiltered_actual, Afiltered_ref);
   EXPECT_TRUE(matches) << "Test case " << testCase << ": matrix with zeros filtered out does not match reference.";
 }
 

--- a/sparse/unit_test/Test_Sparse_spadd.hpp
+++ b/sparse/unit_test/Test_Sparse_spadd.hpp
@@ -11,73 +11,11 @@
 #include <KokkosKernels_IOUtils.hpp>
 #include <KokkosKernels_Utils.hpp>
 
-#include <algorithm>    //for std::random_shuffle
-#include <random>       // for std::default_random_engine
 #include <cstdlib>      //for rand
 #include <type_traits>  //for std::is_same
 
 typedef Kokkos::complex<double> kokkos_complex_double;
 typedef Kokkos::complex<float> kokkos_complex_float;
-
-// Create a random nrows by ncols matrix for testing mat-mat addition kernels.
-// minNNZ, maxNNZ: min and max number of nonzeros in any row.
-// maxNNZ > ncols will result in duplicated entries in a row, otherwise entries
-// in a row are unique.
-// sortRows: whether to sort columns in a row
-template <typename crsMat_t, typename ordinal_type>
-crsMat_t randomMatrix(ordinal_type nrows, ordinal_type ncols, ordinal_type minNNZ, ordinal_type maxNNZ, bool sortRows) {
-  typedef typename crsMat_t::StaticCrsGraphType graph_t;
-  typedef typename graph_t::row_map_type::non_const_type size_type_view_t;
-  typedef typename graph_t::entries_type::non_const_type lno_view_t;
-  typedef typename crsMat_t::values_type::non_const_type scalar_view_t;
-  typedef typename size_type_view_t::non_const_value_type size_type;  // rowptr type
-  typedef typename lno_view_t::non_const_value_type lno_t;            // colind type
-  typedef typename scalar_view_t::non_const_value_type scalar_t;
-  typedef KokkosKernels::ArithTraits<scalar_t> KAT;
-  static_assert(std::is_same<ordinal_type, lno_t>::value, "ordinal_type should be same as lno_t from crsMat_t");
-  // first, populate rowmap
-  size_type_view_t rowmap("rowmap", nrows + 1);
-  typename size_type_view_t::host_mirror_type h_rowmap = Kokkos::create_mirror_view(rowmap);
-  size_type nnz                                        = 0;
-  size_type maxRowEntries                              = 0;
-  for (lno_t i = 0; i < nrows; i++) {
-    size_type rowEntries = rand() % (maxNNZ - minNNZ + 1) + minNNZ;
-    h_rowmap(i)          = nnz;
-    nnz += rowEntries;
-    maxRowEntries = std::max(rowEntries, maxRowEntries);
-  }
-  h_rowmap(nrows) = nnz;
-  Kokkos::deep_copy(rowmap, h_rowmap);
-  // allocate values and entries
-  scalar_view_t values("values", nnz);
-  // populate values
-  typename scalar_view_t::host_mirror_type h_values = Kokkos::create_mirror_view(values);
-  for (size_type i = 0; i < nnz; i++) {
-    h_values(i) = KAT::one() * (((typename KAT::mag_type)rand()) / static_cast<typename KAT::mag_type>(RAND_MAX));
-  }
-  Kokkos::deep_copy(values, h_values);
-  // populate entries (make sure no entry is repeated within a row)
-  lno_view_t entries("entries", nnz);
-  typename lno_view_t::host_mirror_type h_entries = Kokkos::create_mirror_view(entries);
-  std::vector<lno_t> indices(std::max((size_type)ncols, maxRowEntries));
-  auto re = std::mt19937(rand());
-  for (lno_t i = 0; i < nrows; i++) {
-    // this formula guarantees no duplicates if maxNNZ <= ncols, and duplicates
-    // if minNNZ > ncols
-    for (size_t j = 0; j < indices.size(); j++) indices[j] = j % ncols;
-    std::shuffle(indices.begin(), indices.end(), re);
-    size_type rowStart = h_rowmap(i);
-    size_type rowCount = h_rowmap(i + 1) - rowStart;
-    if (sortRows) {
-      std::sort(indices.begin(), indices.begin() + rowCount);
-    }
-    for (size_type j = 0; j < rowCount; j++) {
-      h_entries(rowStart + j) = indices[j];
-    }
-  }
-  Kokkos::deep_copy(entries, h_entries);
-  return crsMat_t("test matrix", nrows, ncols, nnz, values, rowmap, entries);
-}
 
 template <typename scalar_t, typename lno_t, typename size_type, class Device>
 void test_spadd(lno_t numRows, lno_t numCols, size_type minNNZ, size_type maxNNZ, bool sortRows) {
@@ -101,8 +39,8 @@ void test_spadd(lno_t numRows, lno_t numCols, size_type minNNZ, size_type maxNNZ
   // If maxNNZ <= numCols, the generated A, B have unique column indices in each
   // row
   handle.create_spadd_handle(sortRows, static_cast<lno_t>(maxNNZ) <= numCols);
-  crsMat_t A = randomMatrix<crsMat_t, lno_t>(numRows, numCols, minNNZ, maxNNZ, sortRows);
-  crsMat_t B = randomMatrix<crsMat_t, lno_t>(numRows, numCols, minNNZ, maxNNZ, sortRows);
+  crsMat_t A = TestUtils::randomMatrix<crsMat_t, lno_t>(numRows, numCols, minNNZ, maxNNZ, sortRows);
+  crsMat_t B = TestUtils::randomMatrix<crsMat_t, lno_t>(numRows, numCols, minNNZ, maxNNZ, sortRows);
   row_map_type c_row_map(Kokkos::view_alloc(Kokkos::WithoutInitializing, "C row map"), numRows + 1);
   // Make sure that nothing relies on any specific entry of c_row_map being zero
   // initialized

--- a/sparse/unit_test/Test_Sparse_spgemm.hpp
+++ b/sparse/unit_test/Test_Sparse_spgemm.hpp
@@ -310,7 +310,7 @@ void test_spgemm(lno_t m, lno_t k, lno_t n, size_type nnz, lno_t bandwidth, lno_
     timer1.reset();
     if (!is_expected_to_fail) {
       EXPECT_TRUE((res == 0)) << algo;
-      bool is_identical = is_same_matrix<crsMat_t, device>(output_mat, output_mat2);
+      const bool is_identical = TestUtils::is_same_matrix<crsMat_t, device>(output_mat, output_mat2);
       EXPECT_TRUE(is_identical) << "SpGEMM result incorrect: algo=" << algo << ", callMode=" << int(callMode)
                                 << ", testReuse=" << int(testReuse) << ", m=" << m << ", k=" << k << ", n=" << n
                                 << ", nnz=" << nnz << ", bandwidth=" << bandwidth
@@ -448,7 +448,7 @@ void test_issue402() {
     success = false;
   }
   EXPECT_TRUE(success) << "SpGEMM still has issue 402 bug! Error message:\n" << errMsg << '\n';
-  bool correctResult = is_same_matrix<crsMat_t, device>(C, Cgold);
+  bool correctResult = TestUtils::is_same_matrix<crsMat_t, device>(C, Cgold);
   EXPECT_TRUE(correctResult) << "SpGEMM still has issue 402 bug; C=AA' is incorrect!\n";
 }
 

--- a/sparse/unit_test/Test_Sparse_spgemm_jacobi.hpp
+++ b/sparse/unit_test/Test_Sparse_spgemm_jacobi.hpp
@@ -88,75 +88,6 @@ int run_spgemm_jacobi(crsMat_t input_mat, crsMat_t input_mat2, scalar_type omega
   return 0;
 }
 
-template <typename crsMat_t, typename device>
-bool is_same_mat(crsMat_t output_mat1, crsMat_t output_mat2) {
-  typedef typename crsMat_t::StaticCrsGraphType graph_t;
-  typedef typename graph_t::row_map_type::non_const_type lno_view_t;
-  typedef typename graph_t::entries_type::non_const_type lno_nnz_view_t;
-  typedef typename crsMat_t::values_type::non_const_type scalar_view_t;
-
-  size_t nrows1    = output_mat1.graph.row_map.extent(0);
-  size_t nentries1 = output_mat1.graph.entries.extent(0);
-  size_t nvals1    = output_mat1.values.extent(0);
-
-  size_t nrows2    = output_mat2.graph.row_map.extent(0);
-  size_t nentries2 = output_mat2.graph.entries.extent(0);
-  size_t nvals2    = output_mat2.values.extent(0);
-
-  if (nrows1 != nrows2) {
-    std::cout << "nrows1:" << nrows1 << " nrows2:" << nrows2 << std::endl;
-    return false;
-  }
-  if (nentries1 != nentries2) {
-    std::cout << "nentries1:" << nentries1 << " nentries2:" << nentries2 << std::endl;
-    return false;
-  }
-  if (nvals1 != nvals2) {
-    std::cout << "nvals1:" << nvals1 << " nvals2:" << nvals2 << std::endl;
-    return false;
-  }
-
-  bool is_identical = true;
-  is_identical =
-      KokkosKernels::Impl::kk_is_identical_view<typename graph_t::row_map_type, typename graph_t::row_map_type,
-                                                typename lno_view_t::value_type, typename device::execution_space>(
-          output_mat1.graph.row_map, output_mat2.graph.row_map, 0);
-
-  if (!is_identical) {
-    std::cout << "rowmaps are different." << std::endl;
-    KokkosKernels::Impl::kk_print_1Dview(output_mat1.graph.row_map);
-    KokkosKernels::Impl::kk_print_1Dview(output_mat2.graph.row_map);
-    return false;
-  }
-
-  is_identical =
-      KokkosKernels::Impl::kk_is_identical_view<lno_nnz_view_t, lno_nnz_view_t, typename lno_nnz_view_t::value_type,
-                                                typename device::execution_space>(output_mat1.graph.entries,
-                                                                                  output_mat2.graph.entries, 0);
-
-  if (!is_identical) {
-    std::cout << "entries are different." << std::endl;
-    KokkosKernels::Impl::kk_print_1Dview(output_mat1.graph.entries);
-    KokkosKernels::Impl::kk_print_1Dview(output_mat2.graph.entries);
-    return false;
-  }
-
-  typedef typename KokkosKernels::ArithTraits<typename scalar_view_t::non_const_value_type>::mag_type eps_type;
-  eps_type eps = std::is_same<eps_type, float>::value ? 2 * 1e-3 : 1e-7;
-
-  is_identical = KokkosKernels::Impl::kk_is_relatively_identical_view<scalar_view_t, scalar_view_t, eps_type,
-                                                                      typename device::execution_space>(
-      output_mat1.values, output_mat2.values, eps);
-
-  if (!is_identical) {
-    std::cout << "values are different for eps: " << eps << std::endl;
-    KokkosKernels::Impl::kk_print_1Dview(output_mat1.values);
-    KokkosKernels::Impl::kk_print_1Dview(output_mat2.values);
-
-    return false;
-  }
-  return true;
-}
 }  // namespace Test
 
 template <typename scalar_t, typename lno_t, typename size_type, typename device>
@@ -203,7 +134,7 @@ void test_spgemm_jacobi(lno_t numRows, size_type nnz, lno_t bandwidth, lno_t row
   // Sort the reference output_mat2, but not output_mat. It should already be
   // soted.
   KokkosSparse::sort_crs_matrix(output_mat2);
-  bool is_identical = is_same_mat<crsMat_t, device>(output_mat, output_mat2);
+  bool is_identical = TestUtils::is_same_matrix<crsMat_t, device>(output_mat, output_mat2);
   EXPECT_TRUE(is_identical);
 }
 

--- a/sparse/unit_test/Test_Sparse_spmv_bsr.hpp
+++ b/sparse/unit_test/Test_Sparse_spmv_bsr.hpp
@@ -111,7 +111,7 @@ Bsr bsr_random(const int blockSize, const int blockRows, const int blockCols) {
   using Graph        = typename Crs::staticcrsgraph_type;
 
   // construct a random Crs Matrix
-  Test::RandCsMatrix<scalar_type, Kokkos::LayoutLeft, typename Bsr::device_type, ordinal_type, size_type> rcs(
+  TestUtils::RandCsMatrix<scalar_type, Kokkos::LayoutLeft, typename Bsr::device_type, ordinal_type, size_type> rcs(
       blockRows, blockCols, scalar_type(0), max_a<scalar_type>());
 
   const auto colids = Kokkos::subview(rcs.get_ids(), Kokkos::make_pair(size_type(0), rcs.get_nnz()));

--- a/sparse/unit_test/Test_Sparse_spmv_sell.hpp
+++ b/sparse/unit_test/Test_Sparse_spmv_sell.hpp
@@ -150,13 +150,13 @@ void test_spmv_sell_analytic() {
   Kokkos::deep_copy(y_h, y);
 
   constexpr int row_length = 3;
-  Test::EXPECT_NEAR_KK_REL(y_h(0), scalar_t(-1), 10 * row_length * KokkosKernels::ArithTraits<scalar_t>::eps());
-  Test::EXPECT_NEAR_KK_REL(y_h(1), scalar_t(-2), 10 * row_length * KokkosKernels::ArithTraits<scalar_t>::eps());
-  Test::EXPECT_NEAR_KK_REL(y_h(2), scalar_t(-2), 10 * row_length * KokkosKernels::ArithTraits<scalar_t>::eps());
-  Test::EXPECT_NEAR_KK_REL(y_h(3), scalar_t(-2), 10 * row_length * KokkosKernels::ArithTraits<scalar_t>::eps());
-  Test::EXPECT_NEAR_KK_REL(y_h(4), scalar_t(-2), 10 * row_length * KokkosKernels::ArithTraits<scalar_t>::eps());
-  Test::EXPECT_NEAR_KK_REL(y_h(5), scalar_t(-2), 10 * row_length * KokkosKernels::ArithTraits<scalar_t>::eps());
-  Test::EXPECT_NEAR_KK_REL(y_h(6), scalar_t(47), 10 * row_length * KokkosKernels::ArithTraits<scalar_t>::eps());
+  EXPECT_NEAR_KK_REL(y_h(0), scalar_t(-1), 10 * row_length * KokkosKernels::ArithTraits<scalar_t>::eps());
+  EXPECT_NEAR_KK_REL(y_h(1), scalar_t(-2), 10 * row_length * KokkosKernels::ArithTraits<scalar_t>::eps());
+  EXPECT_NEAR_KK_REL(y_h(2), scalar_t(-2), 10 * row_length * KokkosKernels::ArithTraits<scalar_t>::eps());
+  EXPECT_NEAR_KK_REL(y_h(3), scalar_t(-2), 10 * row_length * KokkosKernels::ArithTraits<scalar_t>::eps());
+  EXPECT_NEAR_KK_REL(y_h(4), scalar_t(-2), 10 * row_length * KokkosKernels::ArithTraits<scalar_t>::eps());
+  EXPECT_NEAR_KK_REL(y_h(5), scalar_t(-2), 10 * row_length * KokkosKernels::ArithTraits<scalar_t>::eps());
+  EXPECT_NEAR_KK_REL(y_h(6), scalar_t(47), 10 * row_length * KokkosKernels::ArithTraits<scalar_t>::eps());
 }
 
 template <typename scalar_t, typename ordinal_t, typename size_type, typename Device>
@@ -208,8 +208,7 @@ void test_spmv_sell(ordinal_t num_rows, ordinal_t num_cols, ordinal_t row_length
   Kokkos::deep_copy(y_ref_h, y_ref);
 
   for (int rowIdx = 0; rowIdx < num_rows; ++rowIdx) {
-    Test::EXPECT_NEAR_KK_REL(y_h(rowIdx), y_ref_h(rowIdx),
-                             10 * row_length * KokkosKernels::ArithTraits<scalar_t>::eps());
+    EXPECT_NEAR_KK_REL(y_h(rowIdx), y_ref_h(rowIdx), 10 * row_length * KokkosKernels::ArithTraits<scalar_t>::eps());
   }
 }
 

--- a/sparse/unit_test/Test_Sparse_trsv.hpp
+++ b/sparse/unit_test/Test_Sparse_trsv.hpp
@@ -95,7 +95,7 @@ struct TrsvTest {
     auto lower_part =
         get_LU<Crs, sp_matrix_type, size_type>('L', numRows, nnz, row_size_variance, bandwidth, block_size);
 
-    Test::shuffleMatrixEntries(lower_part.graph.row_map, lower_part.graph.entries, lower_part.values, block_size);
+    TestUtils::shuffleMatrixEntries(lower_part.graph.row_map, lower_part.graph.entries, lower_part.values, block_size);
 
     KokkosSparse::spmv("N", alpha, lower_part, b_x_copy, beta, b_y);
     check_trsv_mv<UseBlocks>(lower_part, b_x, b_y, b_x_copy, numMV, "L", "N");
@@ -108,7 +108,7 @@ struct TrsvTest {
     auto upper_part =
         get_LU<Crs, sp_matrix_type, size_type>('U', numRows, nnz, row_size_variance, bandwidth, block_size);
 
-    Test::shuffleMatrixEntries(upper_part.graph.row_map, upper_part.graph.entries, upper_part.values, block_size);
+    TestUtils::shuffleMatrixEntries(upper_part.graph.row_map, upper_part.graph.entries, upper_part.values, block_size);
 
     KokkosSparse::spmv("N", alpha, upper_part, b_x_copy, beta, b_y);
     check_trsv_mv<UseBlocks>(upper_part, b_x, b_y, b_x_copy, numMV, "U", "N");

--- a/test_common/KokkosKernels_TestUtils.hpp
+++ b/test_common/KokkosKernels_TestUtils.hpp
@@ -13,6 +13,8 @@
 
 #include <random>
 #include <algorithm>
+#include <type_traits>
+#include <vector>
 
 // Simplify ETI macros
 #if !defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)

--- a/test_common/KokkosKernels_TestUtils.hpp
+++ b/test_common/KokkosKernels_TestUtils.hpp
@@ -4,14 +4,15 @@
 #ifndef KOKKOSKERNELS_TEST_UTILS_HPP
 #define KOKKOSKERNELS_TEST_UTILS_HPP
 
-#include <random>
-
 #include "KokkosKernels_Utils.hpp"
 #include "KokkosKernels_IOUtils.hpp"
 #include "KokkosKernels_ArithTraits.hpp"
 #include "KokkosBatched_Vector.hpp"
 // Make this include-able from all subdirectories
 #include "../tpls/gtest/gtest/gtest.h"  //for EXPECT_**
+
+#include <random>
+#include <algorithm>
 
 // Simplify ETI macros
 #if !defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
@@ -491,6 +492,66 @@ void shuffleMatrixEntries(Rowptrs rowptrs, Entries entries, Values values, const
   }
   Kokkos::deep_copy(entries, entriesHost);
   Kokkos::deep_copy(values, valuesHost);
+}
+
+// Create a random nrows by ncols matrix for testing mat-mat addition kernels.
+// minNNZ, maxNNZ: min and max number of nonzeros in any row.
+// maxNNZ > ncols will result in duplicated entries in a row, otherwise entries
+// in a row are unique.
+// sortRows: whether to sort columns in a row
+template <typename crsMat_t, typename ordinal_type>
+crsMat_t randomMatrix(ordinal_type nrows, ordinal_type ncols, ordinal_type minNNZ, ordinal_type maxNNZ, bool sortRows) {
+  typedef typename crsMat_t::StaticCrsGraphType graph_t;
+  typedef typename graph_t::row_map_type::non_const_type size_type_view_t;
+  typedef typename graph_t::entries_type::non_const_type lno_view_t;
+  typedef typename crsMat_t::values_type::non_const_type scalar_view_t;
+  typedef typename size_type_view_t::non_const_value_type size_type;  // rowptr type
+  typedef typename lno_view_t::non_const_value_type lno_t;            // colind type
+  typedef typename scalar_view_t::non_const_value_type scalar_t;
+  typedef KokkosKernels::ArithTraits<scalar_t> KAT;
+  static_assert(std::is_same<ordinal_type, lno_t>::value, "ordinal_type should be same as lno_t from crsMat_t");
+  // first, populate rowmap
+  size_type_view_t rowmap("rowmap", nrows + 1);
+  typename size_type_view_t::host_mirror_type h_rowmap = Kokkos::create_mirror_view(rowmap);
+  size_type nnz                                        = 0;
+  size_type maxRowEntries                              = 0;
+  for (lno_t i = 0; i < nrows; i++) {
+    size_type rowEntries = rand() % (maxNNZ - minNNZ + 1) + minNNZ;
+    h_rowmap(i)          = nnz;
+    nnz += rowEntries;
+    maxRowEntries = std::max(rowEntries, maxRowEntries);
+  }
+  h_rowmap(nrows) = nnz;
+  Kokkos::deep_copy(rowmap, h_rowmap);
+  // allocate values and entries
+  scalar_view_t values("values", nnz);
+  // populate values
+  typename scalar_view_t::host_mirror_type h_values = Kokkos::create_mirror_view(values);
+  for (size_type i = 0; i < nnz; i++) {
+    h_values(i) = KAT::one() * (((typename KAT::mag_type)rand()) / static_cast<typename KAT::mag_type>(RAND_MAX));
+  }
+  Kokkos::deep_copy(values, h_values);
+  // populate entries (make sure no entry is repeated within a row)
+  lno_view_t entries("entries", nnz);
+  typename lno_view_t::host_mirror_type h_entries = Kokkos::create_mirror_view(entries);
+  std::vector<lno_t> indices(std::max((size_type)ncols, maxRowEntries));
+  auto re = std::mt19937(rand());
+  for (lno_t i = 0; i < nrows; i++) {
+    // this formula guarantees no duplicates if maxNNZ <= ncols, and duplicates
+    // if minNNZ > ncols
+    for (size_t j = 0; j < indices.size(); j++) indices[j] = j % ncols;
+    std::shuffle(indices.begin(), indices.end(), re);
+    size_type rowStart = h_rowmap(i);
+    size_type rowCount = h_rowmap(i + 1) - rowStart;
+    if (sortRows) {
+      std::sort(indices.begin(), indices.begin() + rowCount);
+    }
+    for (size_type j = 0; j < rowCount; j++) {
+      h_entries(rowStart + j) = indices[j];
+    }
+  }
+  Kokkos::deep_copy(entries, h_entries);
+  return crsMat_t("test matrix", nrows, ncols, nnz, values, rowmap, entries);
 }
 
 }  // namespace TestUtils

--- a/test_common/KokkosKernels_TestUtils.hpp
+++ b/test_common/KokkosKernels_TestUtils.hpp
@@ -445,11 +445,10 @@ class RandCsMatrix {
     Kokkos::Random_XorShift64_Pool<Kokkos::HostSpace> random(ticks);
     populate_random_cs_mat(ticks);
 
-    vals_d_ = ValViewTypeD("RandCsMatrix.ValViewType", nnz_ + 1);
+    vals_d_ = ValViewTypeD("RandCsMatrix.ValViewType", nnz_);
     vals_   = Kokkos::create_mirror_view(vals_d_);
     Kokkos::fill_random(vals_, random, min_val, max_val);  // random scalars
     Kokkos::fence();
-    vals_(nnz_) = ScalarType(0);
 
     // Copy to device
     Kokkos::deep_copy(vals_d_, vals_);

--- a/test_common/KokkosKernels_TestUtils.hpp
+++ b/test_common/KokkosKernels_TestUtils.hpp
@@ -42,8 +42,7 @@
 #define KOKKOSKERNELS_TEST_COMPLEX_DOUBLE
 #endif
 
-namespace Test {
-
+namespace TestUtils {
 namespace Impl {
 
 template <class Scalar1, class Scalar2, class Scalar3>
@@ -70,7 +69,45 @@ template <class Scalar1, class Scalar2, class Scalar3>
 
 }  // namespace Impl
 
-#define KK_EXPECT_NEAR(val1, val2, tol) EXPECT_PRED_FORMAT3(::Test::Impl::kk_expect_near_pred_format, val1, val2, tol)
+#define KK_EXPECT_NEAR(val1, val2, tol) \
+  EXPECT_PRED_FORMAT3(::TestUtils::Impl::kk_expect_near_pred_format, val1, val2, tol)
+
+// Checks |val1 - val2| <= |tol|.  Expands to a GTest expression so callers
+// can append a failure message: EXPECT_NEAR_KK(a, b, eps) << "context";
+#define EXPECT_NEAR_KK(val1, val2, tol)                                                             \
+  EXPECT_LE((double)KokkosKernels::ArithTraits<std::decay_t<decltype(val1)>>::abs((val1) - (val2)), \
+            (double)KokkosKernels::ArithTraits<std::decay_t<decltype(tol)>>::abs(tol))
+
+// Checks |val1 - val2| <= tol * max(|val1|, |val2|).
+// Expands to a GTest expression; supports << for failure messages.
+#define EXPECT_NEAR_KK_REL(val1, val2, tol)                                                             \
+  EXPECT_NEAR_KK(val1, val2,                                                                            \
+                 (tol)*Kokkos::max(KokkosKernels::ArithTraits<std::decay_t<decltype(val1)>>::abs(val1), \
+                                   KokkosKernels::ArithTraits<std::decay_t<decltype(val2)>>::abs(val2)))
+
+// Checks element-wise |v1(i) - v2(i)| <= |tol| for every index i.
+#define EXPECT_NEAR_KK_1DVIEW(v1, v2, tol)                                                                      \
+  do {                                                                                                          \
+    const size_t _kk_v1_size = (v1).extent(0);                                                                  \
+    EXPECT_EQ(_kk_v1_size, (v2).extent(0));                                                                     \
+    auto _kk_h_v1 = Kokkos::create_mirror_view(v1);                                                             \
+    auto _kk_h_v2 = Kokkos::create_mirror_view(v2);                                                             \
+    KokkosKernels::Impl::safe_device_to_host_deep_copy(_kk_v1_size, v1, _kk_h_v1);                              \
+    KokkosKernels::Impl::safe_device_to_host_deep_copy(_kk_v1_size, v2, _kk_h_v2);                              \
+    for (size_t _kk_i = 0; _kk_i < _kk_v1_size; ++_kk_i) EXPECT_NEAR_KK(_kk_h_v1(_kk_i), _kk_h_v2(_kk_i), tol); \
+  } while (false)
+
+// Checks element-wise relative tolerance for every index i.
+#define EXPECT_NEAR_KK_REL_1DVIEW(v1, v2, tol)                                                                      \
+  do {                                                                                                              \
+    const size_t _kk_v1_size = (v1).extent(0);                                                                      \
+    EXPECT_EQ(_kk_v1_size, (v2).extent(0));                                                                         \
+    auto _kk_h_v1 = Kokkos::create_mirror_view(v1);                                                                 \
+    auto _kk_h_v2 = Kokkos::create_mirror_view(v2);                                                                 \
+    KokkosKernels::Impl::safe_device_to_host_deep_copy(_kk_v1_size, v1, _kk_h_v1);                                  \
+    KokkosKernels::Impl::safe_device_to_host_deep_copy(_kk_v1_size, v2, _kk_h_v2);                                  \
+    for (size_t _kk_i = 0; _kk_i < _kk_v1_size; ++_kk_i) EXPECT_NEAR_KK_REL(_kk_h_v1(_kk_i), _kk_h_v2(_kk_i), tol); \
+  } while (false)
 
 // Utility class for testing kernels with rank-1 and rank-2 views that may be
 // LayoutStride. Simplifies making a LayoutStride view of a given size that is
@@ -147,66 +184,6 @@ struct view_stride_adapter {
   DViewBase d_base;
   HViewBase h_base;
 };
-
-template <class Scalar1, class Scalar2, class Scalar3>
-void EXPECT_NEAR_KK(Scalar1 val1, Scalar2 val2, Scalar3 tol, std::string msg = "") {
-  typedef KokkosKernels::ArithTraits<Scalar1> AT1;
-  typedef KokkosKernels::ArithTraits<Scalar3> AT3;
-  EXPECT_LE((double)AT1::abs(val1 - val2), (double)AT3::abs(tol)) << msg;
-}
-
-template <class Scalar1, class Scalar2, class Scalar3>
-void EXPECT_NEAR_KK_REL(Scalar1 val1, Scalar2 val2, Scalar3 tol, std::string msg = "") {
-  typedef typename std::remove_reference<decltype(val1)>::type hv1_type;
-  typedef typename std::remove_reference<decltype(val2)>::type hv2_type;
-  const auto ahv1 = KokkosKernels::ArithTraits<hv1_type>::abs(val1);
-  const auto ahv2 = KokkosKernels::ArithTraits<hv2_type>::abs(val2);
-  EXPECT_NEAR_KK(val1, val2, tol * Kokkos::max(ahv1, ahv2), msg);
-}
-
-// Special overload for accurate value by value SIMD vectors comparison
-template <class Scalar, int VecLen, class Tolerance>
-void EXPECT_NEAR_KK_REL(const KokkosBatched::Vector<KokkosBatched::SIMD<Scalar>, VecLen>& val1,
-                        const KokkosBatched::Vector<KokkosBatched::SIMD<Scalar>, VecLen>& val2, Tolerance tol,
-                        std::string msg = "") {
-  for (int i = 0; i < VecLen; ++i) {
-    EXPECT_NEAR_KK_REL(val1[i], val2[i], tol, msg);
-  }
-}
-
-template <class ViewType1, class ViewType2, class Scalar>
-void EXPECT_NEAR_KK_1DVIEW(ViewType1 v1, ViewType2 v2, Scalar tol) {
-  size_t v1_size = v1.extent(0);
-  size_t v2_size = v2.extent(0);
-  EXPECT_EQ(v1_size, v2_size);
-
-  typename ViewType1::host_mirror_type h_v1 = Kokkos::create_mirror_view(v1);
-  typename ViewType2::host_mirror_type h_v2 = Kokkos::create_mirror_view(v2);
-
-  KokkosKernels::Impl::safe_device_to_host_deep_copy(v1.extent(0), v1, h_v1);
-  KokkosKernels::Impl::safe_device_to_host_deep_copy(v2.extent(0), v2, h_v2);
-
-  for (size_t i = 0; i < v1_size; ++i) {
-    EXPECT_NEAR_KK(h_v1(i), h_v2(i), tol);
-  }
-}
-
-template <class ViewType1, class ViewType2, class Scalar>
-void EXPECT_NEAR_KK_REL_1DVIEW(ViewType1 v1, ViewType2 v2, Scalar tol) {
-  size_t v1_size = v1.extent(0);
-  size_t v2_size = v2.extent(0);
-  EXPECT_EQ(v1_size, v2_size);
-
-  typename ViewType1::host_mirror_type h_v1 = Kokkos::create_mirror_view(v1);
-  typename ViewType2::host_mirror_type h_v2 = Kokkos::create_mirror_view(v2);
-
-  KokkosKernels::Impl::safe_device_to_host_deep_copy(v1.extent(0), v1, h_v1);
-  KokkosKernels::Impl::safe_device_to_host_deep_copy(v2.extent(0), v2, h_v2);
-
-  for (size_t i = 0; i < v1_size; ++i) {
-    EXPECT_NEAR_KK_REL(h_v1(i), h_v2(i), tol);
-  }
-}
 
 /// This function returns a descriptive user defined failure string for
 /// insertion into gtest macros such as FAIL() and EXPECT_LE(). \param file The
@@ -517,5 +494,6 @@ void shuffleMatrixEntries(Rowptrs rowptrs, Entries entries, Values values, const
   Kokkos::deep_copy(values, valuesHost);
 }
 
-}  // namespace Test
+}  // namespace TestUtils
+
 #endif


### PR DESCRIPTION
Change list:
* Change the KokkosKernels_TestUtils.hpp namespace to TestUtils so as to not clash with the frequently used Test namespace in the tests themselves (which required differentiation between Test:: and ::Test::
* Turn our EXPECT_KK utilities into proper macros to match the gtest test macro API
* Move randomMatrix from Test_Sparse_spadd.hpp to TestUtils
* Remove mysterious injection of a zero in RandCsMatrix, which made the views not represent a valid CRS.
* Remove `is_same_mat` from `Test_Sparse_spgemm_jacobi.hpp`. It was nearly identical to `is_same_matrix` in the utils.