### PR TITLE
Cleanup README a little bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,22 +32,23 @@ Computational kernels in this subpackage include the following:
 
 We organize this directory as follows:
 
-1. Public interfaces to computational kernels live in the src/
-     subdirectory (kokkos-kernels/src):
+1. Public interfaces to computational kernels live in per-subsystem
+     `src/` subdirectories (e.g., `blas/src/`, `sparse/src/`):
 
-*    Kokkos_Blas1_MV.hpp: (Multi)vector operations that
+*    KokkosBlas1_*.hpp: (Multi)vector operations that
        Tpetra::MultiVector uses
-*    Kokkos_Sparse_CrsMatrix.hpp: Declaration and definition of
+*    KokkosSparse_CrsMatrix.hpp: Declaration and definition of
        KokkosSparse::CrsMatrix, the sparse matrix data structure used
        for the computational kernels below
 *    KokkosSparse_spmv.hpp: Sparse matrix-vector multiply with a
        single vector, stored in a 1-D View + Sparse matrix-vector multiply with
        multiple vectors at a time (multivectors), stored in a 2-D View
 
-2. Implementations of computational kernels live in the src/impl/
-     subdirectory (kokkos-kernels/src/impl)
+2. Implementations of computational kernels live in per-subsystem
+     `impl/` subdirectories (e.g., `blas/impl/`, `sparse/impl/`)
 
-3. Correctness tests live in the unit_test/ subdirectory, and
+3. Correctness tests live in per-subsystem `unit_test/` subdirectories
+     (e.g., `blas/unit_test/`, `sparse/unit_test/`), and
      performance tests live in the perf_test/ subdirectory
 
 4. Simple example scripts to build Kokkoskernels are in
@@ -80,13 +81,13 @@ whether ETI is used with a particular datatype, e.g.
 ````
 -DKokkosKernels_INST_DOUBLE=On
 ````
-which does explicit instantation of all kernels for double type.
+which does explicit instantiation of all kernels for double type.
 Kokkos Kernels derives most of its CXXFLAGS, C++ standard, architecture flags,
 and other options from an installed (or in-tree) Kokkos package.
 Tuning for a particular device or architecture is generally done through *Kokkos*
 while tuning which kernels get instantiated is done through *Kokkos Kernels*.
 
-Kokkos Kernels does supply flags for *asserting* properies of the linked Kokkos,
+Kokkos Kernels does supply flags for *asserting* properties of the linked Kokkos,
 for example:
 ````
 -DKokkosKernels_REQUIRE_DEVICES=CUDA
@@ -109,14 +110,14 @@ A basic installation would be done as:
 ````
 spack install kokkos-kernels
 ````
-Spack allows options and and compilers to be tuned in the install command.
+Spack allows options and compilers to be tuned in the install command.
 ````
 spack install kokkos-kernels@3.0 +double %gcc@7.3.0 +openmp
 ````
 This example illustrates the three most common parameters to Spack:
 * Variants: specified with, e.g. `+openmp`, this activates (or deactivates with, e.g. `~openmp`) certain options.
 * Version:  immediately following `kokkos-kernels` the `@version` can specify a particular Kokkos Kernels to build
-* Compiler: a default compiler will be chosen if not specified, but an exact compiler version can be given with the `%`option.
+* Compiler: a default compiler will be chosen if not specified, but an exact compiler version can be given with the `%` option.
 
 For a complete list of Kokkos Kernels options, run:
 ````
@@ -129,14 +130,14 @@ Spack gives a mechanism for directly specifying Kokkos dependency options:
 ````
 spack install kokkos-kernels ^kokkos@3.0+cuda+cuda_uvm
 ````
-The carat `^` sepcifies an exact dependency configuration, which in this case activates CUDA and CUDA_UVM.
+The carat `^` specifies an exact dependency configuration, which in this case activates CUDA and CUDA_UVM.
 For a complete list of tunable Kokkos options, run
 ````
 spack info kokkos
 ````
 
 #### Setting up a development environment with Spack
