### PR TITLE
Remove raja submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "tpls/rajaperf"]
-	path = tpls/rajaperf
-	url = https://github.com/ajpowelsnl/RAJAPerf.git


### PR DESCRIPTION
Some background: My other project (E3SM) relies heavily on git submodules to bring in various dependencies, so I instinctively type `git clone --recursive $url` when cloning repos. I did that recently for KK and was surprised at how long it took and I noticed that the vast majority of the time was spent cloning our `rajaperf` submodule (`tpls/rajaperf`). I did a quick timing:
* Cloning with no rajaperf: 4 seconds
* Recursive cloning with rajaperf: 25 seconds

We don't appear to be using rajaperf for anything, so it doesn't make sense to have it as a submodule, which would imply a tight coupling/dependency between our project and theirs.