### PR TITLE
sort crs: remove redundant fences

### DIFF
--- a/sparse/impl/KokkosSparse_sort_crs_impl.hpp
+++ b/sparse/impl/KokkosSparse_sort_crs_impl.hpp
@@ -389,10 +389,8 @@ Kokkos::View<uint64_t*, ExecSpace> generateBulkCrsKeys(const ExecSpace& exec, co
           keys(rowBegin) = uint64_t(i);
         }
       });
-  Kokkos::fence();
   Kokkos::parallel_scan("CRS bulk sorting: compute keys", Kokkos::RangePolicy<ExecSpace>(exec, 0, entries.extent(0)),
                         MaxScanFunctor<Offset, decltype(keys), Entries>(ncols, keys, entries));
-  Kokkos::fence();
   return keys;
 }
 


### PR DESCRIPTION
Remove unnecessary global fences from bulk-sort path in CRS sorting. The sequence of kernels here runs on one exec space instance and no fences are needed. Discovered in #3189. 