-Spack is generally most useful for installng packages to use.
+Spack is generally most useful for installing packages to use.
 If you want to install all *dependencies* of Kokkos Kernels first so that you can actively develop a given Kokkos Kernels source this can still be done. Go to the Kokkos Kernels source code folder and run:
 ````
 spack diy -u cmake kokkos-kernels@{version} ...
@@ -174,7 +175,7 @@ In `perf_test` there are test drivers.
 
 Please report bugs or performance issues to: https://github.com/kokkos/kokkos-kernels/issues
 
-##### [LICENSE](https://github.com/kokkos/kokkos-kernels/blob/devel/LICENSE)
+##### [LICENSE](https://github.com/kokkos/kokkos-kernels/blob/develop/LICENSE)
 [![License](https://img.shields.io/badge/License-Apache--2.0_WITH_LLVM--exception-blue)](https://spdx.org/licenses/LLVM-exception.html)
 
 Under the terms of Contract DE-NA0003525 with NTESS,

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ spack info kokkos-kernels
 As discussed above in the CMake section, Kokkos Kernels inherits much of its configuration from the installed Kokkos.
 Spack gives a mechanism for directly specifying Kokkos dependency options:
 ````
-spack install kokkos-kernels ^kokkos@3.0+cuda+cuda_uvm
+spack install kokkos-kernels ^kokkos@5.0+cuda
 ````
 The carat `^` specifies an exact dependency configuration, which in this case activates CUDA and CUDA_UVM.
 For a complete list of tunable Kokkos options, run

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ We organize this directory as follows:
        single vector, stored in a 1-D View + Sparse matrix-vector multiply with
        multiple vectors at a time (multivectors), stored in a 2-D View
 
-2. Implementations of computational kernels live in per-subsystem
+2. Implementations of computational kernels live in each component
      `impl/` subdirectories (e.g., `blas/impl/`, `sparse/impl/`)
 
 3. Correctness tests live in per-subsystem `unit_test/` subdirectories

--- a/README.md
+++ b/README.md
@@ -35,8 +35,6 @@ We organize this directory as follows:
 1. Public interfaces to computational kernels live in per-subsystem
      `src/` subdirectories (e.g., `blas/src/`, `sparse/src/`):
 
-*    KokkosBlas1_*.hpp: (Multi)vector operations that
-       Tpetra::MultiVector uses
 *    KokkosSparse_CrsMatrix.hpp: Declaration and definition of
        KokkosSparse::CrsMatrix, the sparse matrix data structure used
        for the computational kernels below

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ We organize this directory as follows:
 2. Implementations of computational kernels live in each component
      `impl/` subdirectories (e.g., `blas/impl/`, `sparse/impl/`)
 
-3. Correctness tests live in per-subsystem `unit_test/` subdirectories
+3. Correctness tests live in each component `unit_test/` subdirectories
      (e.g., `blas/unit_test/`, `sparse/unit_test/`), and
      performance tests live in the perf_test/ subdirectory
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Computational kernels in this subpackage include the following:
 
 We organize this directory as follows:
 
-1. Public interfaces to computational kernels live in per-subsystem
+1. Public interfaces to computational kernels live in each component
      `src/` subdirectories (e.g., `blas/src/`, `sparse/src/`):
 
 *    KokkosSparse_CrsMatrix.hpp: Declaration and definition of

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Spack gives a mechanism for directly specifying Kokkos dependency options:
 ````
 spack install kokkos-kernels ^kokkos@5.0+cuda
 ````
-The carat `^` specifies an exact dependency configuration, which in this case activates CUDA and CUDA_UVM.
+The carat `^` specifies an exact dependency configuration, which in this case activates CUDA
 For a complete list of tunable Kokkos options, run
 ````
 spack info kokkos


### PR DESCRIPTION
I noticed a typo in our README.md file and had AI do a scan for mistakes. It found several:
* Documentation pointing to directories that have moved
* Using outdated file names
* A few misspellings and typos
* Using an outdated URL for the license 