### PR TITLE
Make all TPL specializations partial

### DIFF
--- a/blas/tpls/KokkosBlas1_axpby_tpl_spec_decl.hpp
+++ b/blas/tpls/KokkosBlas1_axpby_tpl_spec_decl.hpp
@@ -26,137 +26,119 @@ inline void axpby_print_specialization() {
 namespace KokkosBlas {
 namespace Impl {
 
-#define KOKKOSBLAS1_DAXPBY_BLAS(ETI_SPEC_AVAIL)                                                                        \
-  template <typename ExecSpace>                                                                                        \
-    requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)                                      \
-  struct Axpby<ExecSpace, double,                                                                                      \
-               Kokkos::View<const double*, Kokkos::LayoutLeft, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,   \
-               double, Kokkos::View<double*, Kokkos::LayoutLeft, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-               1, true, ETI_SPEC_AVAIL> {                                                                              \
-    typedef double AV;                                                                                                 \
-    typedef double BV;                                                                                                 \
-    typedef Kokkos::View<const double*, Kokkos::LayoutLeft, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> > XV;   \
-    typedef Kokkos::View<double*, Kokkos::LayoutLeft, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> > YV;         \
-                                                                                                                       \
-    static void axpby(const ExecSpace& space, const AV& alpha, const XV& X, const BV& beta, const YV& Y) {             \
-      Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_BLAS,double]");                                             \
-      if ((X.extent(0) < INT_MAX) && (beta == 1.0)) {                                                                  \
-        axpby_print_specialization<AV, XV, BV, YV>();                                                                  \
-        int N   = X.extent(0);                                                                                         \
-        int one = 1;                                                                                                   \
-        HostBlas<double>::axpy(N, alpha, X.data(), one, Y.data(), one);                                                \
-      } else                                                                                                           \
-        Axpby<ExecSpace, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(space, alpha, X, beta, Y);            \
-      Kokkos::Profiling::popRegion();                                                                                  \
-    }                                                                                                                  \
-  };
+template <typename ExecSpace, bool ETI_SPEC_AVAIL>
+  requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)
+struct Axpby<ExecSpace, double,
+             Kokkos::View<const double*, Kokkos::LayoutLeft, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,
+             double, Kokkos::View<double*, Kokkos::LayoutLeft, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, 1,
+             true, ETI_SPEC_AVAIL> {
+  typedef double AV;
+  typedef double BV;
+  typedef Kokkos::View<const double*, Kokkos::LayoutLeft, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> > XV;
+  typedef Kokkos::View<double*, Kokkos::LayoutLeft, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> > YV;
 
-#define KOKKOSBLAS1_SAXPBY_BLAS(ETI_SPEC_AVAIL)                                                                      \
-  template <typename ExecSpace>                                                                                      \
-    requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)                                    \
-  struct Axpby<ExecSpace, float,                                                                                     \
-               Kokkos::View<const float*, Kokkos::LayoutLeft, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,  \
-               float, Kokkos::View<float*, Kokkos::LayoutLeft, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-               1, true, ETI_SPEC_AVAIL> {                                                                            \
-    typedef float AV;                                                                                                \
-    typedef float BV;                                                                                                \
-    typedef Kokkos::View<const float*, Kokkos::LayoutLeft, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> > XV;  \
-    typedef Kokkos::View<float*, Kokkos::LayoutLeft, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> > YV;        \
-                                                                                                                     \
-    static void axpby(const ExecSpace& space, const AV& alpha, const XV& X, const BV& beta, const YV& Y) {           \
-      Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_BLAS,float]");                                            \
-      if ((X.extent(0) < INT_MAX) && (beta == 1.0f)) {                                                               \
-        axpby_print_specialization<AV, XV, BV, YV>();                                                                \
-        int N   = X.extent(0);                                                                                       \
-        int one = 1;                                                                                                 \
-        HostBlas<float>::axpy(N, alpha, X.data(), one, Y.data(), one);                                               \
-      } else                                                                                                         \
-        Axpby<ExecSpace, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(space, alpha, X, beta, Y);          \
-      Kokkos::Profiling::popRegion();                                                                                \
-    }                                                                                                                \
-  };
+  static void axpby(const ExecSpace& space, const AV& alpha, const XV& X, const BV& beta, const YV& Y) {
+    Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_BLAS,double]");
+    if ((X.extent(0) < INT_MAX) && (beta == 1.0)) {
+      axpby_print_specialization<AV, XV, BV, YV>();
+      int N   = X.extent(0);
+      int one = 1;
+      HostBlas<double>::axpy(N, alpha, X.data(), one, Y.data(), one);
+    } else
+      Axpby<ExecSpace, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(space, alpha, X, beta, Y);
+    Kokkos::Profiling::popRegion();
+  }
+};
 
-#define KOKKOSBLAS1_ZAXPBY_BLAS(ETI_SPEC_AVAIL)                                                                        \
-  template <typename ExecSpace>                                                                                        \
-    requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)                                      \
-  struct Axpby<                                                                                                        \
-      ExecSpace, Kokkos::complex<double>,                                                                              \
-      Kokkos::View<const Kokkos::complex<double>*, Kokkos::LayoutLeft, ExecSpace,                                      \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                          \
-      Kokkos::complex<double>,                                                                                         \
-      Kokkos::View<Kokkos::complex<double>*, Kokkos::LayoutLeft, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-      1, true, ETI_SPEC_AVAIL> {                                                                                       \
-    typedef Kokkos::complex<double> AV;                                                                                \
-    typedef Kokkos::complex<double> BV;                                                                                \
-    typedef Kokkos::View<const Kokkos::complex<double>*, Kokkos::LayoutLeft, ExecSpace,                                \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >                                                     \
-        XV;                                                                                                            \
-    typedef Kokkos::View<Kokkos::complex<double>*, Kokkos::LayoutLeft, ExecSpace,                                      \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >                                                     \
-        YV;                                                                                                            \
-                                                                                                                       \
-    static void axpby(const ExecSpace& space, const AV& alpha, const XV& X, const BV& beta, const YV& Y) {             \
-      Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_BLAS,complex<double>]");                                    \
-      if ((X.extent(0) < INT_MAX) && (beta == 1.0f)) {                                                                 \
-        axpby_print_specialization<AV, XV, BV, YV>();                                                                  \
-        int N                                = X.extent(0);                                                            \
-        int one                              = 1;                                                                      \
-        const std::complex<double> alpha_val = alpha;                                                                  \
-        HostBlas<std::complex<double> >::axpy(N, alpha_val, reinterpret_cast<const std::complex<double>*>(X.data()),   \
-                                              one, reinterpret_cast<std::complex<double>*>(Y.data()), one);            \
-      } else                                                                                                           \
-        Axpby<ExecSpace, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(space, alpha, X, beta, Y);            \
-      Kokkos::Profiling::popRegion();                                                                                  \
-    }                                                                                                                  \
-  };
+template <typename ExecSpace, bool ETI_SPEC_AVAIL>
+  requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)
+struct Axpby<ExecSpace, float,
+             Kokkos::View<const float*, Kokkos::LayoutLeft, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, float,
+             Kokkos::View<float*, Kokkos::LayoutLeft, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, 1, true,
+             ETI_SPEC_AVAIL> {
+  typedef float AV;
+  typedef float BV;
+  typedef Kokkos::View<const float*, Kokkos::LayoutLeft, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> > XV;
+  typedef Kokkos::View<float*, Kokkos::LayoutLeft, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> > YV;
 
-#define KOKKOSBLAS1_CAXPBY_BLAS(ETI_SPEC_AVAIL)                                                                       \
-  template <typename ExecSpace>                                                                                       \
-    requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)                                     \
-  struct Axpby<                                                                                                       \
-      ExecSpace, Kokkos::complex<float>,                                                                              \
-      Kokkos::View<const Kokkos::complex<float>*, Kokkos::LayoutLeft, ExecSpace,                                      \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                         \
-      Kokkos::complex<float>,                                                                                         \
-      Kokkos::View<Kokkos::complex<float>*, Kokkos::LayoutLeft, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-      1, true, ETI_SPEC_AVAIL> {                                                                                      \
-    typedef Kokkos::complex<float> AV;                                                                                \
-    typedef Kokkos::complex<float> BV;                                                                                \
-    typedef Kokkos::View<const Kokkos::complex<float>*, Kokkos::LayoutLeft, ExecSpace,                                \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >                                                    \
-        XV;                                                                                                           \
-    typedef Kokkos::View<Kokkos::complex<float>*, Kokkos::LayoutLeft, ExecSpace,                                      \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >                                                    \
-        YV;                                                                                                           \
-                                                                                                                      \
-    static void axpby(const ExecSpace& space, const AV& alpha, const XV& X, const BV& beta, const YV& Y) {            \
-      Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_BLAS,complex<float>]");                                    \
-      if ((X.extent(0) < INT_MAX) && (beta == 1.0f)) {                                                                \
-        axpby_print_specialization<AV, XV, BV, YV>();                                                                 \
-        int N                               = X.extent(0);                                                            \
-        int one                             = 1;                                                                      \
-        const std::complex<float> alpha_val = alpha;                                                                  \
-        HostBlas<std::complex<float> >::axpy(N, alpha_val, reinterpret_cast<const std::complex<float>*>(X.data()),    \
-                                             one, reinterpret_cast<std::complex<float>*>(Y.data()), one);             \
-      } else                                                                                                          \
-        Axpby<ExecSpace, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(space, alpha, X, beta, Y);           \
-      Kokkos::Profiling::popRegion();                                                                                 \
-    }                                                                                                                 \
-  };
+  static void axpby(const ExecSpace& space, const AV& alpha, const XV& X, const BV& beta, const YV& Y) {
+    Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_BLAS,float]");
+    if ((X.extent(0) < INT_MAX) && (beta == 1.0f)) {
+      axpby_print_specialization<AV, XV, BV, YV>();
+      int N   = X.extent(0);
+      int one = 1;
+      HostBlas<float>::axpy(N, alpha, X.data(), one, Y.data(), one);
+    } else
+      Axpby<ExecSpace, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(space, alpha, X, beta, Y);
+    Kokkos::Profiling::popRegion();
+  }
+};
 
-KOKKOSBLAS1_DAXPBY_BLAS(true)
-KOKKOSBLAS1_DAXPBY_BLAS(false)
-KOKKOSBLAS1_SAXPBY_BLAS(true)
-KOKKOSBLAS1_SAXPBY_BLAS(false)
-KOKKOSBLAS1_ZAXPBY_BLAS(true)
-KOKKOSBLAS1_ZAXPBY_BLAS(false)
-KOKKOSBLAS1_CAXPBY_BLAS(true)
-KOKKOSBLAS1_CAXPBY_BLAS(false)
+template <typename ExecSpace, bool ETI_SPEC_AVAIL>
+  requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)
+struct Axpby<
+    ExecSpace, Kokkos::complex<double>,
+    Kokkos::View<const Kokkos::complex<double>*, Kokkos::LayoutLeft, ExecSpace,
+                 Kokkos::MemoryTraits<Kokkos::Unmanaged> >,
+    Kokkos::complex<double>,
+    Kokkos::View<Kokkos::complex<double>*, Kokkos::LayoutLeft, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, 1,
+    true, ETI_SPEC_AVAIL> {
+  typedef Kokkos::complex<double> AV;
+  typedef Kokkos::complex<double> BV;
+  typedef Kokkos::View<const Kokkos::complex<double>*, Kokkos::LayoutLeft, ExecSpace,
+                       Kokkos::MemoryTraits<Kokkos::Unmanaged> >
+      XV;
+  typedef Kokkos::View<Kokkos::complex<double>*, Kokkos::LayoutLeft, ExecSpace,
+                       Kokkos::MemoryTraits<Kokkos::Unmanaged> >
+      YV;
 
-#undef KOKKOSBLAS1_DAXPBY_BLAS
-#undef KOKKOSBLAS1_SAXPBY_BLAS
-#undef KOKKOSBLAS1_ZAXPBY_BLAS
-#undef KOKKOSBLAS1_CAXPBY_BLAS
+  static void axpby(const ExecSpace& space, const AV& alpha, const XV& X, const BV& beta, const YV& Y) {
+    Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_BLAS,complex<double>]");
+    if ((X.extent(0) < INT_MAX) && (beta == 1.0f)) {
+      axpby_print_specialization<AV, XV, BV, YV>();
+      int N                                = X.extent(0);
+      int one                              = 1;
+      const std::complex<double> alpha_val = alpha;
+      HostBlas<std::complex<double> >::axpy(N, alpha_val, reinterpret_cast<const std::complex<double>*>(X.data()), one,
+                                            reinterpret_cast<std::complex<double>*>(Y.data()), one);
+    } else
+      Axpby<ExecSpace, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(space, alpha, X, beta, Y);
+    Kokkos::Profiling::popRegion();
+  }
+};
+
+template <typename ExecSpace, bool ETI_SPEC_AVAIL>
+  requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)
+struct Axpby<
+    ExecSpace, Kokkos::complex<float>,
+    Kokkos::View<const Kokkos::complex<float>*, Kokkos::LayoutLeft, ExecSpace,
+                 Kokkos::MemoryTraits<Kokkos::Unmanaged> >,
+    Kokkos::complex<float>,
+    Kokkos::View<Kokkos::complex<float>*, Kokkos::LayoutLeft, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, 1,
+    true, ETI_SPEC_AVAIL> {
+  typedef Kokkos::complex<float> AV;
+  typedef Kokkos::complex<float> BV;
+  typedef Kokkos::View<const Kokkos::complex<float>*, Kokkos::LayoutLeft, ExecSpace,
+                       Kokkos::MemoryTraits<Kokkos::Unmanaged> >
+      XV;
+  typedef Kokkos::View<Kokkos::complex<float>*, Kokkos::LayoutLeft, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >
+      YV;
+
+  static void axpby(const ExecSpace& space, const AV& alpha, const XV& X, const BV& beta, const YV& Y) {
+    Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_BLAS,complex<float>]");
+    if ((X.extent(0) < INT_MAX) && (beta == 1.0f)) {
+      axpby_print_specialization<AV, XV, BV, YV>();
+      int N                               = X.extent(0);
+      int one                             = 1;
+      const std::complex<float> alpha_val = alpha;
+      HostBlas<std::complex<float> >::axpy(N, alpha_val, reinterpret_cast<const std::complex<float>*>(X.data()), one,
+                                           reinterpret_cast<std::complex<float>*>(Y.data()), one);
+    } else
+      Axpby<ExecSpace, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(space, alpha, X, beta, Y);
+    Kokkos::Profiling::popRegion();
+  }
+};
+
 }  // namespace Impl
 }  // namespace KokkosBlas
 
@@ -169,159 +151,135 @@ KOKKOSBLAS1_CAXPBY_BLAS(false)
 namespace KokkosBlas {
 namespace Impl {
 
-#define KOKKOSBLAS1_DAXPBY_CUBLAS(ETI_SPEC_AVAIL)                                                                      \
-  template <>                                                                                                          \
-  struct Axpby<                                                                                                        \
-      Kokkos::Cuda, double,                                                                                            \
-      Kokkos::View<const double*, Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, double, \
-      Kokkos::View<double*, Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, 1, true,      \
-      ETI_SPEC_AVAIL> {                                                                                                \
-    typedef double AV;                                                                                                 \
-    typedef double BV;                                                                                                 \
-    typedef Kokkos::View<const double*, Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> >    \
-        XV;                                                                                                            \
-    typedef Kokkos::View<double*, Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> > YV;      \
-    typedef typename XV::size_type size_type;                                                                          \
-                                                                                                                       \
-    static void axpby(const Kokkos::Cuda& space, const AV& alpha, const XV& X, const BV& beta, const YV& Y) {          \
-      Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_CUBLAS,double]");                                           \
-      const size_type numElems = X.extent(0);                                                                          \
-      if ((numElems < static_cast<size_type>(INT_MAX)) && (beta == 1.0)) {                                             \
-        axpby_print_specialization<AV, XV, BV, YV>();                                                                  \
-        const int N                            = static_cast<int>(numElems);                                           \
-        constexpr int one                      = 1;                                                                    \
-        KokkosBlas::Impl::CudaBlasSingleton& s = KokkosBlas::Impl::CudaBlasSingleton::singleton();                     \
-        KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasSetStream(s.handle, space.cuda_stream()));                              \
-        KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasDaxpy(s.handle, N, &alpha, X.data(), one, Y.data(), one));              \
-        KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasSetStream(s.handle, NULL));                                             \
-      } else                                                                                                           \
-        Axpby<Kokkos::Cuda, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(space, alpha, X, beta, Y);         \
-      Kokkos::Profiling::popRegion();                                                                                  \
-    }                                                                                                                  \
-  };
+template <bool ETI_SPEC_AVAIL>
+struct Axpby<Kokkos::Cuda, double,
+             Kokkos::View<const double*, Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,
+             double, Kokkos::View<double*, Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,
+             1, true, ETI_SPEC_AVAIL> {
+  typedef double AV;
+  typedef double BV;
+  typedef Kokkos::View<const double*, Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> > XV;
+  typedef Kokkos::View<double*, Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> > YV;
+  typedef typename XV::size_type size_type;
 
-#define KOKKOSBLAS1_SAXPBY_CUBLAS(ETI_SPEC_AVAIL)                                                                      \
-  template <>                                                                                                          \
-  struct Axpby<Kokkos::Cuda, float,                                                                                    \
-               Kokkos::View<const float*, Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
-               float,                                                                                                  \
-               Kokkos::View<float*, Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, 1,    \
-               true, ETI_SPEC_AVAIL> {                                                                                 \
-    typedef float AV;                                                                                                  \
-    typedef float BV;                                                                                                  \
-    typedef Kokkos::View<const float*, Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> > XV; \
-    typedef Kokkos::View<float*, Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> > YV;       \
-    typedef typename XV::size_type size_type;                                                                          \
-                                                                                                                       \
-    static void axpby(const Kokkos::Cuda& space, const AV& alpha, const XV& X, const BV& beta, const YV& Y) {          \
-      Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_CUBLAS,float]");                                            \
-      const size_type numElems = X.extent(0);                                                                          \
-      if ((numElems < static_cast<size_type>(INT_MAX)) && (beta == 1.0f)) {                                            \
-        axpby_print_specialization<AV, XV, BV, YV>();                                                                  \
-        const int N                            = static_cast<int>(numElems);                                           \
-        constexpr int one                      = 1;                                                                    \
-        KokkosBlas::Impl::CudaBlasSingleton& s = KokkosBlas::Impl::CudaBlasSingleton::singleton();                     \
-        KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasSetStream(s.handle, space.cuda_stream()));                              \
-        KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasSaxpy(s.handle, N, &alpha, X.data(), one, Y.data(), one));              \
-        KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasSetStream(s.handle, NULL));                                             \
-      } else                                                                                                           \
-        Axpby<Kokkos::Cuda, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(space, alpha, X, beta, Y);         \
-      Kokkos::Profiling::popRegion();                                                                                  \
-    }                                                                                                                  \
-  };
+  static void axpby(const Kokkos::Cuda& space, const AV& alpha, const XV& X, const BV& beta, const YV& Y) {
+    Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_CUBLAS,double]");
+    const size_type numElems = X.extent(0);
+    if ((numElems < static_cast<size_type>(INT_MAX)) && (beta == 1.0)) {
+      axpby_print_specialization<AV, XV, BV, YV>();
+      const int N                            = static_cast<int>(numElems);
+      constexpr int one                      = 1;
+      KokkosBlas::Impl::CudaBlasSingleton& s = KokkosBlas::Impl::CudaBlasSingleton::singleton();
+      KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasSetStream(s.handle, space.cuda_stream()));
+      KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasDaxpy(s.handle, N, &alpha, X.data(), one, Y.data(), one));
+      KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasSetStream(s.handle, NULL));
+    } else
+      Axpby<Kokkos::Cuda, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(space, alpha, X, beta, Y);
+    Kokkos::Profiling::popRegion();
+  }
+};
 
-#define KOKKOSBLAS1_ZAXPBY_CUBLAS(ETI_SPEC_AVAIL)                                                                   \
-  template <>                                                                                                       \
-  struct Axpby<Kokkos::Cuda, Kokkos::complex<double>,                                                               \
-               Kokkos::View<const Kokkos::complex<double>*, Kokkos::LayoutLeft, Kokkos::Cuda,                       \
-                            Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                              \
-               Kokkos::complex<double>,                                                                             \
-               Kokkos::View<Kokkos::complex<double>*, Kokkos::LayoutLeft, Kokkos::Cuda,                             \
-                            Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                              \
-               1, true, ETI_SPEC_AVAIL> {                                                                           \
-    typedef Kokkos::complex<double> AV;                                                                             \
-    typedef Kokkos::complex<double> BV;                                                                             \
-    typedef Kokkos::View<const Kokkos::complex<double>*, Kokkos::LayoutLeft, Kokkos::Cuda,                          \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >                                                  \
-        XV;                                                                                                         \
-    typedef Kokkos::View<Kokkos::complex<double>*, Kokkos::LayoutLeft, Kokkos::Cuda,                                \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >                                                  \
-        YV;                                                                                                         \
-    typedef typename XV::size_type size_type;                                                                       \
-                                                                                                                    \
-    static void axpby(const Kokkos::Cuda& space, const AV& alpha, const XV& X, const BV& beta, const YV& Y) {       \
-      Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_CUBLAS,complex<double>]");                               \
-      const size_type numElems = X.extent(0);                                                                       \
-      if ((numElems < static_cast<size_type>(INT_MAX)) && (beta == 1.0f)) {                                         \
-        axpby_print_specialization<AV, XV, BV, YV>();                                                               \
-        const int N                            = static_cast<int>(numElems);                                        \
-        constexpr int one                      = 1;                                                                 \
-        KokkosBlas::Impl::CudaBlasSingleton& s = KokkosBlas::Impl::CudaBlasSingleton::singleton();                  \
-        KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasSetStream(s.handle, space.cuda_stream()));                           \
-        KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasZaxpy(s.handle, N, reinterpret_cast<const cuDoubleComplex*>(&alpha), \
-                                                     reinterpret_cast<const cuDoubleComplex*>(X.data()), one,       \
-                                                     reinterpret_cast<cuDoubleComplex*>(Y.data()), one));           \
-        KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasSetStream(s.handle, NULL));                                          \
-      } else                                                                                                        \
-        Axpby<Kokkos::Cuda, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(space, alpha, X, beta, Y);      \
-      Kokkos::Profiling::popRegion();                                                                               \
-    }                                                                                                               \
-  };
+template <bool ETI_SPEC_AVAIL>
+struct Axpby<Kokkos::Cuda, float,
+             Kokkos::View<const float*, Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,
+             float, Kokkos::View<float*, Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, 1,
+             true, ETI_SPEC_AVAIL> {
+  typedef float AV;
+  typedef float BV;
+  typedef Kokkos::View<const float*, Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> > XV;
+  typedef Kokkos::View<float*, Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> > YV;
+  typedef typename XV::size_type size_type;
 
-#define KOKKOSBLAS1_CAXPBY_CUBLAS(ETI_SPEC_AVAIL)                                                              \
-  template <>                                                                                                  \
-  struct Axpby<Kokkos::Cuda, Kokkos::complex<float>,                                                           \
-               Kokkos::View<const Kokkos::complex<float>*, Kokkos::LayoutLeft, Kokkos::Cuda,                   \
-                            Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                         \
-               Kokkos::complex<float>,                                                                         \
-               Kokkos::View<Kokkos::complex<float>*, Kokkos::LayoutLeft, Kokkos::Cuda,                         \
-                            Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                         \
-               1, true, ETI_SPEC_AVAIL> {                                                                      \
-    typedef Kokkos::complex<float> AV;                                                                         \
-    typedef Kokkos::complex<float> BV;                                                                         \
-    typedef Kokkos::View<const Kokkos::complex<float>*, Kokkos::LayoutLeft, Kokkos::Cuda,                      \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >                                             \
-        XV;                                                                                                    \
-    typedef Kokkos::View<Kokkos::complex<float>*, Kokkos::LayoutLeft, Kokkos::Cuda,                            \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >                                             \
-        YV;                                                                                                    \
-    typedef typename XV::size_type size_type;                                                                  \
-                                                                                                               \
-    static void axpby(const Kokkos::Cuda& space, const AV& alpha, const XV& X, const BV& beta, const YV& Y) {  \
-      Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_CUBLAS,complex<float>]");                           \
-      const size_type numElems = X.extent(0);                                                                  \
-      if ((numElems < static_cast<size_type>(INT_MAX)) && (beta == 1.0f)) {                                    \
-        axpby_print_specialization<AV, XV, BV, YV>();                                                          \
-        const int N                            = static_cast<int>(numElems);                                   \
-        constexpr int one                      = 1;                                                            \
-        KokkosBlas::Impl::CudaBlasSingleton& s = KokkosBlas::Impl::CudaBlasSingleton::singleton();             \
-        KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasSetStream(s.handle, space.cuda_stream()));                      \
-        KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasCaxpy(s.handle, N, reinterpret_cast<const cuComplex*>(&alpha),  \
-                                                     reinterpret_cast<const cuComplex*>(X.data()), one,        \
-                                                     reinterpret_cast<cuComplex*>(Y.data()), one));            \
-        KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasSetStream(s.handle, NULL));                                     \
-      } else                                                                                                   \
-        Axpby<Kokkos::Cuda, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(space, alpha, X, beta, Y); \
-      Kokkos::Profiling::popRegion();                                                                          \
-    }                                                                                                          \
-  };
+  static void axpby(const Kokkos::Cuda& space, const AV& alpha, const XV& X, const BV& beta, const YV& Y) {
+    Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_CUBLAS,float]");
+    const size_type numElems = X.extent(0);
+    if ((numElems < static_cast<size_type>(INT_MAX)) && (beta == 1.0f)) {
+      axpby_print_specialization<AV, XV, BV, YV>();
+      const int N                            = static_cast<int>(numElems);
+      constexpr int one                      = 1;
+      KokkosBlas::Impl::CudaBlasSingleton& s = KokkosBlas::Impl::CudaBlasSingleton::singleton();
+      KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasSetStream(s.handle, space.cuda_stream()));
+      KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasSaxpy(s.handle, N, &alpha, X.data(), one, Y.data(), one));
+      KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasSetStream(s.handle, NULL));
+    } else
+      Axpby<Kokkos::Cuda, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(space, alpha, X, beta, Y);
+    Kokkos::Profiling::popRegion();
+  }
+};
 
-KOKKOSBLAS1_DAXPBY_CUBLAS(true)
-KOKKOSBLAS1_DAXPBY_CUBLAS(false)
+template <bool ETI_SPEC_AVAIL>
+struct Axpby<
+    Kokkos::Cuda, Kokkos::complex<double>,
+    Kokkos::View<const Kokkos::complex<double>*, Kokkos::LayoutLeft, Kokkos::Cuda,
+                 Kokkos::MemoryTraits<Kokkos::Unmanaged> >,
+    Kokkos::complex<double>,
+    Kokkos::View<Kokkos::complex<double>*, Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,
+    1, true, ETI_SPEC_AVAIL> {
+  typedef Kokkos::complex<double> AV;
+  typedef Kokkos::complex<double> BV;
+  typedef Kokkos::View<const Kokkos::complex<double>*, Kokkos::LayoutLeft, Kokkos::Cuda,
+                       Kokkos::MemoryTraits<Kokkos::Unmanaged> >
+      XV;
+  typedef Kokkos::View<Kokkos::complex<double>*, Kokkos::LayoutLeft, Kokkos::Cuda,
+                       Kokkos::MemoryTraits<Kokkos::Unmanaged> >
+      YV;
+  typedef typename XV::size_type size_type;
 
-KOKKOSBLAS1_SAXPBY_CUBLAS(true)
-KOKKOSBLAS1_SAXPBY_CUBLAS(false)
+  static void axpby(const Kokkos::Cuda& space, const AV& alpha, const XV& X, const BV& beta, const YV& Y) {
+    Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_CUBLAS,complex<double>]");
+    const size_type numElems = X.extent(0);
+    if ((numElems < static_cast<size_type>(INT_MAX)) && (beta == 1.0f)) {
+      axpby_print_specialization<AV, XV, BV, YV>();
+      const int N                            = static_cast<int>(numElems);
+      constexpr int one                      = 1;
+      KokkosBlas::Impl::CudaBlasSingleton& s = KokkosBlas::Impl::CudaBlasSingleton::singleton();
+      KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasSetStream(s.handle, space.cuda_stream()));
+      KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasZaxpy(s.handle, N, reinterpret_cast<const cuDoubleComplex*>(&alpha),
+                                                   reinterpret_cast<const cuDoubleComplex*>(X.data()), one,
+                                                   reinterpret_cast<cuDoubleComplex*>(Y.data()), one));
+      KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasSetStream(s.handle, NULL));
+    } else
+      Axpby<Kokkos::Cuda, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(space, alpha, X, beta, Y);
+    Kokkos::Profiling::popRegion();
+  }
+};
 
-KOKKOSBLAS1_ZAXPBY_CUBLAS(true)
-KOKKOSBLAS1_ZAXPBY_CUBLAS(false)
+template <bool ETI_SPEC_AVAIL>
+struct Axpby<
+    Kokkos::Cuda, Kokkos::complex<float>,
+    Kokkos::View<const Kokkos::complex<float>*, Kokkos::LayoutLeft, Kokkos::Cuda,
+                 Kokkos::MemoryTraits<Kokkos::Unmanaged> >,
+    Kokkos::complex<float>,
+    Kokkos::View<Kokkos::complex<float>*, Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,
+    1, true, ETI_SPEC_AVAIL> {
+  typedef Kokkos::complex<float> AV;
+  typedef Kokkos::complex<float> BV;
+  typedef Kokkos::View<const Kokkos::complex<float>*, Kokkos::LayoutLeft, Kokkos::Cuda,
+                       Kokkos::MemoryTraits<Kokkos::Unmanaged> >
+      XV;
+  typedef Kokkos::View<Kokkos::complex<float>*, Kokkos::LayoutLeft, Kokkos::Cuda,
+                       Kokkos::MemoryTraits<Kokkos::Unmanaged> >
+      YV;
+  typedef typename XV::size_type size_type;
 
-KOKKOSBLAS1_CAXPBY_CUBLAS(true)
-KOKKOSBLAS1_CAXPBY_CUBLAS(false)
-
-#undef KOKKOSBLAS1_DAXPBY_CUBLAS
-#undef KOKKOSBLAS1_SAXPBY_CUBLAS
-#undef KOKKOSBLAS1_ZAXPBY_CUBLAS
-#undef KOKKOSBLAS1_CAXPBY_CUBLAS
+  static void axpby(const Kokkos::Cuda& space, const AV& alpha, const XV& X, const BV& beta, const YV& Y) {
+    Kokkos::Profiling::pushRegion("KokkosBlas::axpby[TPL_CUBLAS,complex<float>]");
+    const size_type numElems = X.extent(0);
+    if ((numElems < static_cast<size_type>(INT_MAX)) && (beta == 1.0f)) {
+      axpby_print_specialization<AV, XV, BV, YV>();
+      const int N                            = static_cast<int>(numElems);
+      constexpr int one                      = 1;
+      KokkosBlas::Impl::CudaBlasSingleton& s = KokkosBlas::Impl::CudaBlasSingleton::singleton();
+      KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasSetStream(s.handle, space.cuda_stream()));
+      KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasCaxpy(s.handle, N, reinterpret_cast<const cuComplex*>(&alpha),
+                                                   reinterpret_cast<const cuComplex*>(X.data()), one,
+                                                   reinterpret_cast<cuComplex*>(Y.data()), one));
+      KOKKOSBLAS_IMPL_CUBLAS_SAFE_CALL(cublasSetStream(s.handle, NULL));
+    } else
+      Axpby<Kokkos::Cuda, AV, XV, BV, YV, YV::rank, false, ETI_SPEC_AVAIL>::axpby(space, alpha, X, beta, Y);
+    Kokkos::Profiling::popRegion();
+  }
+};
 }  // namespace Impl
 }  // namespace KokkosBlas
 

--- a/blas/tpls/KokkosBlas1_dot_tpl_spec_decl.hpp
+++ b/blas/tpls/KokkosBlas1_dot_tpl_spec_decl.hpp
@@ -26,8 +26,8 @@ inline void dot_print_specialization() {
 
 namespace KokkosBlas {
 namespace Impl {
-#define KOKKOSBLAS1_DOT_TPL_SPEC_DECL_BLAS(KOKKOS_TYPE, TPL_TYPE, ETI_SPEC_AVAIL)                                      \
-  template <typename ExecSpace>                                                                                        \
+#define KOKKOSBLAS1_DOT_TPL_SPEC_DECL_BLAS(KOKKOS_TYPE, TPL_TYPE)                                                      \
+  template <typename ExecSpace, bool ETI_SPEC_AVAIL>                                                                   \
     requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)                                      \
   struct Dot<                                                                                                          \
       ExecSpace,                                                                                                       \
@@ -58,14 +58,11 @@ namespace Impl {
     }                                                                                                                  \
   };
 
-#define KOKKOSBLAS1_DOT_TPL_SPEC_DECL_BLAS_EXT(ETI_SPEC_AVAIL)                                    \
-  KOKKOSBLAS1_DOT_TPL_SPEC_DECL_BLAS(float, float, ETI_SPEC_AVAIL)                                \
-  KOKKOSBLAS1_DOT_TPL_SPEC_DECL_BLAS(double, double, ETI_SPEC_AVAIL)                              \
-  KOKKOSBLAS1_DOT_TPL_SPEC_DECL_BLAS(Kokkos::complex<float>, std::complex<float>, ETI_SPEC_AVAIL) \
-  KOKKOSBLAS1_DOT_TPL_SPEC_DECL_BLAS(Kokkos::complex<double>, std::complex<double>, ETI_SPEC_AVAIL)
+KOKKOSBLAS1_DOT_TPL_SPEC_DECL_BLAS(float, float)
+KOKKOSBLAS1_DOT_TPL_SPEC_DECL_BLAS(double, double)
+KOKKOSBLAS1_DOT_TPL_SPEC_DECL_BLAS(Kokkos::complex<float>, std::complex<float>)
+KOKKOSBLAS1_DOT_TPL_SPEC_DECL_BLAS(Kokkos::complex<double>, std::complex<double>)
 
-KOKKOSBLAS1_DOT_TPL_SPEC_DECL_BLAS_EXT(true)
-KOKKOSBLAS1_DOT_TPL_SPEC_DECL_BLAS_EXT(false)
 }  // namespace Impl
 }  // namespace KokkosBlas
 #endif
@@ -79,8 +76,8 @@ KOKKOSBLAS1_DOT_TPL_SPEC_DECL_BLAS_EXT(false)
 
 namespace KokkosBlas {
 namespace Impl {
-#define KOKKOSBLAS1_DOT_TPL_SPEC_DECL_CUBLAS(KOKKOS_TYPE, TPL_TYPE, TPL_DOT, ETI_SPEC_AVAIL)                           \
-  template <>                                                                                                          \
+#define KOKKOSBLAS1_DOT_TPL_SPEC_DECL_CUBLAS(KOKKOS_TYPE, TPL_TYPE, TPL_DOT)                                           \
+  template <bool ETI_SPEC_AVAIL>                                                                                       \
   struct Dot<                                                                                                          \
       Kokkos::Cuda,                                                                                                    \
       Kokkos::View<KOKKOS_TYPE, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,      \
@@ -115,16 +112,11 @@ namespace Impl {
     }                                                                                                                  \
   };
 
-#define KOKKOSBLAS1_DOT_TPL_SPEC_DECL_CUBLAS_EXT(ETI_SPEC_AVAIL)                                                  \
-  KOKKOSBLAS1_DOT_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutLeft, float, float, cublasSdot, ETI_SPEC_AVAIL)              \
-  KOKKOSBLAS1_DOT_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutLeft, double, double, cublasDdot, ETI_SPEC_AVAIL)            \
-  KOKKOSBLAS1_DOT_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutLeft, Kokkos::complex<float>, cuComplex, cublasCdotc,        \
-                                       ETI_SPEC_AVAIL)                                                            \
-  KOKKOSBLAS1_DOT_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutLeft, Kokkos::complex<double>, cuDoubleComplex, cublasZdotc, \
-                                       ETI_SPEC_AVAIL)
+KOKKOSBLAS1_DOT_TPL_SPEC_DECL_CUBLAS(float, float, cublasSdot)
+KOKKOSBLAS1_DOT_TPL_SPEC_DECL_CUBLAS(double, double, cublasDdot)
+KOKKOSBLAS1_DOT_TPL_SPEC_DECL_CUBLAS(Kokkos::complex<float>, cuComplex, cublasCdotc)
+KOKKOSBLAS1_DOT_TPL_SPEC_DECL_CUBLAS(Kokkos::complex<double>, cuDoubleComplex, cublasZdotc)
 
-KOKKOSBLAS1_DOT_TPL_SPEC_DECL_CUBLAS_EXT(true)
-KOKKOSBLAS1_DOT_TPL_SPEC_DECL_CUBLAS_EXT(false)
 }  // namespace Impl
 }  // namespace KokkosBlas
 #endif
@@ -136,8 +128,8 @@ KOKKOSBLAS1_DOT_TPL_SPEC_DECL_CUBLAS_EXT(false)
 
 namespace KokkosBlas {
 namespace Impl {
-#define KOKKOSBLAS1_DOT_TPL_SPEC_DECL_ROCBLAS(KOKKOS_TYPE, TPL_TYPE, TPL_DOT, ETI_SPEC_AVAIL)                          \
-  template <>                                                                                                          \
+#define KOKKOSBLAS1_DOT_TPL_SPEC_DECL_ROCBLAS(KOKKOS_TYPE, TPL_TYPE, TPL_DOT)                                          \
+  template <bool ETI_SPEC_AVAIL>                                                                                       \
   struct Dot<                                                                                                          \
       Kokkos::HIP,                                                                                                     \
       Kokkos::View<KOKKOS_TYPE, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,      \
@@ -171,14 +163,11 @@ namespace Impl {
     }                                                                                                                  \
   };
 
-#define KOKKOSBLAS1_DOT_TPL_SPEC_DECL_ROCBLAS_EXT(ETI_SPEC_AVAIL)                                                     \
-  KOKKOSBLAS1_DOT_TPL_SPEC_DECL_ROCBLAS(float, float, rocblas_sdot, ETI_SPEC_AVAIL)                                   \
-  KOKKOSBLAS1_DOT_TPL_SPEC_DECL_ROCBLAS(double, double, rocblas_ddot, ETI_SPEC_AVAIL)                                 \
-  KOKKOSBLAS1_DOT_TPL_SPEC_DECL_ROCBLAS(Kokkos::complex<float>, rocblas_float_complex, rocblas_cdotc, ETI_SPEC_AVAIL) \
-  KOKKOSBLAS1_DOT_TPL_SPEC_DECL_ROCBLAS(Kokkos::complex<double>, rocblas_double_complex, rocblas_zdotc, ETI_SPEC_AVAIL)
+KOKKOSBLAS1_DOT_TPL_SPEC_DECL_ROCBLAS(float, float, rocblas_sdot)
+KOKKOSBLAS1_DOT_TPL_SPEC_DECL_ROCBLAS(double, double, rocblas_ddot)
+KOKKOSBLAS1_DOT_TPL_SPEC_DECL_ROCBLAS(Kokkos::complex<float>, rocblas_float_complex, rocblas_cdotc)
+KOKKOSBLAS1_DOT_TPL_SPEC_DECL_ROCBLAS(Kokkos::complex<double>, rocblas_double_complex, rocblas_zdotc)
 
-KOKKOSBLAS1_DOT_TPL_SPEC_DECL_ROCBLAS_EXT(true)
-KOKKOSBLAS1_DOT_TPL_SPEC_DECL_ROCBLAS_EXT(false)
 }  // namespace Impl
 }  // namespace KokkosBlas
 #endif
@@ -191,8 +180,8 @@ KOKKOSBLAS1_DOT_TPL_SPEC_DECL_ROCBLAS_EXT(false)
 
 namespace KokkosBlas {
 namespace Impl {
-#define KOKKOSBLAS1_DOT_TPL_SPEC_DECL_ONEMKL(KOKKOS_TYPE, TPL_TYPE, TPL_DOT, ETI_SPEC_AVAIL)                           \
-  template <>                                                                                                          \
+#define KOKKOSBLAS1_DOT_TPL_SPEC_DECL_ONEMKL(KOKKOS_TYPE, TPL_TYPE, TPL_DOT)                                           \
+  template <bool ETI_SPEC_AVAIL>                                                                                       \
   struct Dot<                                                                                                          \
       Kokkos::SYCL,                                                                                                    \
       Kokkos::View<KOKKOS_TYPE, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,      \
@@ -224,16 +213,11 @@ namespace Impl {
     }                                                                                                                  \
   };
 
-#define KOKKOSBLAS1_DOT_TPL_SPEC_DECL_ONEMKL_EXT(ETI_SPEC_AVAIL)                                          \
-  KOKKOSBLAS1_DOT_TPL_SPEC_DECL_ONEMKL(float, float, oneapi::mkl::blas::row_major::dot, ETI_SPEC_AVAIL)   \
-  KOKKOSBLAS1_DOT_TPL_SPEC_DECL_ONEMKL(double, double, oneapi::mkl::blas::row_major::dot, ETI_SPEC_AVAIL) \
-  KOKKOSBLAS1_DOT_TPL_SPEC_DECL_ONEMKL(Kokkos::complex<float>, std::complex<float>,                       \
-                                       oneapi::mkl::blas::row_major::dotc, ETI_SPEC_AVAIL)                \
-  KOKKOSBLAS1_DOT_TPL_SPEC_DECL_ONEMKL(Kokkos::complex<double>, std::complex<double>,                     \
-                                       oneapi::mkl::blas::row_major::dotc, ETI_SPEC_AVAIL)
+KOKKOSBLAS1_DOT_TPL_SPEC_DECL_ONEMKL(float, float, oneapi::mkl::blas::row_major::dot)
+KOKKOSBLAS1_DOT_TPL_SPEC_DECL_ONEMKL(double, double, oneapi::mkl::blas::row_major::dot)
+KOKKOSBLAS1_DOT_TPL_SPEC_DECL_ONEMKL(Kokkos::complex<float>, std::complex<float>, oneapi::mkl::blas::row_major::dotc)
+KOKKOSBLAS1_DOT_TPL_SPEC_DECL_ONEMKL(Kokkos::complex<double>, std::complex<double>, oneapi::mkl::blas::row_major::dotc)
 
-KOKKOSBLAS1_DOT_TPL_SPEC_DECL_ONEMKL_EXT(true)
-KOKKOSBLAS1_DOT_TPL_SPEC_DECL_ONEMKL_EXT(false)
 }  // namespace Impl
 }  // namespace KokkosBlas
 #endif

--- a/blas/tpls/KokkosBlas1_iamax_tpl_spec_decl.hpp
+++ b/blas/tpls/KokkosBlas1_iamax_tpl_spec_decl.hpp
@@ -30,8 +30,8 @@ inline void iamax_print_specialization() {
 namespace KokkosBlas {
 namespace Impl {
 
-#define KOKKOSBLAS1_XIAMAX_TPL_SPEC_DECL_BLAS(SCALAR_TYPE, BASE_SCALAR_TYPE, ETI_SPEC_AVAIL)                            \
-  template <typename ExecSpace>                                                                                         \
+#define KOKKOSBLAS1_XIAMAX_TPL_SPEC_DECL_BLAS(SCALAR_TYPE, BASE_SCALAR_TYPE)                                            \
+  template <typename ExecSpace, bool ETI_SPEC_AVAIL>                                                                    \
     requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)                                       \
   struct Iamax<                                                                                                         \
       ExecSpace,                                                                                                        \
@@ -66,29 +66,11 @@ namespace Impl {
     }                                                                                                                   \
   };
 
-#define KOKKOSBLAS1_DIAMAX_TPL_SPEC_DECL_BLAS(ETI_SPEC_AVAIL) \
-  KOKKOSBLAS1_XIAMAX_TPL_SPEC_DECL_BLAS(double, double, ETI_SPEC_AVAIL)
+KOKKOSBLAS1_XIAMAX_TPL_SPEC_DECL_BLAS(double, double)
+KOKKOSBLAS1_XIAMAX_TPL_SPEC_DECL_BLAS(float, float)
+KOKKOSBLAS1_XIAMAX_TPL_SPEC_DECL_BLAS(Kokkos::complex<double>, std::complex<double>)
+KOKKOSBLAS1_XIAMAX_TPL_SPEC_DECL_BLAS(Kokkos::complex<float>, std::complex<float>)
 
-#define KOKKOSBLAS1_SIAMAX_TPL_SPEC_DECL_BLAS(ETI_SPEC_AVAIL) \
-  KOKKOSBLAS1_XIAMAX_TPL_SPEC_DECL_BLAS(float, float, ETI_SPEC_AVAIL)
-
-#define KOKKOSBLAS1_ZIAMAX_TPL_SPEC_DECL_BLAS(ETI_SPEC_AVAIL) \
-  KOKKOSBLAS1_XIAMAX_TPL_SPEC_DECL_BLAS(Kokkos::complex<double>, std::complex<double>, ETI_SPEC_AVAIL)
-
-#define KOKKOSBLAS1_CIAMAX_TPL_SPEC_DECL_BLAS(ETI_SPEC_AVAIL) \
-  KOKKOSBLAS1_XIAMAX_TPL_SPEC_DECL_BLAS(Kokkos::complex<float>, std::complex<float>, ETI_SPEC_AVAIL)
-
-KOKKOSBLAS1_DIAMAX_TPL_SPEC_DECL_BLAS(true)
-KOKKOSBLAS1_DIAMAX_TPL_SPEC_DECL_BLAS(false)
-
-KOKKOSBLAS1_SIAMAX_TPL_SPEC_DECL_BLAS(true)
-KOKKOSBLAS1_SIAMAX_TPL_SPEC_DECL_BLAS(false)
-
-KOKKOSBLAS1_ZIAMAX_TPL_SPEC_DECL_BLAS(true)
-KOKKOSBLAS1_ZIAMAX_TPL_SPEC_DECL_BLAS(false)
-
-KOKKOSBLAS1_CIAMAX_TPL_SPEC_DECL_BLAS(true)
-KOKKOSBLAS1_CIAMAX_TPL_SPEC_DECL_BLAS(false)
 }  // namespace Impl
 }  // namespace KokkosBlas
 
@@ -104,9 +86,9 @@ namespace Impl {
 using CUBLAS_DEVICE_TYPE = Kokkos::Cuda;
 
 #define KOKKOSBLAS1_XIAMAX_TPL_SPEC_DECL_CUBLAS_WRAPPER(SCALAR_TYPE, CUDA_SCALAR_TYPE, CUBLAS_FN, INDEX_TYPE,          \
-                                                        EXEC_SPACE, ETI_SPEC_AVAIL, RET_DEVICE_TYPE,                   \
-                                                        CUBLAS_PTR_MODE_1, CUBLAS_PTR_MODE_2)                          \
-  template <>                                                                                                          \
+                                                        EXEC_SPACE, RET_DEVICE_TYPE, CUBLAS_PTR_MODE_1,                \
+                                                        CUBLAS_PTR_MODE_2)                                             \
+  template <bool ETI_SPEC_AVAIL>                                                                                       \
   struct Iamax<                                                                                                        \
       EXEC_SPACE,                                                                                                      \
       Kokkos::View<INDEX_TYPE, Kokkos::LayoutLeft, RET_DEVICE_TYPE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,         \
@@ -151,50 +133,41 @@ using CUBLAS_DEVICE_TYPE = Kokkos::Cuda;
     }                                                                                                                  \
   };
 
-#define KOKKOSBLAS1_XIAMAX_TPL_SPEC_DECL_CUBLAS(SCALAR_TYPE, CUDA_SCALAR_TYPE, CUBLAS_FN, INDEX_TYPE, ETI_SPEC_AVAIL) \
+#define KOKKOSBLAS1_XIAMAX_TPL_SPEC_DECL_CUBLAS(SCALAR_TYPE, CUDA_SCALAR_TYPE, CUBLAS_FN, INDEX_TYPE)                 \
   KOKKOSBLAS1_XIAMAX_TPL_SPEC_DECL_CUBLAS_WRAPPER(SCALAR_TYPE, CUDA_SCALAR_TYPE, CUBLAS_FN, INDEX_TYPE, Kokkos::Cuda, \
-                                                  ETI_SPEC_AVAIL, Kokkos::HostSpace, CUBLAS_POINTER_MODE_HOST,        \
+                                                  Kokkos::HostSpace, CUBLAS_POINTER_MODE_HOST,                        \
                                                   CUBLAS_POINTER_MODE_DEVICE)                                         \
   KOKKOSBLAS1_XIAMAX_TPL_SPEC_DECL_CUBLAS_WRAPPER(SCALAR_TYPE, CUDA_SCALAR_TYPE, CUBLAS_FN, INDEX_TYPE, Kokkos::Cuda, \
-                                                  ETI_SPEC_AVAIL, CUBLAS_DEVICE_TYPE, CUBLAS_POINTER_MODE_DEVICE,     \
+                                                  CUBLAS_DEVICE_TYPE, CUBLAS_POINTER_MODE_DEVICE,                     \
                                                   CUBLAS_POINTER_MODE_HOST)
 
-#define KOKKOSBLAS1_DIAMAX_TPL_SPEC_DECL_CUBLAS(INDEX_TYPE, ETI_SPEC_AVAIL) \
-  KOKKOSBLAS1_XIAMAX_TPL_SPEC_DECL_CUBLAS(double, double, cublasIdamax, INDEX_TYPE, ETI_SPEC_AVAIL)
+#define KOKKOSBLAS1_DIAMAX_TPL_SPEC_DECL_CUBLAS(INDEX_TYPE) \
+  KOKKOSBLAS1_XIAMAX_TPL_SPEC_DECL_CUBLAS(double, double, cublasIdamax, INDEX_TYPE)
 
-#define KOKKOSBLAS1_SIAMAX_TPL_SPEC_DECL_CUBLAS(INDEX_TYPE, ETI_SPEC_AVAIL) \
-  KOKKOSBLAS1_XIAMAX_TPL_SPEC_DECL_CUBLAS(float, float, cublasIsamax, INDEX_TYPE, ETI_SPEC_AVAIL)
+#define KOKKOSBLAS1_SIAMAX_TPL_SPEC_DECL_CUBLAS(INDEX_TYPE) \
+  KOKKOSBLAS1_XIAMAX_TPL_SPEC_DECL_CUBLAS(float, float, cublasIsamax, INDEX_TYPE)
 
-#define KOKKOSBLAS1_ZIAMAX_TPL_SPEC_DECL_CUBLAS(INDEX_TYPE, ETI_SPEC_AVAIL)                                   \
-  KOKKOSBLAS1_XIAMAX_TPL_SPEC_DECL_CUBLAS(Kokkos::complex<double>, cuDoubleComplex, cublasIzamax, INDEX_TYPE, \
-                                          ETI_SPEC_AVAIL)
+#define KOKKOSBLAS1_ZIAMAX_TPL_SPEC_DECL_CUBLAS(INDEX_TYPE) \
+  KOKKOSBLAS1_XIAMAX_TPL_SPEC_DECL_CUBLAS(Kokkos::complex<double>, cuDoubleComplex, cublasIzamax, INDEX_TYPE)
 
-#define KOKKOSBLAS1_CIAMAX_TPL_SPEC_DECL_CUBLAS(INDEX_TYPE, ETI_SPEC_AVAIL) \
-  KOKKOSBLAS1_XIAMAX_TPL_SPEC_DECL_CUBLAS(Kokkos::complex<float>, cuComplex, cublasIcamax, INDEX_TYPE, ETI_SPEC_AVAIL)
+#define KOKKOSBLAS1_CIAMAX_TPL_SPEC_DECL_CUBLAS(INDEX_TYPE) \
+  KOKKOSBLAS1_XIAMAX_TPL_SPEC_DECL_CUBLAS(Kokkos::complex<float>, cuComplex, cublasIcamax, INDEX_TYPE)
 
-KOKKOSBLAS1_DIAMAX_TPL_SPEC_DECL_CUBLAS(unsigned long, true)
-KOKKOSBLAS1_DIAMAX_TPL_SPEC_DECL_CUBLAS(unsigned long, false)
+KOKKOSBLAS1_DIAMAX_TPL_SPEC_DECL_CUBLAS(unsigned long)
 
-KOKKOSBLAS1_SIAMAX_TPL_SPEC_DECL_CUBLAS(unsigned long, true)
-KOKKOSBLAS1_SIAMAX_TPL_SPEC_DECL_CUBLAS(unsigned long, false)
+KOKKOSBLAS1_SIAMAX_TPL_SPEC_DECL_CUBLAS(unsigned long)
 
-KOKKOSBLAS1_ZIAMAX_TPL_SPEC_DECL_CUBLAS(unsigned long, true)
-KOKKOSBLAS1_ZIAMAX_TPL_SPEC_DECL_CUBLAS(unsigned long, false)
+KOKKOSBLAS1_ZIAMAX_TPL_SPEC_DECL_CUBLAS(unsigned long)
 
-KOKKOSBLAS1_CIAMAX_TPL_SPEC_DECL_CUBLAS(unsigned long, true)
-KOKKOSBLAS1_CIAMAX_TPL_SPEC_DECL_CUBLAS(unsigned long, false)
+KOKKOSBLAS1_CIAMAX_TPL_SPEC_DECL_CUBLAS(unsigned long)
 
-KOKKOSBLAS1_DIAMAX_TPL_SPEC_DECL_CUBLAS(unsigned int, true)
-KOKKOSBLAS1_DIAMAX_TPL_SPEC_DECL_CUBLAS(unsigned int, false)
+KOKKOSBLAS1_DIAMAX_TPL_SPEC_DECL_CUBLAS(unsigned int)
 
-KOKKOSBLAS1_SIAMAX_TPL_SPEC_DECL_CUBLAS(unsigned int, true)
-KOKKOSBLAS1_SIAMAX_TPL_SPEC_DECL_CUBLAS(unsigned int, false)
+KOKKOSBLAS1_SIAMAX_TPL_SPEC_DECL_CUBLAS(unsigned int)
 
-KOKKOSBLAS1_ZIAMAX_TPL_SPEC_DECL_CUBLAS(unsigned int, true)
-KOKKOSBLAS1_ZIAMAX_TPL_SPEC_DECL_CUBLAS(unsigned int, false)
+KOKKOSBLAS1_ZIAMAX_TPL_SPEC_DECL_CUBLAS(unsigned int)
 
-KOKKOSBLAS1_CIAMAX_TPL_SPEC_DECL_CUBLAS(unsigned int, true)
-KOKKOSBLAS1_CIAMAX_TPL_SPEC_DECL_CUBLAS(unsigned int, false)
+KOKKOSBLAS1_CIAMAX_TPL_SPEC_DECL_CUBLAS(unsigned int)
 
 }  // namespace Impl
 }  // namespace KokkosBlas
@@ -211,9 +184,8 @@ namespace Impl {
 using ROCBLAS_DEVICE_TYPE = Kokkos::HIP;
 
 #define KOKKOSBLAS1_XIAMAX_TPL_SPEC_DECL_ROCBLAS_WRAPPER(SCALAR_TYPE, ROCBLAS_SCALAR_TYPE, ROCBLAS_FN, INDEX_TYPE,    \
-                                                         ETI_SPEC_AVAIL, RET_DEVICE_TYPE, ROCBLAS_PTR_MODE_1,         \
-                                                         ROCBLAS_PTR_MODE_2)                                          \
-  template <>                                                                                                         \
+                                                         RET_DEVICE_TYPE, ROCBLAS_PTR_MODE_1, ROCBLAS_PTR_MODE_2)     \
+  template <bool ETI_SPEC_AVAIL>                                                                                      \
   struct Iamax<                                                                                                       \
       Kokkos::HIP,                                                                                                    \
       Kokkos::View<INDEX_TYPE, Kokkos::LayoutLeft, RET_DEVICE_TYPE, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,        \
@@ -260,52 +232,41 @@ using ROCBLAS_DEVICE_TYPE = Kokkos::HIP;
     }                                                                                                                 \
   };
 
-#define KOKKOSBLAS1_XIAMAX_TPL_SPEC_DECL_ROCBLAS(SCALAR_TYPE, ROCBLAS_SCALAR_TYPE, ROCBLAS_FN, INDEX_TYPE,           \
-                                                 ETI_SPEC_AVAIL)                                                     \
-  KOKKOSBLAS1_XIAMAX_TPL_SPEC_DECL_ROCBLAS_WRAPPER(SCALAR_TYPE, ROCBLAS_SCALAR_TYPE, ROCBLAS_FN, INDEX_TYPE,         \
-                                                   ETI_SPEC_AVAIL, Kokkos::HostSpace, rocblas_pointer_mode_host,     \
-                                                   rocblas_pointer_mode_device)                                      \
-  KOKKOSBLAS1_XIAMAX_TPL_SPEC_DECL_ROCBLAS_WRAPPER(SCALAR_TYPE, ROCBLAS_SCALAR_TYPE, ROCBLAS_FN, INDEX_TYPE,         \
-                                                   ETI_SPEC_AVAIL, ROCBLAS_DEVICE_TYPE, rocblas_pointer_mode_device, \
+#define KOKKOSBLAS1_XIAMAX_TPL_SPEC_DECL_ROCBLAS(SCALAR_TYPE, ROCBLAS_SCALAR_TYPE, ROCBLAS_FN, INDEX_TYPE)   \
+  KOKKOSBLAS1_XIAMAX_TPL_SPEC_DECL_ROCBLAS_WRAPPER(SCALAR_TYPE, ROCBLAS_SCALAR_TYPE, ROCBLAS_FN, INDEX_TYPE, \
+                                                   Kokkos::HostSpace, rocblas_pointer_mode_host,             \
+                                                   rocblas_pointer_mode_device)                              \
+  KOKKOSBLAS1_XIAMAX_TPL_SPEC_DECL_ROCBLAS_WRAPPER(SCALAR_TYPE, ROCBLAS_SCALAR_TYPE, ROCBLAS_FN, INDEX_TYPE, \
+                                                   ROCBLAS_DEVICE_TYPE, rocblas_pointer_mode_device,         \
                                                    rocblas_pointer_mode_host)
 
-#define KOKKOSBLAS1_DIAMAX_TPL_SPEC_DECL_ROCBLAS(INDEX_TYPE, ETI_SPEC_AVAIL) \
-  KOKKOSBLAS1_XIAMAX_TPL_SPEC_DECL_ROCBLAS(double, double, rocblas_idamax, INDEX_TYPE, ETI_SPEC_AVAIL)
+#define KOKKOSBLAS1_DIAMAX_TPL_SPEC_DECL_ROCBLAS(INDEX_TYPE) \
+  KOKKOSBLAS1_XIAMAX_TPL_SPEC_DECL_ROCBLAS(double, double, rocblas_idamax, INDEX_TYPE)
 
-#define KOKKOSBLAS1_SIAMAX_TPL_SPEC_DECL_ROCBLAS(INDEX_TYPE, ETI_SPEC_AVAIL) \
-  KOKKOSBLAS1_XIAMAX_TPL_SPEC_DECL_ROCBLAS(float, float, rocblas_isamax, INDEX_TYPE, ETI_SPEC_AVAIL)
+#define KOKKOSBLAS1_SIAMAX_TPL_SPEC_DECL_ROCBLAS(INDEX_TYPE) \
+  KOKKOSBLAS1_XIAMAX_TPL_SPEC_DECL_ROCBLAS(float, float, rocblas_isamax, INDEX_TYPE)
 
-#define KOKKOSBLAS1_ZIAMAX_TPL_SPEC_DECL_ROCBLAS(INDEX_TYPE, ETI_SPEC_AVAIL)                                \
-  KOKKOSBLAS1_XIAMAX_TPL_SPEC_DECL_ROCBLAS(Kokkos::complex<double>, rocblas_double_complex, rocblas_izamax, \
-                                           INDEX_TYPE, ETI_SPEC_AVAIL)
+#define KOKKOSBLAS1_ZIAMAX_TPL_SPEC_DECL_ROCBLAS(INDEX_TYPE) \
+  KOKKOSBLAS1_XIAMAX_TPL_SPEC_DECL_ROCBLAS(Kokkos::complex<double>, rocblas_double_complex, rocblas_izamax, INDEX_TYPE)
 
-#define KOKKOSBLAS1_CIAMAX_TPL_SPEC_DECL_ROCBLAS(INDEX_TYPE, ETI_SPEC_AVAIL)                                          \
-  KOKKOSBLAS1_XIAMAX_TPL_SPEC_DECL_ROCBLAS(Kokkos::complex<float>, rocblas_float_complex, rocblas_icamax, INDEX_TYPE, \
-                                           ETI_SPEC_AVAIL)
+#define KOKKOSBLAS1_CIAMAX_TPL_SPEC_DECL_ROCBLAS(INDEX_TYPE) \
+  KOKKOSBLAS1_XIAMAX_TPL_SPEC_DECL_ROCBLAS(Kokkos::complex<float>, rocblas_float_complex, rocblas_icamax, INDEX_TYPE)
 
-KOKKOSBLAS1_DIAMAX_TPL_SPEC_DECL_ROCBLAS(unsigned long, true)
-KOKKOSBLAS1_DIAMAX_TPL_SPEC_DECL_ROCBLAS(unsigned long, false)
+KOKKOSBLAS1_DIAMAX_TPL_SPEC_DECL_ROCBLAS(unsigned long)
 
-KOKKOSBLAS1_SIAMAX_TPL_SPEC_DECL_ROCBLAS(unsigned long, true)
-KOKKOSBLAS1_SIAMAX_TPL_SPEC_DECL_ROCBLAS(unsigned long, false)
+KOKKOSBLAS1_SIAMAX_TPL_SPEC_DECL_ROCBLAS(unsigned long)
 
-KOKKOSBLAS1_ZIAMAX_TPL_SPEC_DECL_ROCBLAS(unsigned long, true)
-KOKKOSBLAS1_ZIAMAX_TPL_SPEC_DECL_ROCBLAS(unsigned long, false)
+KOKKOSBLAS1_ZIAMAX_TPL_SPEC_DECL_ROCBLAS(unsigned long)
 
-KOKKOSBLAS1_CIAMAX_TPL_SPEC_DECL_ROCBLAS(unsigned long, true)
-KOKKOSBLAS1_CIAMAX_TPL_SPEC_DECL_ROCBLAS(unsigned long, false)
+KOKKOSBLAS1_CIAMAX_TPL_SPEC_DECL_ROCBLAS(unsigned long)
 
-KOKKOSBLAS1_DIAMAX_TPL_SPEC_DECL_ROCBLAS(unsigned int, true)
-KOKKOSBLAS1_DIAMAX_TPL_SPEC_DECL_ROCBLAS(unsigned int, false)
+KOKKOSBLAS1_DIAMAX_TPL_SPEC_DECL_ROCBLAS(unsigned int)
 
-KOKKOSBLAS1_SIAMAX_TPL_SPEC_DECL_ROCBLAS(unsigned int, true)
-KOKKOSBLAS1_SIAMAX_TPL_SPEC_DECL_ROCBLAS(unsigned int, false)
+KOKKOSBLAS1_SIAMAX_TPL_SPEC_DECL_ROCBLAS(unsigned int)
 
-KOKKOSBLAS1_ZIAMAX_TPL_SPEC_DECL_ROCBLAS(unsigned int, true)
-KOKKOSBLAS1_ZIAMAX_TPL_SPEC_DECL_ROCBLAS(unsigned int, false)
+KOKKOSBLAS1_ZIAMAX_TPL_SPEC_DECL_ROCBLAS(unsigned int)
 
-KOKKOSBLAS1_CIAMAX_TPL_SPEC_DECL_ROCBLAS(unsigned int, true)
-KOKKOSBLAS1_CIAMAX_TPL_SPEC_DECL_ROCBLAS(unsigned int, false)
+KOKKOSBLAS1_CIAMAX_TPL_SPEC_DECL_ROCBLAS(unsigned int)
 
 }  // namespace Impl
 }  // namespace KokkosBlas

--- a/blas/tpls/KokkosBlas1_nrm1_tpl_spec_decl.hpp
+++ b/blas/tpls/KokkosBlas1_nrm1_tpl_spec_decl.hpp
@@ -26,12 +26,12 @@ namespace KokkosBlas {
 namespace Impl {
 
 #define KOKKOSBLAS1_NRM1_TPL_SPEC_DECL_BLAS(SCALAR, EXECSPACE)                                                         \
-  template <>                                                                                                          \
+  template <bool ETI_SPEC_AVAIL>                                                                                       \
   struct Nrm1<EXECSPACE,                                                                                               \
               Kokkos::View<typename KokkosKernels::ArithTraits<SCALAR>::mag_type, Kokkos::LayoutLeft,                  \
                            Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                \
               Kokkos::View<const SCALAR*, Kokkos::LayoutLeft, EXECSPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, 1,  \
-              true> {                                                                                                  \
+              true, ETI_SPEC_AVAIL> {                                                                                  \
     using mag_type = typename KokkosKernels::ArithTraits<SCALAR>::mag_type;                                            \
     using RV = Kokkos::View<mag_type, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>; \
     using XV = Kokkos::View<const SCALAR*, Kokkos::LayoutLeft, EXECSPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;    \
@@ -51,7 +51,7 @@ namespace Impl {
           R() = HostBlas<SCALAR>::asum(N, X.data(), one);                                                              \
         }                                                                                                              \
       } else {                                                                                                         \
-        Nrm1<EXECSPACE, RV, XV, 1, false, nrm1_eti_spec_avail<EXECSPACE, RV, XV>::value>::nrm1(space, R, X);           \
+        Nrm1<EXECSPACE, RV, XV, 1, false, ETI_SPEC_AVAIL>::nrm1(space, R, X);                                          \
       }                                                                                                                \
       Kokkos::Profiling::popRegion();                                                                                  \
     }                                                                                                                  \
@@ -118,17 +118,12 @@ void cublasAsumWrapper(const ExecutionSpace& space, RViewType& R, const XViewTyp
 }
 
 #define KOKKOSBLAS1_NRM1_TPL_SPEC_DECL_CUBLAS(SCALAR)                                                                  \
-  template <>                                                                                                          \
-  struct Nrm1<                                                                                                         \
-      Kokkos::Cuda,                                                                                                    \
-      Kokkos::View<typename KokkosKernels::ArithTraits<SCALAR>::mag_type, Kokkos::LayoutLeft, Kokkos::HostSpace,       \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                           \
-      Kokkos::View<const SCALAR*, Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, 1, true, \
-      nrm1_eti_spec_avail<Kokkos::Cuda,                                                                                \
-                          Kokkos::View<typename KokkosKernels::ArithTraits<SCALAR>::mag_type, Kokkos::LayoutLeft,      \
-                                       Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                    \
-                          Kokkos::View<const SCALAR*, Kokkos::LayoutLeft, Kokkos::Cuda,                                \
-                                       Kokkos::MemoryTraits<Kokkos::Unmanaged>>>::value> {                             \
+  template <bool ETI_SPEC_AVAIL>                                                                                       \
+  struct Nrm1<Kokkos::Cuda,                                                                                            \
+              Kokkos::View<typename KokkosKernels::ArithTraits<SCALAR>::mag_type, Kokkos::LayoutLeft,                  \
+                           Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                \
+              Kokkos::View<const SCALAR*, Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,  \
+              1, true, ETI_SPEC_AVAIL> {                                                                               \
     using execution_space = Kokkos::Cuda;                                                                              \
     using RV              = Kokkos::View<typename KokkosKernels::ArithTraits<SCALAR>::mag_type, Kokkos::LayoutLeft,    \
                             Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                  \
@@ -141,7 +136,7 @@ void cublasAsumWrapper(const ExecutionSpace& space, RViewType& R, const XViewTyp
       if (numElems < static_cast<size_type>(INT_MAX)) {                                                                \
         cublasAsumWrapper(space, R, X);                                                                                \
       } else {                                                                                                         \
-        Nrm1<execution_space, RV, XV, 1, false, nrm1_eti_spec_avail<Kokkos::Cuda, RV, XV>::value>::nrm1(space, R, X);  \
+        Nrm1<execution_space, RV, XV, 1, false, ETI_SPEC_AVAIL>::nrm1(space, R, X);                                    \
       }                                                                                                                \
       Kokkos::Profiling::popRegion();                                                                                  \
     }                                                                                                                  \
@@ -191,17 +186,12 @@ void rocblasAsumWrapper(const ExecutionSpace& space, RViewType& R, const XViewTy
 }
 
 #define KOKKOSBLAS1_NRM1_TPL_SPEC_DECL_ROCBLAS(SCALAR)                                                                \
-  template <>                                                                                                         \
-  struct Nrm1<                                                                                                        \
-      Kokkos::HIP,                                                                                                    \
-      Kokkos::View<typename KokkosKernels::ArithTraits<SCALAR>::mag_type, Kokkos::LayoutLeft, Kokkos::HostSpace,      \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                          \
-      Kokkos::View<const SCALAR*, Kokkos::LayoutLeft, Kokkos::HIP, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, 1, true, \
-      nrm1_eti_spec_avail<Kokkos::HIP,                                                                                \
-                          Kokkos::View<typename KokkosKernels::ArithTraits<SCALAR>::mag_type, Kokkos::LayoutLeft,     \
-                                       Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                   \
-                          Kokkos::View<const SCALAR*, Kokkos::LayoutLeft, Kokkos::HIP,                                \
-                                       Kokkos::MemoryTraits<Kokkos::Unmanaged>>>::value> {                            \
+  template <bool ETI_SPEC_AVAIL>                                                                                      \
+  struct Nrm1<Kokkos::HIP,                                                                                            \
+              Kokkos::View<typename KokkosKernels::ArithTraits<SCALAR>::mag_type, Kokkos::LayoutLeft,                 \
+                           Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                               \
+              Kokkos::View<const SCALAR*, Kokkos::LayoutLeft, Kokkos::HIP, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,  \
+              1, true, ETI_SPEC_AVAIL> {                                                                              \
     using RV = Kokkos::View<typename KokkosKernels::ArithTraits<SCALAR>::mag_type, Kokkos::LayoutLeft,                \
                             Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                              \
     using XV = Kokkos::View<const SCALAR*, Kokkos::LayoutLeft, Kokkos::HIP, Kokkos::MemoryTraits<Kokkos::Unmanaged>>; \
@@ -213,7 +203,7 @@ void rocblasAsumWrapper(const ExecutionSpace& space, RViewType& R, const XViewTy
       if (numElems < static_cast<size_type>(INT_MAX)) {                                                               \
         rocblasAsumWrapper(space, R, X);                                                                              \
       } else {                                                                                                        \
-        Nrm1<Kokkos::HIP, RV, XV, 1, false, nrm1_eti_spec_avail<Kokkos::HIP, RV, XV>::value>::nrm1(space, R, X);      \
+        Nrm1<Kokkos::HIP, RV, XV, 1, false, ETI_SPEC_AVAIL>::nrm1(space, R, X);                                       \
       }                                                                                                               \
       Kokkos::Profiling::popRegion();                                                                                 \
     }                                                                                                                 \
@@ -275,17 +265,12 @@ void onemklAsumWrapper(const ExecutionSpace& space, RViewType& R, const XViewTyp
 }
 
 #define KOKKOSBLAS1_NRM1_ONEMKL(SCALAR)                                                                                \
-  template <>                                                                                                          \
-  struct Nrm1<                                                                                                         \
-      Kokkos::SYCL,                                                                                                    \
-      Kokkos::View<typename KokkosKernels::ArithTraits<SCALAR>::mag_type, Kokkos::LayoutLeft, Kokkos::HostSpace,       \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                           \
-      Kokkos::View<const SCALAR*, Kokkos::LayoutLeft, Kokkos::SYCL, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, 1, true, \
-      nrm1_eti_spec_avail<Kokkos::SYCL,                                                                                \
-                          Kokkos::View<typename KokkosKernels::ArithTraits<SCALAR>::mag_type, Kokkos::LayoutLeft,      \
-                                       Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                    \
-                          Kokkos::View<const SCALAR*, Kokkos::LayoutLeft, Kokkos::SYCL,                                \
-                                       Kokkos::MemoryTraits<Kokkos::Unmanaged>>>::value> {                             \
+  template <bool ETI_SPEC_AVAIL>                                                                                       \
+  struct Nrm1<Kokkos::SYCL,                                                                                            \
+              Kokkos::View<typename KokkosKernels::ArithTraits<SCALAR>::mag_type, Kokkos::LayoutLeft,                  \
+                           Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                \
+              Kokkos::View<const SCALAR*, Kokkos::LayoutLeft, Kokkos::SYCL, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,  \
+              1, true, ETI_SPEC_AVAIL> {                                                                               \
     using execution_space = Kokkos::SYCL;                                                                              \
     using RV              = Kokkos::View<typename KokkosKernels::ArithTraits<SCALAR>::mag_type, Kokkos::LayoutLeft,    \
                             Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                  \
@@ -298,7 +283,7 @@ void onemklAsumWrapper(const ExecutionSpace& space, RViewType& R, const XViewTyp
       if (numElems < static_cast<size_type>(INT_MAX)) {                                                                \
         onemklAsumWrapper(space, R, X);                                                                                \
       } else {                                                                                                         \
-        Nrm1<execution_space, RV, XV, 1, false, nrm1_eti_spec_avail<Kokkos::SYCL, RV, XV>::value>::nrm1(space, R, X);  \
+        Nrm1<execution_space, RV, XV, 1, false, ETI_SPEC_AVAIL>::nrm1(space, R, X);                                    \
       }                                                                                                                \
       Kokkos::Profiling::popRegion();                                                                                  \
     }                                                                                                                  \

--- a/blas/tpls/KokkosBlas1_nrm2_tpl_spec_decl.hpp
+++ b/blas/tpls/KokkosBlas1_nrm2_tpl_spec_decl.hpp
@@ -25,130 +25,116 @@ inline void nrm2_print_specialization() {
 namespace KokkosBlas {
 namespace Impl {
 
-#define KOKKOSBLAS1_DNRM2_TPL_SPEC_DECL_BLAS(ETI_SPEC_AVAIL)                                                           \
-  template <typename ExecSpace>                                                                                        \
-    requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)                                      \
-  struct Nrm2<ExecSpace,                                                                                               \
-              Kokkos::View<double, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,   \
-              Kokkos::View<const double*, Kokkos::LayoutLeft, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, 1, \
-              true, ETI_SPEC_AVAIL> {                                                                                  \
-    typedef Kokkos::View<double, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> > RV;  \
-    typedef Kokkos::View<const double*, Kokkos::LayoutLeft, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> > XV;   \
-    typedef typename XV::size_type size_type;                                                                          \
-                                                                                                                       \
-    static void nrm2(const ExecSpace& space, RV& R, const XV& X, const bool& take_sqrt) {                              \
-      Kokkos::Profiling::pushRegion("KokkosBlas::nrm2[TPL_BLAS,double]");                                              \
-      const size_type numElems = X.extent(0);                                                                          \
-      if (numElems < static_cast<size_type>(INT_MAX)) {                                                                \
-        nrm2_print_specialization<RV, XV>();                                                                           \
-        int N       = numElems;                                                                                        \
-        int int_one = 1;                                                                                               \
-        R()         = HostBlas<double>::nrm2(N, X.data(), int_one);                                                    \
-        if (!take_sqrt) R() = R() * R();                                                                               \
-      } else {                                                                                                         \
-        Nrm2<ExecSpace, RV, XV, 1, false, ETI_SPEC_AVAIL>::nrm2(space, R, X, take_sqrt);                               \
-      }                                                                                                                \
-      Kokkos::Profiling::popRegion();                                                                                  \
-    }                                                                                                                  \
-  };
+template <typename ExecSpace, bool ETI_SPEC_AVAIL>
+  requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)
+struct Nrm2<ExecSpace,
+            Kokkos::View<double, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,
+            Kokkos::View<const double*, Kokkos::LayoutLeft, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, 1,
+            true, ETI_SPEC_AVAIL> {
+  typedef Kokkos::View<double, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> > RV;
+  typedef Kokkos::View<const double*, Kokkos::LayoutLeft, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> > XV;
+  typedef typename XV::size_type size_type;
 
-#define KOKKOSBLAS1_SNRM2_TPL_SPEC_DECL_BLAS(ETI_SPEC_AVAIL)                                                          \
-  template <typename ExecSpace>                                                                                       \
-    requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)                                     \
-  struct Nrm2<ExecSpace,                                                                                              \
-              Kokkos::View<float, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,   \
-              Kokkos::View<const float*, Kokkos::LayoutLeft, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, 1, \
-              true, ETI_SPEC_AVAIL> {                                                                                 \
-    typedef Kokkos::View<float, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> > RV;  \
-    typedef Kokkos::View<const float*, Kokkos::LayoutLeft, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> > XV;   \
-    typedef typename XV::size_type size_type;                                                                         \
-                                                                                                                      \
-    static void nrm2(const ExecSpace& space, RV& R, const XV& X, const bool& take_sqrt) {                             \
-      Kokkos::Profiling::pushRegion("KokkosBlas::nrm2[TPL_BLAS,float]");                                              \
-      const size_type numElems = X.extent(0);                                                                         \
-      if (numElems < static_cast<size_type>(INT_MAX)) {                                                               \
-        nrm2_print_specialization<RV, XV>();                                                                          \
-        int N       = numElems;                                                                                       \
-        int int_one = 1;                                                                                              \
-        R()         = HostBlas<float>::nrm2(N, X.data(), int_one);                                                    \
-        if (!take_sqrt) R() = R() * R();                                                                              \
-      } else {                                                                                                        \
-        Nrm2<ExecSpace, RV, XV, 1, false, ETI_SPEC_AVAIL>::nrm2(space, R, X, take_sqrt);                              \
-      }                                                                                                               \
-      Kokkos::Profiling::popRegion();                                                                                 \
-    }                                                                                                                 \
-  };
+  static void nrm2(const ExecSpace& space, RV& R, const XV& X, const bool& take_sqrt) {
+    Kokkos::Profiling::pushRegion("KokkosBlas::nrm2[TPL_BLAS,double]");
+    const size_type numElems = X.extent(0);
+    if (numElems < static_cast<size_type>(INT_MAX)) {
+      nrm2_print_specialization<RV, XV>();
+      int N       = numElems;
+      int int_one = 1;
+      R()         = HostBlas<double>::nrm2(N, X.data(), int_one);
+      if (!take_sqrt) R() = R() * R();
+    } else {
+      Nrm2<ExecSpace, RV, XV, 1, false, ETI_SPEC_AVAIL>::nrm2(space, R, X, take_sqrt);
+    }
+    Kokkos::Profiling::popRegion();
+  }
+};
 
-#define KOKKOSBLAS1_ZNRM2_TPL_SPEC_DECL_BLAS(ETI_SPEC_AVAIL)                                                            \
-  template <typename ExecSpace>                                                                                         \
-    requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)                                       \
-  struct Nrm2<ExecSpace,                                                                                                \
-              Kokkos::View<double, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,    \
-              Kokkos::View<const Kokkos::complex<double>*, Kokkos::LayoutLeft, ExecSpace,                               \
-                           Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                   \
-              1, true, ETI_SPEC_AVAIL> {                                                                                \
-    typedef Kokkos::View<double, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> > RV;   \
-    typedef Kokkos::View<const Kokkos::complex<double>*, Kokkos::LayoutLeft, ExecSpace,                                 \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >                                                      \
-        XV;                                                                                                             \
-    typedef typename XV::size_type size_type;                                                                           \
-                                                                                                                        \
-    static void nrm2(const ExecSpace& space, RV& R, const XV& X, const bool& take_sqrt) {                               \
-      Kokkos::Profiling::pushRegion("KokkosBlas::nrm2[TPL_BLAS,complex<double>]");                                      \
-      const size_type numElems = X.extent(0);                                                                           \
-      if (numElems < static_cast<size_type>(INT_MAX)) {                                                                 \
-        nrm2_print_specialization<RV, XV>();                                                                            \
-        int N       = numElems;                                                                                         \
-        int int_one = 1;                                                                                                \
-        R()         = HostBlas<std::complex<double> >::nrm2(N, reinterpret_cast<const std::complex<double>*>(X.data()), \
-                                                            int_one);                                                   \
-        if (!take_sqrt) R() = R() * R();                                                                                \
-      } else {                                                                                                          \
-        Nrm2<ExecSpace, RV, XV, 1, false, ETI_SPEC_AVAIL>::nrm2(space, R, X, take_sqrt);                                \
-      }                                                                                                                 \
-      Kokkos::Profiling::popRegion();                                                                                   \
-    }                                                                                                                   \
-  };
+template <typename ExecSpace, bool ETI_SPEC_AVAIL>
+  requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)
+struct Nrm2<ExecSpace,
+            Kokkos::View<float, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,
+            Kokkos::View<const float*, Kokkos::LayoutLeft, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, 1,
+            true, ETI_SPEC_AVAIL> {
+  typedef Kokkos::View<float, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> > RV;
+  typedef Kokkos::View<const float*, Kokkos::LayoutLeft, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> > XV;
+  typedef typename XV::size_type size_type;
 
-#define KOKKOSBLAS1_CNRM2_TPL_SPEC_DECL_BLAS(ETI_SPEC_AVAIL)                                                          \
-  template <typename ExecSpace>                                                                                       \
-    requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)                                     \
-  struct Nrm2<ExecSpace,                                                                                              \
-              Kokkos::View<float, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,   \
-              Kokkos::View<const Kokkos::complex<float>*, Kokkos::LayoutLeft, ExecSpace,                              \
-                           Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                                 \
-              1, true, ETI_SPEC_AVAIL> {                                                                              \
-    typedef Kokkos::View<float, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> > RV;  \
-    typedef Kokkos::View<const Kokkos::complex<float>*, Kokkos::LayoutLeft, ExecSpace,                                \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >                                                    \
-        XV;                                                                                                           \
-    typedef typename XV::size_type size_type;                                                                         \
-                                                                                                                      \
-    static void nrm2(const ExecSpace& space, RV& R, const XV& X, const bool& take_sqrt) {                             \
-      Kokkos::Profiling::pushRegion("KokkosBlas::nrm2[TPL_BLAS,complex<float>]");                                     \
-      const size_type numElems = X.extent(0);                                                                         \
-      if (numElems < static_cast<size_type>(INT_MAX)) {                                                               \
-        nrm2_print_specialization<RV, XV>();                                                                          \
-        int N       = numElems;                                                                                       \
-        int int_one = 1;                                                                                              \
-        R() =                                                                                                         \
-            HostBlas<std::complex<float> >::nrm2(N, reinterpret_cast<const std::complex<float>*>(X.data()), int_one); \
-        if (!take_sqrt) R() = R() * R();                                                                              \
-      } else {                                                                                                        \
-        Nrm2<ExecSpace, RV, XV, 1, false, ETI_SPEC_AVAIL>::nrm2(space, R, X, take_sqrt);                              \
-      }                                                                                                               \
-      Kokkos::Profiling::popRegion();                                                                                 \
-    }                                                                                                                 \
-  };
+  static void nrm2(const ExecSpace& space, RV& R, const XV& X, const bool& take_sqrt) {
+    Kokkos::Profiling::pushRegion("KokkosBlas::nrm2[TPL_BLAS,float]");
+    const size_type numElems = X.extent(0);
+    if (numElems < static_cast<size_type>(INT_MAX)) {
+      nrm2_print_specialization<RV, XV>();
+      int N       = numElems;
+      int int_one = 1;
+      R()         = HostBlas<float>::nrm2(N, X.data(), int_one);
+      if (!take_sqrt) R() = R() * R();
+    } else {
+      Nrm2<ExecSpace, RV, XV, 1, false, ETI_SPEC_AVAIL>::nrm2(space, R, X, take_sqrt);
+    }
+    Kokkos::Profiling::popRegion();
+  }
+};
 
-KOKKOSBLAS1_DNRM2_TPL_SPEC_DECL_BLAS(true)
-KOKKOSBLAS1_DNRM2_TPL_SPEC_DECL_BLAS(false)
-KOKKOSBLAS1_SNRM2_TPL_SPEC_DECL_BLAS(true)
-KOKKOSBLAS1_SNRM2_TPL_SPEC_DECL_BLAS(false)
-KOKKOSBLAS1_ZNRM2_TPL_SPEC_DECL_BLAS(true)
-KOKKOSBLAS1_ZNRM2_TPL_SPEC_DECL_BLAS(false)
-KOKKOSBLAS1_CNRM2_TPL_SPEC_DECL_BLAS(true)
-KOKKOSBLAS1_CNRM2_TPL_SPEC_DECL_BLAS(false)
+template <typename ExecSpace, bool ETI_SPEC_AVAIL>
+  requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)
+struct Nrm2<ExecSpace,
+            Kokkos::View<double, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,
+            Kokkos::View<const Kokkos::complex<double>*, Kokkos::LayoutLeft, ExecSpace,
+                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >,
+            1, true, ETI_SPEC_AVAIL> {
+  typedef Kokkos::View<double, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> > RV;
+  typedef Kokkos::View<const Kokkos::complex<double>*, Kokkos::LayoutLeft, ExecSpace,
+                       Kokkos::MemoryTraits<Kokkos::Unmanaged> >
+      XV;
+  typedef typename XV::size_type size_type;
+
+  static void nrm2(const ExecSpace& space, RV& R, const XV& X, const bool& take_sqrt) {
+    Kokkos::Profiling::pushRegion("KokkosBlas::nrm2[TPL_BLAS,complex<double>]");
+    const size_type numElems = X.extent(0);
+    if (numElems < static_cast<size_type>(INT_MAX)) {
+      nrm2_print_specialization<RV, XV>();
+      int N       = numElems;
+      int int_one = 1;
+      R() = HostBlas<std::complex<double> >::nrm2(N, reinterpret_cast<const std::complex<double>*>(X.data()), int_one);
+      if (!take_sqrt) R() = R() * R();
+    } else {
+      Nrm2<ExecSpace, RV, XV, 1, false, ETI_SPEC_AVAIL>::nrm2(space, R, X, take_sqrt);
+    }
+    Kokkos::Profiling::popRegion();
+  }
+};
+
+template <typename ExecSpace, bool ETI_SPEC_AVAIL>
+  requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)
+struct Nrm2<ExecSpace,
+            Kokkos::View<float, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,
+            Kokkos::View<const Kokkos::complex<float>*, Kokkos::LayoutLeft, ExecSpace,
+                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >,
+            1, true, ETI_SPEC_AVAIL> {
+  typedef Kokkos::View<float, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> > RV;
+  typedef Kokkos::View<const Kokkos::complex<float>*, Kokkos::LayoutLeft, ExecSpace,
+                       Kokkos::MemoryTraits<Kokkos::Unmanaged> >
+      XV;
+  typedef typename XV::size_type size_type;
+
+  static void nrm2(const ExecSpace& space, RV& R, const XV& X, const bool& take_sqrt) {
+    Kokkos::Profiling::pushRegion("KokkosBlas::nrm2[TPL_BLAS,complex<float>]");
+    const size_type numElems = X.extent(0);
+    if (numElems < static_cast<size_type>(INT_MAX)) {
+      nrm2_print_specialization<RV, XV>();
+      int N       = numElems;
+      int int_one = 1;
+      R() = HostBlas<std::complex<float> >::nrm2(N, reinterpret_cast<const std::complex<float>*>(X.data()), int_one);
+      if (!take_sqrt) R() = R() * R();
+    } else {
+      Nrm2<ExecSpace, RV, XV, 1, false, ETI_SPEC_AVAIL>::nrm2(space, R, X, take_sqrt);
+    }
+    Kokkos::Profiling::popRegion();
+  }
+};
+
 }  // namespace Impl
 }  // namespace KokkosBlas
 
@@ -160,8 +146,8 @@ KOKKOSBLAS1_CNRM2_TPL_SPEC_DECL_BLAS(false)
 namespace KokkosBlas {
 namespace Impl {
 
-#define KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_CUBLAS(KOKKOS_TYPE, TPL_TYPE, TPL_NRM2, ETI_SPEC_AVAIL)                         \
-  template <>                                                                                                          \
+#define KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_CUBLAS(KOKKOS_TYPE, TPL_TYPE, TPL_NRM2)                                         \
+  template <bool ETI_SPEC_AVAIL>                                                                                       \
   struct Nrm2<                                                                                                         \
       Kokkos::Cuda,                                                                                                    \
       Kokkos::View<KokkosKernels::ArithTraits<KOKKOS_TYPE>::mag_type, Kokkos::LayoutLeft, Kokkos::HostSpace,           \
@@ -193,14 +179,10 @@ namespace Impl {
     }                                                                                                                  \
   };
 
-#define KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_CUBLAS_EXT(ETI_SPEC_AVAIL)                                        \
-  KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_CUBLAS(float, float, cublasSnrm2, ETI_SPEC_AVAIL)                       \
-  KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_CUBLAS(double, double, cublasDnrm2, ETI_SPEC_AVAIL)                     \
-  KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_CUBLAS(Kokkos::complex<float>, cuComplex, cublasScnrm2, ETI_SPEC_AVAIL) \
-  KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_CUBLAS(Kokkos::complex<double>, cuDoubleComplex, cublasDznrm2, ETI_SPEC_AVAIL)
-
-KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_CUBLAS_EXT(true)
-KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_CUBLAS_EXT(false)
+KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_CUBLAS(float, float, cublasSnrm2)
+KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_CUBLAS(double, double, cublasDnrm2)
+KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_CUBLAS(Kokkos::complex<float>, cuComplex, cublasScnrm2)
+KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_CUBLAS(Kokkos::complex<double>, cuDoubleComplex, cublasDznrm2)
 
 }  // namespace Impl
 }  // namespace KokkosBlas
@@ -213,8 +195,8 @@ KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_CUBLAS_EXT(false)
 namespace KokkosBlas {
 namespace Impl {
 
-#define KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_ROCBLAS(KOKKOS_TYPE, TPL_TYPE, TPL_NRM2, ETI_SPEC_AVAIL)                       \
-  template <>                                                                                                         \
+#define KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_ROCBLAS(KOKKOS_TYPE, TPL_TYPE, TPL_NRM2)                                       \
+  template <bool ETI_SPEC_AVAIL>                                                                                      \
   struct Nrm2<                                                                                                        \
       Kokkos::HIP,                                                                                                    \
       Kokkos::View<KokkosKernels::ArithTraits<KOKKOS_TYPE>::mag_type, Kokkos::LayoutLeft, Kokkos::HostSpace,          \
@@ -247,16 +229,10 @@ namespace Impl {
     }                                                                                                                 \
   };
 
-#define KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_ROCBLAS_EXT(ETI_SPEC_AVAIL)                                        \
-  KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_ROCBLAS(float, float, rocblas_snrm2, ETI_SPEC_AVAIL)                     \
-  KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_ROCBLAS(double, double, rocblas_dnrm2, ETI_SPEC_AVAIL)                   \
-  KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_ROCBLAS(Kokkos::complex<float>, rocblas_float_complex, rocblas_scnrm2,   \
-                                         ETI_SPEC_AVAIL)                                                  \
-  KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_ROCBLAS(Kokkos::complex<double>, rocblas_double_complex, rocblas_dznrm2, \
-                                         ETI_SPEC_AVAIL)
-
-KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_ROCBLAS_EXT(true)
-KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_ROCBLAS_EXT(false)
+KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_ROCBLAS(float, float, rocblas_snrm2)
+KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_ROCBLAS(double, double, rocblas_dnrm2)
+KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_ROCBLAS(Kokkos::complex<float>, rocblas_float_complex, rocblas_scnrm2)
+KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_ROCBLAS(Kokkos::complex<double>, rocblas_double_complex, rocblas_dznrm2)
 
 }  // namespace Impl
 }  // namespace KokkosBlas
@@ -271,8 +247,8 @@ KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_ROCBLAS_EXT(false)
 namespace KokkosBlas {
 namespace Impl {
 
-#define KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_ONEMKL(KOKKOS_TYPE, TPL_TYPE, TPL_NRM2, ETI_SPEC_AVAIL)                         \
-  template <>                                                                                                          \
+#define KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_ONEMKL(KOKKOS_TYPE, TPL_TYPE, TPL_NRM2)                                         \
+  template <bool ETI_SPEC_AVAIL>                                                                                       \
   struct Nrm2<                                                                                                         \
       Kokkos::SYCL,                                                                                                    \
       Kokkos::View<KokkosKernels::ArithTraits<KOKKOS_TYPE>::mag_type, Kokkos::LayoutLeft, Kokkos::HostSpace,           \
@@ -303,16 +279,10 @@ namespace Impl {
     }                                                                                                                  \
   };
 
-#define KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_ONEMKL_EXT(ETI_SPEC_AVAIL)                                           \
-  KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_ONEMKL(float, float, oneapi::mkl::blas::row_major::nrm2, ETI_SPEC_AVAIL)   \
-  KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_ONEMKL(double, double, oneapi::mkl::blas::row_major::nrm2, ETI_SPEC_AVAIL) \
-  KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_ONEMKL(Kokkos::complex<float>, std::complex<float>,                        \
-                                        oneapi::mkl::blas::row_major::nrm2, ETI_SPEC_AVAIL)                 \
-  KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_ONEMKL(Kokkos::complex<double>, std::complex<double>,                      \
-                                        oneapi::mkl::blas::row_major::nrm2, ETI_SPEC_AVAIL)
-
-KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_ONEMKL_EXT(true)
-KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_ONEMKL_EXT(false)
+KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_ONEMKL(float, float, oneapi::mkl::blas::row_major::nrm2)
+KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_ONEMKL(double, double, oneapi::mkl::blas::row_major::nrm2)
+KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_ONEMKL(Kokkos::complex<float>, std::complex<float>, oneapi::mkl::blas::row_major::nrm2)
+KOKKOSBLAS1_NRM2_TPL_SPEC_DECL_ONEMKL(Kokkos::complex<double>, std::complex<double>, oneapi::mkl::blas::row_major::nrm2)
 
 }  // namespace Impl
 }  // namespace KokkosBlas

--- a/blas/tpls/KokkosBlas1_nrminf_tpl_spec_decl.hpp
+++ b/blas/tpls/KokkosBlas1_nrminf_tpl_spec_decl.hpp
@@ -25,154 +25,137 @@ inline void nrminf_print_specialization() {
 namespace KokkosBlas {
 namespace Impl {
 
-#define KOKKOSBLAS1_DNRMINF_TPL_SPEC_DECL_BLAS(ETI_SPEC_AVAIL)                                                        \
-  template <typename ExecSpace>                                                                                       \
-    requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)                                     \
-  struct NrmInf<ExecSpace,                                                                                            \
-                Kokkos::View<double, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
-                Kokkos::View<const double*, Kokkos::LayoutLeft, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,  \
-                1, true, ETI_SPEC_AVAIL> {                                                                            \
-    typedef Kokkos::View<double, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>> RV;  \
-    typedef Kokkos::View<const double*, Kokkos::LayoutLeft, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>> XV;   \
-    typedef typename XV::size_type size_type;                                                                         \
-    typedef KokkosKernels::Details::InnerProductSpaceTraits<double> IPT;                                              \
-                                                                                                                      \
-    static void nrminf(const ExecSpace& space, RV& R, const XV& X) {                                                  \
-      Kokkos::Profiling::pushRegion("KokkosBlas::nrminf[TPL_BLAS,double]");                                           \
-      const size_type numElems = X.extent(0);                                                                         \
-      if (numElems == 0) {                                                                                            \
-        R() = 0.0;                                                                                                    \
-        return;                                                                                                       \
-      }                                                                                                               \
-      if (numElems < static_cast<size_type>(INT_MAX)) {                                                               \
-        nrminf_print_specialization<RV, XV>();                                                                        \
-        int N   = numElems;                                                                                           \
-        int one = 1;                                                                                                  \
-        int idx = HostBlas<double>::iamax(N, X.data(), one) - 1;                                                      \
-        R()     = IPT::norm(X(idx));                                                                                  \
-      } else {                                                                                                        \
-        NrmInf<ExecSpace, RV, XV, 1, false, ETI_SPEC_AVAIL>::nrminf(space, R, X);                                     \
-      }                                                                                                               \
-      Kokkos::Profiling::popRegion();                                                                                 \
-    }                                                                                                                 \
-  };
+template <typename ExecSpace, bool ETI_SPEC_AVAIL>
+  requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)
+struct NrmInf<ExecSpace,
+              Kokkos::View<double, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,
+              Kokkos::View<const double*, Kokkos::LayoutLeft, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, 1,
+              true, ETI_SPEC_AVAIL> {
+  typedef Kokkos::View<double, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>> RV;
+  typedef Kokkos::View<const double*, Kokkos::LayoutLeft, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>> XV;
+  typedef typename XV::size_type size_type;
+  typedef KokkosKernels::Details::InnerProductSpaceTraits<double> IPT;
 
-#define KOKKOSBLAS1_SNRMINF_TPL_SPEC_DECL_BLAS(ETI_SPEC_AVAIL)                                                         \
-  template <typename ExecSpace>                                                                                        \
-    requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)                                      \
-  struct NrmInf<ExecSpace,                                                                                             \
-                Kokkos::View<float, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,   \
-                Kokkos::View<const float*, Kokkos::LayoutLeft, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, 1, \
-                true, ETI_SPEC_AVAIL> {                                                                                \
-    typedef Kokkos::View<float, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>> RV;    \
-    typedef Kokkos::View<const float*, Kokkos::LayoutLeft, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>> XV;     \
-    typedef typename XV::size_type size_type;                                                                          \
-    typedef KokkosKernels::Details::InnerProductSpaceTraits<float> IPT;                                                \
-                                                                                                                       \
-    static void nrminf(const ExecSpace& space, RV& R, const XV& X) {                                                   \
-      Kokkos::Profiling::pushRegion("KokkosBlas::nrminf[TPL_BLAS,float]");                                             \
-      const size_type numElems = X.extent(0);                                                                          \
-      if (numElems == 0) {                                                                                             \
-        R() = 0.0f;                                                                                                    \
-        return;                                                                                                        \
-      }                                                                                                                \
-      if (numElems < static_cast<size_type>(INT_MAX)) {                                                                \
-        nrminf_print_specialization<RV, XV>();                                                                         \
-        int N   = numElems;                                                                                            \
-        int one = 1;                                                                                                   \
-        int idx = HostBlas<float>::iamax(N, X.data(), one) - 1;                                                        \
-        R()     = IPT::norm(X(idx));                                                                                   \
-      } else {                                                                                                         \
-        NrmInf<ExecSpace, RV, XV, 1, false, ETI_SPEC_AVAIL>::nrminf(space, R, X);                                      \
-      }                                                                                                                \
-      Kokkos::Profiling::popRegion();                                                                                  \
-    }                                                                                                                  \
-  };
+  static void nrminf(const ExecSpace& space, RV& R, const XV& X) {
+    Kokkos::Profiling::pushRegion("KokkosBlas::nrminf[TPL_BLAS,double]");
+    const size_type numElems = X.extent(0);
+    if (numElems == 0) {
+      R() = 0.0;
+      return;
+    }
+    if (numElems < static_cast<size_type>(INT_MAX)) {
+      nrminf_print_specialization<RV, XV>();
+      int N   = numElems;
+      int one = 1;
+      int idx = HostBlas<double>::iamax(N, X.data(), one) - 1;
+      R()     = IPT::norm(X(idx));
+    } else {
+      NrmInf<ExecSpace, RV, XV, 1, false, ETI_SPEC_AVAIL>::nrminf(space, R, X);
+    }
+    Kokkos::Profiling::popRegion();
+  }
+};
 
-#define KOKKOSBLAS1_ZNRMINF_TPL_SPEC_DECL_BLAS(ETI_SPEC_AVAIL)                                                        \
-  template <typename ExecSpace>                                                                                       \
-    requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)                                     \
-  struct NrmInf<ExecSpace,                                                                                            \
-                Kokkos::View<double, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
-                Kokkos::View<const Kokkos::complex<double>*, Kokkos::LayoutLeft, ExecSpace,                           \
-                             Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                \
-                1, true, ETI_SPEC_AVAIL> {                                                                            \
-    typedef Kokkos::View<double, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>> RV;  \
-    typedef Kokkos::View<const Kokkos::complex<double>*, Kokkos::LayoutLeft, ExecSpace,                               \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged>>                                                     \
-        XV;                                                                                                           \
-    typedef typename XV::size_type size_type;                                                                         \
-    typedef KokkosKernels::Details::InnerProductSpaceTraits<Kokkos::complex<double>> IPT;                             \
-                                                                                                                      \
-    static void nrminf(const ExecSpace& space, RV& R, const XV& X) {                                                  \
-      Kokkos::Profiling::pushRegion("KokkosBlas::nrminf[TPL_BLAS,complex<double>]");                                  \
-      const size_type numElems = X.extent(0);                                                                         \
-      if (numElems == 0) {                                                                                            \
-        R() = 0.0;                                                                                                    \
-        return;                                                                                                       \
-      }                                                                                                               \
-      if (numElems < static_cast<size_type>(INT_MAX)) {                                                               \
-        nrminf_print_specialization<RV, XV>();                                                                        \
-        int N   = numElems;                                                                                           \
-        int one = 1;                                                                                                  \
-        int idx =                                                                                                     \
-            HostBlas<std::complex<double>>::iamax(N, reinterpret_cast<const std::complex<double>*>(X.data()), one) -  \
-            1;                                                                                                        \
-        R() = IPT::norm(X(idx));                                                                                      \
-      } else {                                                                                                        \
-        NrmInf<ExecSpace, RV, XV, 1, false, ETI_SPEC_AVAIL>::nrminf(space, R, X);                                     \
-      }                                                                                                               \
-      Kokkos::Profiling::popRegion();                                                                                 \
-    }                                                                                                                 \
-  };
+template <typename ExecSpace, bool ETI_SPEC_AVAIL>
+  requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)
+struct NrmInf<ExecSpace,
+              Kokkos::View<float, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,
+              Kokkos::View<const float*, Kokkos::LayoutLeft, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, 1,
+              true, ETI_SPEC_AVAIL> {
+  typedef Kokkos::View<float, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>> RV;
+  typedef Kokkos::View<const float*, Kokkos::LayoutLeft, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>> XV;
+  typedef typename XV::size_type size_type;
+  typedef KokkosKernels::Details::InnerProductSpaceTraits<float> IPT;
 
-#define KOKKOSBLAS1_CNRMINF_TPL_SPEC_DECL_BLAS(ETI_SPEC_AVAIL)                                                        \
-  template <typename ExecSpace>                                                                                       \
-    requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)                                     \
-  struct NrmInf<ExecSpace,                                                                                            \
-                Kokkos::View<float, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,  \
-                Kokkos::View<const Kokkos::complex<float>*, Kokkos::LayoutLeft, ExecSpace,                            \
-                             Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                \
-                1, true, ETI_SPEC_AVAIL> {                                                                            \
-    typedef Kokkos::View<float, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>> RV;   \
-    typedef Kokkos::View<const Kokkos::complex<float>*, Kokkos::LayoutLeft, ExecSpace,                                \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged>>                                                     \
-        XV;                                                                                                           \
-    typedef typename XV::size_type size_type;                                                                         \
-    typedef KokkosKernels::Details::InnerProductSpaceTraits<Kokkos::complex<float>> IPT;                              \
-                                                                                                                      \
-    static void nrminf(const ExecSpace& space, RV& R, const XV& X) {                                                  \
-      Kokkos::Profiling::pushRegion("KokkosBlas::nrminf[TPL_BLAS,complex<float>]");                                   \
-      const size_type numElems = X.extent(0);                                                                         \
-      if (numElems == 0) {                                                                                            \
-        R() = 0.0f;                                                                                                   \
-        return;                                                                                                       \
-      }                                                                                                               \
-      if (numElems < static_cast<size_type>(INT_MAX)) {                                                               \
-        nrminf_print_specialization<RV, XV>();                                                                        \
-        int N   = numElems;                                                                                           \
-        int one = 1;                                                                                                  \
-        int idx =                                                                                                     \
-            HostBlas<std::complex<float>>::iamax(N, reinterpret_cast<const std::complex<float>*>(X.data()), one) - 1; \
-        R() = IPT::norm(X(idx));                                                                                      \
-      } else {                                                                                                        \
-        NrmInf<ExecSpace, RV, XV, 1, false, ETI_SPEC_AVAIL>::nrminf(space, R, X);                                     \
-      }                                                                                                               \
-      Kokkos::Profiling::popRegion();                                                                                 \
-    }                                                                                                                 \
-  };
+  static void nrminf(const ExecSpace& space, RV& R, const XV& X) {
+    Kokkos::Profiling::pushRegion("KokkosBlas::nrminf[TPL_BLAS,float]");
+    const size_type numElems = X.extent(0);
+    if (numElems == 0) {
+      R() = 0.0f;
+      return;
+    }
+    if (numElems < static_cast<size_type>(INT_MAX)) {
+      nrminf_print_specialization<RV, XV>();
+      int N   = numElems;
+      int one = 1;
+      int idx = HostBlas<float>::iamax(N, X.data(), one) - 1;
+      R()     = IPT::norm(X(idx));
+    } else {
+      NrmInf<ExecSpace, RV, XV, 1, false, ETI_SPEC_AVAIL>::nrminf(space, R, X);
+    }
+    Kokkos::Profiling::popRegion();
+  }
+};
 
-KOKKOSBLAS1_DNRMINF_TPL_SPEC_DECL_BLAS(true)
-KOKKOSBLAS1_DNRMINF_TPL_SPEC_DECL_BLAS(false)
+template <typename ExecSpace, bool ETI_SPEC_AVAIL>
+  requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)
+struct NrmInf<ExecSpace,
+              Kokkos::View<double, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,
+              Kokkos::View<const Kokkos::complex<double>*, Kokkos::LayoutLeft, ExecSpace,
+                           Kokkos::MemoryTraits<Kokkos::Unmanaged>>,
+              1, true, ETI_SPEC_AVAIL> {
+  typedef Kokkos::View<double, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>> RV;
+  typedef Kokkos::View<const Kokkos::complex<double>*, Kokkos::LayoutLeft, ExecSpace,
+                       Kokkos::MemoryTraits<Kokkos::Unmanaged>>
+      XV;
+  typedef typename XV::size_type size_type;
+  typedef KokkosKernels::Details::InnerProductSpaceTraits<Kokkos::complex<double>> IPT;
 
-KOKKOSBLAS1_SNRMINF_TPL_SPEC_DECL_BLAS(true)
-KOKKOSBLAS1_SNRMINF_TPL_SPEC_DECL_BLAS(false)
+  static void nrminf(const ExecSpace& space, RV& R, const XV& X) {
+    Kokkos::Profiling::pushRegion("KokkosBlas::nrminf[TPL_BLAS,complex<double>]");
+    const size_type numElems = X.extent(0);
+    if (numElems == 0) {
+      R() = 0.0;
+      return;
+    }
+    if (numElems < static_cast<size_type>(INT_MAX)) {
+      nrminf_print_specialization<RV, XV>();
+      int N   = numElems;
+      int one = 1;
+      int idx =
+          HostBlas<std::complex<double>>::iamax(N, reinterpret_cast<const std::complex<double>*>(X.data()), one) - 1;
+      R() = IPT::norm(X(idx));
+    } else {
+      NrmInf<ExecSpace, RV, XV, 1, false, ETI_SPEC_AVAIL>::nrminf(space, R, X);
+    }
+    Kokkos::Profiling::popRegion();
+  }
+};
 
-KOKKOSBLAS1_ZNRMINF_TPL_SPEC_DECL_BLAS(true)
-KOKKOSBLAS1_ZNRMINF_TPL_SPEC_DECL_BLAS(false)
+template <typename ExecSpace, bool ETI_SPEC_AVAIL>
+  requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)
+struct NrmInf<
+    ExecSpace, Kokkos::View<float, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,
+    Kokkos::View<const Kokkos::complex<float>*, Kokkos::LayoutLeft, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,
+    1, true, ETI_SPEC_AVAIL> {
+  typedef Kokkos::View<float, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>> RV;
+  typedef Kokkos::View<const Kokkos::complex<float>*, Kokkos::LayoutLeft, ExecSpace,
+                       Kokkos::MemoryTraits<Kokkos::Unmanaged>>
+      XV;
+  typedef typename XV::size_type size_type;
+  typedef KokkosKernels::Details::InnerProductSpaceTraits<Kokkos::complex<float>> IPT;
 
-KOKKOSBLAS1_CNRMINF_TPL_SPEC_DECL_BLAS(true)
-KOKKOSBLAS1_CNRMINF_TPL_SPEC_DECL_BLAS(false)
+  static void nrminf(const ExecSpace& space, RV& R, const XV& X) {
+    Kokkos::Profiling::pushRegion("KokkosBlas::nrminf[TPL_BLAS,complex<float>]");
+    const size_type numElems = X.extent(0);
+    if (numElems == 0) {
+      R() = 0.0f;
+      return;
+    }
+    if (numElems < static_cast<size_type>(INT_MAX)) {
+      nrminf_print_specialization<RV, XV>();
+      int N   = numElems;
+      int one = 1;
+      int idx =
+          HostBlas<std::complex<float>>::iamax(N, reinterpret_cast<const std::complex<float>*>(X.data()), one) - 1;
+      R() = IPT::norm(X(idx));
+    } else {
+      NrmInf<ExecSpace, RV, XV, 1, false, ETI_SPEC_AVAIL>::nrminf(space, R, X);
+    }
+    Kokkos::Profiling::popRegion();
+  }
+};
+
 }  // namespace Impl
 }  // namespace KokkosBlas
 

--- a/blas/tpls/KokkosBlas1_rot_tpl_spec_decl.hpp
+++ b/blas/tpls/KokkosBlas1_rot_tpl_spec_decl.hpp
@@ -26,113 +26,97 @@ inline void rot_print_specialization() {
 namespace KokkosBlas {
 namespace Impl {
 
-#define KOKKOSBLAS1_DROT_TPL_SPEC_DECL_BLAS(ETI_SPEC_AVAIL)                                                         \
-  template <typename ExecSpace>                                                                                     \
-    requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)                                   \
-  struct Rot<ExecSpace,                                                                                             \
-             Kokkos::View<double*, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
-             Kokkos::View<double, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,  \
-             Kokkos::View<double, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,  \
-             true, ETI_SPEC_AVAIL> {                                                                                \
-    using VectorView =                                                                                              \
-        Kokkos::View<double*, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;      \
-    using MagnitudeView =                                                                                           \
-        Kokkos::View<double, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;       \
-    using ScalarView =                                                                                              \
-        Kokkos::View<double, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;       \
-    static void rot(ExecSpace const& /*space*/, VectorView const& X, VectorView const& Y, MagnitudeView const& c,   \
-                    ScalarView const& s) {                                                                          \
-      Kokkos::Profiling::pushRegion("KokkosBlas::rot[TPL_BLAS,double]");                                            \
-      HostBlas<double>::rot(X.extent_int(0), X.data(), 1, Y.data(), 1, c.data(), s.data());                         \
-      Kokkos::Profiling::popRegion();                                                                               \
-    }                                                                                                               \
-  };
+template <typename ExecSpace, bool ETI_SPEC_AVAIL>
+  requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)
+struct Rot<ExecSpace,
+           Kokkos::View<double*, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,
+           Kokkos::View<double, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,
+           Kokkos::View<double, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, true,
+           ETI_SPEC_AVAIL> {
+  using VectorView =
+      Kokkos::View<double*, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+  using MagnitudeView =
+      Kokkos::View<double, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+  using ScalarView =
+      Kokkos::View<double, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+  static void rot(ExecSpace const& /*space*/, VectorView const& X, VectorView const& Y, MagnitudeView const& c,
+                  ScalarView const& s) {
+    Kokkos::Profiling::pushRegion("KokkosBlas::rot[TPL_BLAS,double]");
+    HostBlas<double>::rot(X.extent_int(0), X.data(), 1, Y.data(), 1, c.data(), s.data());
+    Kokkos::Profiling::popRegion();
+  }
+};
 
-#define KOKKOSBLAS1_SROT_TPL_SPEC_DECL_BLAS(ETI_SPEC_AVAIL)                                                        \
-  template <typename ExecSpace>                                                                                    \
-    requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)                                  \
-  struct Rot<ExecSpace,                                                                                            \
-             Kokkos::View<float*, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
-             Kokkos::View<float, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,  \
-             Kokkos::View<float, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,  \
-             true, ETI_SPEC_AVAIL> {                                                                               \
-    using VectorView =                                                                                             \
-        Kokkos::View<float*, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;      \
-    using MagnitudeView =                                                                                          \
-        Kokkos::View<float, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;       \
-    using ScalarView =                                                                                             \
-        Kokkos::View<float, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;       \
-    static void rot(ExecSpace const& /*space*/, VectorView const& X, VectorView const& Y, MagnitudeView const& c,  \
-                    ScalarView const& s) {                                                                         \
-      Kokkos::Profiling::pushRegion("KokkosBlas::rot[TPL_BLAS,float]");                                            \
-      HostBlas<float>::rot(X.extent_int(0), X.data(), 1, Y.data(), 1, c.data(), s.data());                         \
-      Kokkos::Profiling::popRegion();                                                                              \
-    }                                                                                                              \
-  };
+template <typename ExecSpace, bool ETI_SPEC_AVAIL>
+  requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)
+struct Rot<ExecSpace,
+           Kokkos::View<float*, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,
+           Kokkos::View<float, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,
+           Kokkos::View<float, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, true,
+           ETI_SPEC_AVAIL> {
+  using VectorView =
+      Kokkos::View<float*, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+  using MagnitudeView =
+      Kokkos::View<float, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+  using ScalarView =
+      Kokkos::View<float, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+  static void rot(ExecSpace const& /*space*/, VectorView const& X, VectorView const& Y, MagnitudeView const& c,
+                  ScalarView const& s) {
+    Kokkos::Profiling::pushRegion("KokkosBlas::rot[TPL_BLAS,float]");
+    HostBlas<float>::rot(X.extent_int(0), X.data(), 1, Y.data(), 1, c.data(), s.data());
+    Kokkos::Profiling::popRegion();
+  }
+};
 
-#define KOKKOSBLAS1_ZROT_TPL_SPEC_DECL_BLAS(ETI_SPEC_AVAIL)                                                        \
-  template <typename ExecSpace>                                                                                    \
-    requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)                                  \
-  struct Rot<ExecSpace,                                                                                            \
-             Kokkos::View<Kokkos::complex<double>*, Kokkos::LayoutLeft, Kokkos::HostSpace,                         \
-                          Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                \
-             Kokkos::View<double, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
-             Kokkos::View<Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::HostSpace,                          \
-                          Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                \
-             true, ETI_SPEC_AVAIL> {                                                                               \
-    using VectorView = Kokkos::View<Kokkos::complex<double>*, Kokkos::LayoutLeft, Kokkos::HostSpace,               \
-                                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                      \
-    using MagnitudeView =                                                                                          \
-        Kokkos::View<double, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;      \
-    using ScalarView = Kokkos::View<Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::HostSpace,                \
-                                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                      \
-    static void rot(ExecSpace const& /*space*/, VectorView const& X, VectorView const& Y, MagnitudeView const& c,  \
-                    ScalarView const& s) {                                                                         \
-      Kokkos::Profiling::pushRegion("KokkosBlas::rot[TPL_BLAS,complex<double>]");                                  \
-      HostBlas<std::complex<double>>::rot(X.extent_int(0), reinterpret_cast<std::complex<double>*>(X.data()), 1,   \
-                                          reinterpret_cast<std::complex<double>*>(Y.data()), 1, c.data(),          \
-                                          reinterpret_cast<std::complex<double>*>(s.data()));                      \
-      Kokkos::Profiling::popRegion();                                                                              \
-    }                                                                                                              \
-  };
+template <typename ExecSpace, bool ETI_SPEC_AVAIL>
+  requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)
+struct Rot<ExecSpace,
+           Kokkos::View<Kokkos::complex<double>*, Kokkos::LayoutLeft, Kokkos::HostSpace,
+                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>,
+           Kokkos::View<double, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,
+           Kokkos::View<Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::HostSpace,
+                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>,
+           true, ETI_SPEC_AVAIL> {
+  using VectorView = Kokkos::View<Kokkos::complex<double>*, Kokkos::LayoutLeft, Kokkos::HostSpace,
+                                  Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+  using MagnitudeView =
+      Kokkos::View<double, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+  using ScalarView = Kokkos::View<Kokkos::complex<double>, Kokkos::LayoutLeft, Kokkos::HostSpace,
+                                  Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+  static void rot(ExecSpace const& /*space*/, VectorView const& X, VectorView const& Y, MagnitudeView const& c,
+                  ScalarView const& s) {
+    Kokkos::Profiling::pushRegion("KokkosBlas::rot[TPL_BLAS,complex<double>]");
+    HostBlas<std::complex<double>>::rot(X.extent_int(0), reinterpret_cast<std::complex<double>*>(X.data()), 1,
+                                        reinterpret_cast<std::complex<double>*>(Y.data()), 1, c.data(),
+                                        reinterpret_cast<std::complex<double>*>(s.data()));
+    Kokkos::Profiling::popRegion();
+  }
+};
 
-#define KOKKOSBLAS1_CROT_TPL_SPEC_DECL_BLAS(ETI_SPEC_AVAIL)                                                       \
-  template <typename ExecSpace>                                                                                   \
-    requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)                                 \
-  struct Rot<ExecSpace,                                                                                           \
-             Kokkos::View<Kokkos::complex<float>*, Kokkos::LayoutLeft, Kokkos::HostSpace,                         \
-                          Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                               \
-             Kokkos::View<float, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
-             Kokkos::View<Kokkos::complex<float>, Kokkos::LayoutLeft, Kokkos::HostSpace,                          \
-                          Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                               \
-             true, ETI_SPEC_AVAIL> {                                                                              \
-    using VectorView = Kokkos::View<Kokkos::complex<float>*, Kokkos::LayoutLeft, Kokkos::HostSpace,               \
-                                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                     \
-    using MagnitudeView =                                                                                         \
-        Kokkos::View<float, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;      \
-    using ScalarView = Kokkos::View<Kokkos::complex<float>, Kokkos::LayoutLeft, Kokkos::HostSpace,                \
-                                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                     \
-    static void rot(ExecSpace const& /*space*/, VectorView const& X, VectorView const& Y, MagnitudeView const& c, \
-                    ScalarView const& s) {                                                                        \
-      Kokkos::Profiling::pushRegion("KokkosBlas::rot[TPL_BLAS,complex<float>]");                                  \
-      HostBlas<std::complex<float>>::rot(X.extent_int(0), reinterpret_cast<std::complex<float>*>(X.data()), 1,    \
-                                         reinterpret_cast<std::complex<float>*>(Y.data()), 1, c.data(),           \
-                                         reinterpret_cast<std::complex<float>*>(s.data()));                       \
-      Kokkos::Profiling::popRegion();                                                                             \
-    }                                                                                                             \
-  };
-
-KOKKOSBLAS1_DROT_TPL_SPEC_DECL_BLAS(true)
-KOKKOSBLAS1_DROT_TPL_SPEC_DECL_BLAS(false)
-
-KOKKOSBLAS1_SROT_TPL_SPEC_DECL_BLAS(true)
-KOKKOSBLAS1_SROT_TPL_SPEC_DECL_BLAS(false)
-
-KOKKOSBLAS1_ZROT_TPL_SPEC_DECL_BLAS(true)
-KOKKOSBLAS1_ZROT_TPL_SPEC_DECL_BLAS(false)
-
-KOKKOSBLAS1_CROT_TPL_SPEC_DECL_BLAS(true)
-KOKKOSBLAS1_CROT_TPL_SPEC_DECL_BLAS(false)
+template <typename ExecSpace, bool ETI_SPEC_AVAIL>
+  requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)
+struct Rot<ExecSpace,
+           Kokkos::View<Kokkos::complex<float>*, Kokkos::LayoutLeft, Kokkos::HostSpace,
+                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>,
+           Kokkos::View<float, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,
+           Kokkos::View<Kokkos::complex<float>, Kokkos::LayoutLeft, Kokkos::HostSpace,
+                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>,
+           true, ETI_SPEC_AVAIL> {
+  using VectorView = Kokkos::View<Kokkos::complex<float>*, Kokkos::LayoutLeft, Kokkos::HostSpace,
+                                  Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+  using MagnitudeView =
+      Kokkos::View<float, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+  using ScalarView = Kokkos::View<Kokkos::complex<float>, Kokkos::LayoutLeft, Kokkos::HostSpace,
+                                  Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+  static void rot(ExecSpace const& /*space*/, VectorView const& X, VectorView const& Y, MagnitudeView const& c,
+                  ScalarView const& s) {
+    Kokkos::Profiling::pushRegion("KokkosBlas::rot[TPL_BLAS,complex<float>]");
+    HostBlas<std::complex<float>>::rot(X.extent_int(0), reinterpret_cast<std::complex<float>*>(X.data()), 1,
+                                       reinterpret_cast<std::complex<float>*>(Y.data()), 1, c.data(),
+                                       reinterpret_cast<std::complex<float>*>(s.data()));
+    Kokkos::Profiling::popRegion();
+  }
+};
 
 }  // namespace Impl
 }  // namespace KokkosBlas
@@ -145,8 +129,8 @@ KOKKOSBLAS1_CROT_TPL_SPEC_DECL_BLAS(false)
 namespace KokkosBlas {
 namespace Impl {
 
-#define KOKKOSBLAS1_DROT_TPL_SPEC_DECL_CUBLAS(LAYOUT, ETI_SPEC_AVAIL)                                            \
-  template <>                                                                                                    \
+#define KOKKOSBLAS1_DROT_TPL_SPEC_DECL_CUBLAS(LAYOUT)                                                            \
+  template <bool ETI_SPEC_AVAIL>                                                                                 \
   struct Rot<Kokkos::Cuda, Kokkos::View<double*, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
              Kokkos::View<double, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                \
              Kokkos::View<double, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, true,          \
@@ -169,8 +153,8 @@ namespace Impl {
     }                                                                                                            \
   };
 
-#define KOKKOSBLAS1_SROT_TPL_SPEC_DECL_CUBLAS(LAYOUT, ETI_SPEC_AVAIL)                                            \
-  template <>                                                                                                    \
+#define KOKKOSBLAS1_SROT_TPL_SPEC_DECL_CUBLAS(LAYOUT)                                                            \
+  template <bool ETI_SPEC_AVAIL>                                                                                 \
   struct Rot<Kokkos::Cuda, Kokkos::View<float*, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,  \
              Kokkos::View<float, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                 \
              Kokkos::View<float, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, true,           \
@@ -193,8 +177,8 @@ namespace Impl {
     }                                                                                                            \
   };
 
-#define KOKKOSBLAS1_ZROT_TPL_SPEC_DECL_CUBLAS(LAYOUT, ETI_SPEC_AVAIL)                                               \
-  template <>                                                                                                       \
+#define KOKKOSBLAS1_ZROT_TPL_SPEC_DECL_CUBLAS(LAYOUT)                                                               \
+  template <bool ETI_SPEC_AVAIL>                                                                                    \
   struct Rot<Kokkos::Cuda,                                                                                          \
              Kokkos::View<Kokkos::complex<double>*, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
              Kokkos::View<double, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                   \
@@ -222,8 +206,8 @@ namespace Impl {
     }                                                                                                               \
   };
 
-#define KOKKOSBLAS1_CROT_TPL_SPEC_DECL_CUBLAS(LAYOUT, ETI_SPEC_AVAIL)                                              \
-  template <>                                                                                                      \
+#define KOKKOSBLAS1_CROT_TPL_SPEC_DECL_CUBLAS(LAYOUT)                                                              \
+  template <bool ETI_SPEC_AVAIL>                                                                                   \
   struct Rot<Kokkos::Cuda,                                                                                         \
              Kokkos::View<Kokkos::complex<float>*, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
              Kokkos::View<float, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                   \
@@ -250,25 +234,17 @@ namespace Impl {
     }                                                                                                              \
   };
 
-KOKKOSBLAS1_DROT_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS1_DROT_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS1_DROT_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS1_DROT_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutRight, false)
+KOKKOSBLAS1_DROT_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS1_DROT_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutRight)
 
-KOKKOSBLAS1_SROT_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS1_SROT_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS1_SROT_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS1_SROT_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutRight, false)
+KOKKOSBLAS1_SROT_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS1_SROT_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutRight)
 
-KOKKOSBLAS1_ZROT_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS1_ZROT_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS1_ZROT_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS1_ZROT_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutRight, false)
+KOKKOSBLAS1_ZROT_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS1_ZROT_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutRight)
 
-KOKKOSBLAS1_CROT_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS1_CROT_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS1_CROT_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS1_CROT_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutRight, false)
+KOKKOSBLAS1_CROT_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS1_CROT_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutRight)
 }  // namespace Impl
 }  // namespace KokkosBlas
 #endif  // KOKKOSKERNELS_ENABLE_TPL_CUBLAS

--- a/blas/tpls/KokkosBlas1_rotg_tpl_spec_decl.hpp
+++ b/blas/tpls/KokkosBlas1_rotg_tpl_spec_decl.hpp
@@ -26,8 +26,8 @@ inline void rotg_print_specialization() {
 namespace KokkosBlas {
 namespace Impl {
 
-#define KOKKOSBLAS1_DROTG_TPL_SPEC_DECL_BLAS(LAYOUT, ETI_SPEC_AVAIL)                                       \
-  template <typename ExecSpace>                                                                            \
+#define KOKKOSBLAS1_DROTG_TPL_SPEC_DECL_BLAS(LAYOUT)                                                       \
+  template <typename ExecSpace, bool ETI_SPEC_AVAIL>                                                       \
     requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)                          \
   struct Rotg<ExecSpace, Kokkos::View<double, LAYOUT, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
               Kokkos::View<double, LAYOUT, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, true,      \
@@ -42,8 +42,8 @@ namespace Impl {
     }                                                                                                      \
   };
 
-#define KOKKOSBLAS1_SROTG_TPL_SPEC_DECL_BLAS(LAYOUT, ETI_SPEC_AVAIL)                                                   \
-  template <typename ExecSpace>                                                                                        \
+#define KOKKOSBLAS1_SROTG_TPL_SPEC_DECL_BLAS(LAYOUT)                                                                   \
+  template <typename ExecSpace, bool ETI_SPEC_AVAIL>                                                                   \
     requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)                                      \
   struct Rotg<ExecSpace, Kokkos::View<float, LAYOUT, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,              \
               Kokkos::View<float, LAYOUT, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, true, ETI_SPEC_AVAIL> { \
@@ -57,8 +57,8 @@ namespace Impl {
     }                                                                                                                  \
   };
 
-#define KOKKOSBLAS1_ZROTG_TPL_SPEC_DECL_BLAS(LAYOUT, ETI_SPEC_AVAIL)                                                \
-  template <typename ExecSpace>                                                                                     \
+#define KOKKOSBLAS1_ZROTG_TPL_SPEC_DECL_BLAS(LAYOUT)                                                                \
+  template <typename ExecSpace, bool ETI_SPEC_AVAIL>                                                                \
     requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)                                   \
   struct Rotg<                                                                                                      \
       ExecSpace, Kokkos::View<Kokkos::complex<double>, LAYOUT, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
@@ -76,8 +76,8 @@ namespace Impl {
     }                                                                                                               \
   };
 
-#define KOKKOSBLAS1_CROTG_TPL_SPEC_DECL_BLAS(LAYOUT, ETI_SPEC_AVAIL)                                                   \
-  template <typename ExecSpace>                                                                                        \
+#define KOKKOSBLAS1_CROTG_TPL_SPEC_DECL_BLAS(LAYOUT)                                                                   \
+  template <typename ExecSpace, bool ETI_SPEC_AVAIL>                                                                   \
     requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)                                      \
   struct Rotg<ExecSpace,                                                                                               \
               Kokkos::View<Kokkos::complex<float>, LAYOUT, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,        \
@@ -95,25 +95,17 @@ namespace Impl {
     }                                                                                                                  \
   };
 
-KOKKOSBLAS1_DROTG_TPL_SPEC_DECL_BLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS1_DROTG_TPL_SPEC_DECL_BLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS1_DROTG_TPL_SPEC_DECL_BLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS1_DROTG_TPL_SPEC_DECL_BLAS(Kokkos::LayoutRight, false)
+KOKKOSBLAS1_DROTG_TPL_SPEC_DECL_BLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS1_DROTG_TPL_SPEC_DECL_BLAS(Kokkos::LayoutRight)
 
-KOKKOSBLAS1_SROTG_TPL_SPEC_DECL_BLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS1_SROTG_TPL_SPEC_DECL_BLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS1_SROTG_TPL_SPEC_DECL_BLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS1_SROTG_TPL_SPEC_DECL_BLAS(Kokkos::LayoutRight, false)
+KOKKOSBLAS1_SROTG_TPL_SPEC_DECL_BLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS1_SROTG_TPL_SPEC_DECL_BLAS(Kokkos::LayoutRight)
 
-KOKKOSBLAS1_ZROTG_TPL_SPEC_DECL_BLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS1_ZROTG_TPL_SPEC_DECL_BLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS1_ZROTG_TPL_SPEC_DECL_BLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS1_ZROTG_TPL_SPEC_DECL_BLAS(Kokkos::LayoutRight, false)
+KOKKOSBLAS1_ZROTG_TPL_SPEC_DECL_BLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS1_ZROTG_TPL_SPEC_DECL_BLAS(Kokkos::LayoutRight)
 
-KOKKOSBLAS1_CROTG_TPL_SPEC_DECL_BLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS1_CROTG_TPL_SPEC_DECL_BLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS1_CROTG_TPL_SPEC_DECL_BLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS1_CROTG_TPL_SPEC_DECL_BLAS(Kokkos::LayoutRight, false)
+KOKKOSBLAS1_CROTG_TPL_SPEC_DECL_BLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS1_CROTG_TPL_SPEC_DECL_BLAS(Kokkos::LayoutRight)
 }  // namespace Impl
 }  // namespace KokkosBlas
 
@@ -126,8 +118,8 @@ KOKKOSBLAS1_CROTG_TPL_SPEC_DECL_BLAS(Kokkos::LayoutRight, false)
 namespace KokkosBlas {
 namespace Impl {
 
-#define KOKKOSBLAS1_DROTG_TPL_SPEC_DECL_CUBLAS(LAYOUT, ETI_SPEC_AVAIL)                                           \
-  template <>                                                                                                    \
+#define KOKKOSBLAS1_DROTG_TPL_SPEC_DECL_CUBLAS(LAYOUT)                                                           \
+  template <bool ETI_SPEC_AVAIL>                                                                                 \
   struct Rotg<Kokkos::Cuda, Kokkos::View<double, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
               Kokkos::View<double, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, true,         \
               ETI_SPEC_AVAIL> {                                                                                  \
@@ -148,8 +140,8 @@ namespace Impl {
     }                                                                                                            \
   };
 
-#define KOKKOSBLAS1_SROTG_TPL_SPEC_DECL_CUBLAS(LAYOUT, ETI_SPEC_AVAIL)                                          \
-  template <>                                                                                                   \
+#define KOKKOSBLAS1_SROTG_TPL_SPEC_DECL_CUBLAS(LAYOUT)                                                          \
+  template <bool ETI_SPEC_AVAIL>                                                                                \
   struct Rotg<Kokkos::Cuda, Kokkos::View<float, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
               Kokkos::View<float, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, true,         \
               ETI_SPEC_AVAIL> {                                                                                 \
@@ -170,8 +162,8 @@ namespace Impl {
     }                                                                                                           \
   };
 
-#define KOKKOSBLAS1_ZROTG_TPL_SPEC_DECL_CUBLAS(LAYOUT, ETI_SPEC_AVAIL)                                              \
-  template <>                                                                                                       \
+#define KOKKOSBLAS1_ZROTG_TPL_SPEC_DECL_CUBLAS(LAYOUT)                                                              \
+  template <bool ETI_SPEC_AVAIL>                                                                                    \
   struct Rotg<Kokkos::Cuda,                                                                                         \
               Kokkos::View<Kokkos::complex<double>, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
               Kokkos::View<double, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, true,            \
@@ -196,8 +188,8 @@ namespace Impl {
     }                                                                                                               \
   };
 
-#define KOKKOSBLAS1_CROTG_TPL_SPEC_DECL_CUBLAS(LAYOUT, ETI_SPEC_AVAIL)                                             \
-  template <>                                                                                                      \
+#define KOKKOSBLAS1_CROTG_TPL_SPEC_DECL_CUBLAS(LAYOUT)                                                             \
+  template <bool ETI_SPEC_AVAIL>                                                                                   \
   struct Rotg<Kokkos::Cuda,                                                                                        \
               Kokkos::View<Kokkos::complex<float>, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
               Kokkos::View<float, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, true,            \
@@ -222,25 +214,17 @@ namespace Impl {
     }                                                                                                              \
   };
 
-KOKKOSBLAS1_DROTG_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS1_DROTG_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS1_DROTG_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS1_DROTG_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutRight, false)
+KOKKOSBLAS1_DROTG_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS1_DROTG_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutRight)
 
-KOKKOSBLAS1_SROTG_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS1_SROTG_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS1_SROTG_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS1_SROTG_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutRight, false)
+KOKKOSBLAS1_SROTG_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS1_SROTG_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutRight)
 
-KOKKOSBLAS1_ZROTG_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS1_ZROTG_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS1_ZROTG_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS1_ZROTG_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutRight, false)
+KOKKOSBLAS1_ZROTG_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS1_ZROTG_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutRight)
 
-KOKKOSBLAS1_CROTG_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS1_CROTG_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS1_CROTG_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS1_CROTG_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutRight, false)
+KOKKOSBLAS1_CROTG_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS1_CROTG_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutRight)
 
 }  // namespace Impl
 }  // namespace KokkosBlas
@@ -254,8 +238,8 @@ KOKKOSBLAS1_CROTG_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutRight, false)
 namespace KokkosBlas {
 namespace Impl {
 
-#define KOKKOSBLAS1_DROTG_TPL_SPEC_DECL_ROCBLAS(LAYOUT, ETI_SPEC_AVAIL)                                           \
-  template <>                                                                                                     \
+#define KOKKOSBLAS1_DROTG_TPL_SPEC_DECL_ROCBLAS(LAYOUT)                                                           \
+  template <bool ETI_SPEC_AVAIL>                                                                                  \
   struct Rotg<Kokkos::HIP, Kokkos::View<double, LAYOUT, Kokkos::HIP, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,    \
               Kokkos::View<double, LAYOUT, Kokkos::HIP, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, true,           \
               ETI_SPEC_AVAIL> {                                                                                   \
@@ -276,8 +260,8 @@ namespace Impl {
     }                                                                                                             \
   };
 
-#define KOKKOSBLAS1_SROTG_TPL_SPEC_DECL_ROCBLAS(LAYOUT, ETI_SPEC_AVAIL)                                           \
-  template <>                                                                                                     \
+#define KOKKOSBLAS1_SROTG_TPL_SPEC_DECL_ROCBLAS(LAYOUT)                                                           \
+  template <bool ETI_SPEC_AVAIL>                                                                                  \
   struct Rotg<Kokkos::HIP, Kokkos::View<float, LAYOUT, Kokkos::HIP, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,     \
               Kokkos::View<float, LAYOUT, Kokkos::HIP, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, true,            \
               ETI_SPEC_AVAIL> {                                                                                   \
@@ -298,8 +282,8 @@ namespace Impl {
     }                                                                                                             \
   };
 
-#define KOKKOSBLAS1_ZROTG_TPL_SPEC_DECL_ROCBLAS(LAYOUT, ETI_SPEC_AVAIL)                                              \
-  template <>                                                                                                        \
+#define KOKKOSBLAS1_ZROTG_TPL_SPEC_DECL_ROCBLAS(LAYOUT)                                                              \
+  template <bool ETI_SPEC_AVAIL>                                                                                     \
   struct Rotg<Kokkos::HIP,                                                                                           \
               Kokkos::View<Kokkos::complex<double>, LAYOUT, Kokkos::HIP, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,   \
               Kokkos::View<double, LAYOUT, Kokkos::HIP, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, true,              \
@@ -325,8 +309,8 @@ namespace Impl {
     }                                                                                                                \
   };
 
-#define KOKKOSBLAS1_CROTG_TPL_SPEC_DECL_ROCBLAS(LAYOUT, ETI_SPEC_AVAIL)                                                \
-  template <>                                                                                                          \
+#define KOKKOSBLAS1_CROTG_TPL_SPEC_DECL_ROCBLAS(LAYOUT)                                                                \
+  template <bool ETI_SPEC_AVAIL>                                                                                       \
   struct Rotg<                                                                                                         \
       Kokkos::HIP, Kokkos::View<Kokkos::complex<float>, LAYOUT, Kokkos::HIP, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
       Kokkos::View<float, LAYOUT, Kokkos::HIP, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, true, ETI_SPEC_AVAIL> {       \
@@ -351,25 +335,17 @@ namespace Impl {
     }                                                                                                                  \
   };
 
-KOKKOSBLAS1_DROTG_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS1_DROTG_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS1_DROTG_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS1_DROTG_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutRight, false)
+KOKKOSBLAS1_DROTG_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS1_DROTG_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutRight)
 
-KOKKOSBLAS1_SROTG_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS1_SROTG_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS1_SROTG_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS1_SROTG_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutRight, false)
+KOKKOSBLAS1_SROTG_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS1_SROTG_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutRight)
 
-KOKKOSBLAS1_ZROTG_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS1_ZROTG_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS1_ZROTG_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS1_ZROTG_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutRight, false)
+KOKKOSBLAS1_ZROTG_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS1_ZROTG_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutRight)
 
-KOKKOSBLAS1_CROTG_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS1_CROTG_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS1_CROTG_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS1_CROTG_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutRight, false)
+KOKKOSBLAS1_CROTG_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS1_CROTG_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutRight)
 
 }  // namespace Impl
 }  // namespace KokkosBlas

--- a/blas/tpls/KokkosBlas1_rotm_tpl_spec_decl.hpp
+++ b/blas/tpls/KokkosBlas1_rotm_tpl_spec_decl.hpp
@@ -25,8 +25,8 @@ inline void rotm_print_specialization() {
 namespace KokkosBlas {
 namespace Impl {
 
-#define KOKKOSBLAS1_ROTM_TPL_SPEC_DECL_BLAS(SCALAR, LAYOUT, ETI_SPEC_AVAIL)                                       \
-  template <typename ExecSpace>                                                                                   \
+#define KOKKOSBLAS1_ROTM_TPL_SPEC_DECL_BLAS(SCALAR, LAYOUT)                                                       \
+  template <typename ExecSpace, bool ETI_SPEC_AVAIL>                                                              \
     requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)                                 \
   struct Rotm<ExecSpace, Kokkos::View<SCALAR*, LAYOUT, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,       \
               Kokkos::View<const SCALAR[5], LAYOUT, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, true,    \
@@ -40,14 +40,10 @@ namespace Impl {
     }                                                                                                             \
   };
 
-KOKKOSBLAS1_ROTM_TPL_SPEC_DECL_BLAS(double, Kokkos::LayoutLeft, true)
-KOKKOSBLAS1_ROTM_TPL_SPEC_DECL_BLAS(double, Kokkos::LayoutLeft, false)
-KOKKOSBLAS1_ROTM_TPL_SPEC_DECL_BLAS(double, Kokkos::LayoutRight, true)
-KOKKOSBLAS1_ROTM_TPL_SPEC_DECL_BLAS(double, Kokkos::LayoutRight, false)
-KOKKOSBLAS1_ROTM_TPL_SPEC_DECL_BLAS(float, Kokkos::LayoutLeft, true)
-KOKKOSBLAS1_ROTM_TPL_SPEC_DECL_BLAS(float, Kokkos::LayoutLeft, false)
-KOKKOSBLAS1_ROTM_TPL_SPEC_DECL_BLAS(float, Kokkos::LayoutRight, true)
-KOKKOSBLAS1_ROTM_TPL_SPEC_DECL_BLAS(float, Kokkos::LayoutRight, false)
+KOKKOSBLAS1_ROTM_TPL_SPEC_DECL_BLAS(double, Kokkos::LayoutLeft)
+KOKKOSBLAS1_ROTM_TPL_SPEC_DECL_BLAS(double, Kokkos::LayoutRight)
+KOKKOSBLAS1_ROTM_TPL_SPEC_DECL_BLAS(float, Kokkos::LayoutLeft)
+KOKKOSBLAS1_ROTM_TPL_SPEC_DECL_BLAS(float, Kokkos::LayoutRight)
 
 }  // namespace Impl
 }  // namespace KokkosBlas
@@ -61,8 +57,8 @@ KOKKOSBLAS1_ROTM_TPL_SPEC_DECL_BLAS(float, Kokkos::LayoutRight, false)
 namespace KokkosBlas {
 namespace Impl {
 
-#define KOKKOSBLAS1_DROTM_TPL_SPEC_DECL_CUBLAS(LAYOUT, ETI_SPEC_AVAIL)                                               \
-  template <>                                                                                                        \
+#define KOKKOSBLAS1_DROTM_TPL_SPEC_DECL_CUBLAS(LAYOUT)                                                               \
+  template <bool ETI_SPEC_AVAIL>                                                                                     \
   struct Rotm<Kokkos::Cuda, Kokkos::View<double*, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,    \
               Kokkos::View<const double[5], LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, true,    \
               ETI_SPEC_AVAIL> {                                                                                      \
@@ -83,13 +79,11 @@ namespace Impl {
     }                                                                                                                \
   };
 
-KOKKOSBLAS1_DROTM_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS1_DROTM_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS1_DROTM_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS1_DROTM_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutRight, false)
+KOKKOSBLAS1_DROTM_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS1_DROTM_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutRight)
 
-#define KOKKOSBLAS1_SROTM_TPL_SPEC_DECL_CUBLAS(LAYOUT, ETI_SPEC_AVAIL)                                              \
-  template <>                                                                                                       \
+#define KOKKOSBLAS1_SROTM_TPL_SPEC_DECL_CUBLAS(LAYOUT)                                                              \
+  template <bool ETI_SPEC_AVAIL>                                                                                    \
   struct Rotm<Kokkos::Cuda, Kokkos::View<float*, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,    \
               Kokkos::View<const float[5], LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, true,    \
               ETI_SPEC_AVAIL> {                                                                                     \
@@ -110,10 +104,8 @@ KOKKOSBLAS1_DROTM_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutRight, false)
     }                                                                                                               \
   };
 
-KOKKOSBLAS1_SROTM_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS1_SROTM_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS1_SROTM_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS1_SROTM_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutRight, false)
+KOKKOSBLAS1_SROTM_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS1_SROTM_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutRight)
 
 }  // namespace Impl
 }  // namespace KokkosBlas
@@ -127,8 +119,8 @@ KOKKOSBLAS1_SROTM_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutRight, false)
 namespace KokkosBlas {
 namespace Impl {
 
-#define KOKKOSBLAS1_DROTM_TPL_SPEC_DECL_ROCBLAS(LAYOUT, ETI_SPEC_AVAIL)                                             \
-  template <>                                                                                                       \
+#define KOKKOSBLAS1_DROTM_TPL_SPEC_DECL_ROCBLAS(LAYOUT)                                                             \
+  template <bool ETI_SPEC_AVAIL>                                                                                    \
   struct Rotm<Kokkos::HIP, Kokkos::View<double*, LAYOUT, Kokkos::HIP, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,     \
               Kokkos::View<const double[5], LAYOUT, Kokkos::HIP, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, true,    \
               ETI_SPEC_AVAIL> {                                                                                     \
@@ -150,13 +142,11 @@ namespace Impl {
     }                                                                                                               \
   };
 
-KOKKOSBLAS1_DROTM_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS1_DROTM_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS1_DROTM_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS1_DROTM_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutRight, false)
+KOKKOSBLAS1_DROTM_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS1_DROTM_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutRight)
 
-#define KOKKOSBLAS1_SROTM_TPL_SPEC_DECL_ROCBLAS(LAYOUT, ETI_SPEC_AVAIL)                                            \
-  template <>                                                                                                      \
+#define KOKKOSBLAS1_SROTM_TPL_SPEC_DECL_ROCBLAS(LAYOUT)                                                            \
+  template <bool ETI_SPEC_AVAIL>                                                                                   \
   struct Rotm<Kokkos::HIP, Kokkos::View<float*, LAYOUT, Kokkos::HIP, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,     \
               Kokkos::View<const float[5], LAYOUT, Kokkos::HIP, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, true,    \
               ETI_SPEC_AVAIL> {                                                                                    \
@@ -178,10 +168,8 @@ KOKKOSBLAS1_DROTM_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutRight, false)
     }                                                                                                              \
   };
 
-KOKKOSBLAS1_SROTM_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS1_SROTM_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS1_SROTM_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS1_SROTM_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutRight, false)
+KOKKOSBLAS1_SROTM_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS1_SROTM_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutRight)
 
 }  // namespace Impl
 }  // namespace KokkosBlas

--- a/blas/tpls/KokkosBlas1_rotmg_tpl_spec_decl.hpp
+++ b/blas/tpls/KokkosBlas1_rotmg_tpl_spec_decl.hpp
@@ -25,8 +25,8 @@ inline void rotmg_print_specialization() {
 namespace KokkosBlas {
 namespace Impl {
 
-#define KOKKOSBLAS1_ROTMG_TPL_SPEC_DECL_BLAS(SCALAR, LAYOUT, ETI_SPEC_AVAIL)                                       \
-  template <typename ExecSpace>                                                                                    \
+#define KOKKOSBLAS1_ROTMG_TPL_SPEC_DECL_BLAS(SCALAR, LAYOUT)                                                       \
+  template <typename ExecSpace, bool ETI_SPEC_AVAIL>                                                               \
     requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)                                  \
   struct Rotmg<ExecSpace, Kokkos::View<SCALAR, LAYOUT, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,        \
                Kokkos::View<SCALAR const, LAYOUT, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,             \
@@ -42,14 +42,10 @@ namespace Impl {
     }                                                                                                              \
   };
 
-KOKKOSBLAS1_ROTMG_TPL_SPEC_DECL_BLAS(double, Kokkos::LayoutLeft, true)
-KOKKOSBLAS1_ROTMG_TPL_SPEC_DECL_BLAS(double, Kokkos::LayoutLeft, false)
-KOKKOSBLAS1_ROTMG_TPL_SPEC_DECL_BLAS(double, Kokkos::LayoutRight, true)
-KOKKOSBLAS1_ROTMG_TPL_SPEC_DECL_BLAS(double, Kokkos::LayoutRight, false)
-KOKKOSBLAS1_ROTMG_TPL_SPEC_DECL_BLAS(float, Kokkos::LayoutLeft, true)
-KOKKOSBLAS1_ROTMG_TPL_SPEC_DECL_BLAS(float, Kokkos::LayoutLeft, false)
-KOKKOSBLAS1_ROTMG_TPL_SPEC_DECL_BLAS(float, Kokkos::LayoutRight, true)
-KOKKOSBLAS1_ROTMG_TPL_SPEC_DECL_BLAS(float, Kokkos::LayoutRight, false)
+KOKKOSBLAS1_ROTMG_TPL_SPEC_DECL_BLAS(double, Kokkos::LayoutLeft)
+KOKKOSBLAS1_ROTMG_TPL_SPEC_DECL_BLAS(double, Kokkos::LayoutRight)
+KOKKOSBLAS1_ROTMG_TPL_SPEC_DECL_BLAS(float, Kokkos::LayoutLeft)
+KOKKOSBLAS1_ROTMG_TPL_SPEC_DECL_BLAS(float, Kokkos::LayoutRight)
 
 }  // namespace Impl
 }  // namespace KokkosBlas
@@ -63,8 +59,8 @@ KOKKOSBLAS1_ROTMG_TPL_SPEC_DECL_BLAS(float, Kokkos::LayoutRight, false)
 namespace KokkosBlas {
 namespace Impl {
 
-#define KOKKOSBLAS1_DROTMG_TPL_SPEC_DECL_CUBLAS(LAYOUT, ETI_SPEC_AVAIL)                                           \
-  template <>                                                                                                     \
+#define KOKKOSBLAS1_DROTMG_TPL_SPEC_DECL_CUBLAS(LAYOUT)                                                           \
+  template <bool ETI_SPEC_AVAIL>                                                                                  \
   struct Rotmg<Kokkos::Cuda, Kokkos::View<double, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
                Kokkos::View<double const, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,         \
                Kokkos::View<double[5], LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, true,      \
@@ -89,13 +85,11 @@ namespace Impl {
     }                                                                                                             \
   };
 
-KOKKOSBLAS1_DROTMG_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS1_DROTMG_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS1_DROTMG_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS1_DROTMG_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutRight, false)
+KOKKOSBLAS1_DROTMG_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS1_DROTMG_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutRight)
 
-#define KOKKOSBLAS1_SROTMG_TPL_SPEC_DECL_CUBLAS(LAYOUT, ETI_SPEC_AVAIL)                                          \
-  template <>                                                                                                    \
+#define KOKKOSBLAS1_SROTMG_TPL_SPEC_DECL_CUBLAS(LAYOUT)                                                          \
+  template <bool ETI_SPEC_AVAIL>                                                                                 \
   struct Rotmg<Kokkos::Cuda, Kokkos::View<float, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
                Kokkos::View<float const, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,         \
                Kokkos::View<float[5], LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, true,      \
@@ -120,10 +114,8 @@ KOKKOSBLAS1_DROTMG_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutRight, false)
     }                                                                                                            \
   };
 
-KOKKOSBLAS1_SROTMG_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS1_SROTMG_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS1_SROTMG_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS1_SROTMG_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutRight, false)
+KOKKOSBLAS1_SROTMG_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS1_SROTMG_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutRight)
 
 }  // namespace Impl
 }  // namespace KokkosBlas
@@ -137,8 +129,8 @@ KOKKOSBLAS1_SROTMG_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutRight, false)
 namespace KokkosBlas {
 namespace Impl {
 
-#define KOKKOSBLAS1_DROTMG_TPL_SPEC_DECL_ROCBLAS(LAYOUT, ETI_SPEC_AVAIL)                                               \
-  template <>                                                                                                          \
+#define KOKKOSBLAS1_DROTMG_TPL_SPEC_DECL_ROCBLAS(LAYOUT)                                                               \
+  template <bool ETI_SPEC_AVAIL>                                                                                       \
   struct Rotmg<Kokkos::HIP, Kokkos::View<double, LAYOUT, Kokkos::HIP, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,        \
                Kokkos::View<double const, LAYOUT, Kokkos::HIP, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,               \
                Kokkos::View<double[5], LAYOUT, Kokkos::HIP, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, true,            \
@@ -163,13 +155,11 @@ namespace Impl {
     }                                                                                                                  \
   };
 
-KOKKOSBLAS1_DROTMG_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS1_DROTMG_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS1_DROTMG_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS1_DROTMG_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutRight, false)
+KOKKOSBLAS1_DROTMG_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS1_DROTMG_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutRight)
 
-#define KOKKOSBLAS1_SROTMG_TPL_SPEC_DECL_ROCBLAS(LAYOUT, ETI_SPEC_AVAIL)                                               \
-  template <>                                                                                                          \
+#define KOKKOSBLAS1_SROTMG_TPL_SPEC_DECL_ROCBLAS(LAYOUT)                                                               \
+  template <bool ETI_SPEC_AVAIL>                                                                                       \
   struct Rotmg<Kokkos::HIP, Kokkos::View<float, LAYOUT, Kokkos::HIP, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,         \
                Kokkos::View<float const, LAYOUT, Kokkos::HIP, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                \
                Kokkos::View<float[5], LAYOUT, Kokkos::HIP, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, true,             \
@@ -194,10 +184,8 @@ KOKKOSBLAS1_DROTMG_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutRight, false)
     }                                                                                                                  \
   };
 
-KOKKOSBLAS1_SROTMG_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS1_SROTMG_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS1_SROTMG_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS1_SROTMG_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutRight, false)
+KOKKOSBLAS1_SROTMG_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS1_SROTMG_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutRight)
 
 }  // namespace Impl
 }  // namespace KokkosBlas

--- a/blas/tpls/KokkosBlas1_scal_tpl_spec_decl.hpp
+++ b/blas/tpls/KokkosBlas1_scal_tpl_spec_decl.hpp
@@ -25,8 +25,8 @@ inline void scal_print_specialization() {
 namespace KokkosBlas {
 namespace Impl {
 
-#define KOKKOSBLAS1_XSCAL_TPL_SPEC_DECL_BLAS(SCALAR_TYPE, BASE_SCALAR_TYPE, ETI_SPEC_AVAIL)                           \
-  template <typename ExecSpace>                                                                                       \
+#define KOKKOSBLAS1_XSCAL_TPL_SPEC_DECL_BLAS(SCALAR_TYPE, BASE_SCALAR_TYPE)                                           \
+  template <typename ExecSpace, bool ETI_SPEC_AVAIL>                                                                  \
     requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)                                     \
   struct Scal<                                                                                                        \
       ExecSpace, Kokkos::View<SCALAR_TYPE*, Kokkos::LayoutLeft, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
@@ -55,29 +55,13 @@ namespace Impl {
     }                                                                                                                 \
   };
 
-#define KOKKOSBLAS1_DSCAL_TPL_SPEC_DECL_BLAS(ETI_SPEC_AVAIL) \
-  KOKKOSBLAS1_XSCAL_TPL_SPEC_DECL_BLAS(double, double, ETI_SPEC_AVAIL)
+KOKKOSBLAS1_XSCAL_TPL_SPEC_DECL_BLAS(double, double)
 
-#define KOKKOSBLAS1_SSCAL_TPL_SPEC_DECL_BLAS(ETI_SPEC_AVAIL) \
-  KOKKOSBLAS1_XSCAL_TPL_SPEC_DECL_BLAS(float, float, ETI_SPEC_AVAIL)
+KOKKOSBLAS1_XSCAL_TPL_SPEC_DECL_BLAS(float, float)
 
-#define KOKKOSBLAS1_ZSCAL_TPL_SPEC_DECL_BLAS(ETI_SPEC_AVAIL) \
-  KOKKOSBLAS1_XSCAL_TPL_SPEC_DECL_BLAS(Kokkos::complex<double>, std::complex<double>, ETI_SPEC_AVAIL)
+KOKKOSBLAS1_XSCAL_TPL_SPEC_DECL_BLAS(Kokkos::complex<double>, std::complex<double>)
 
-#define KOKKOSBLAS1_CSCAL_TPL_SPEC_DECL_BLAS(ETI_SPEC_AVAIL) \
-  KOKKOSBLAS1_XSCAL_TPL_SPEC_DECL_BLAS(Kokkos::complex<float>, std::complex<float>, ETI_SPEC_AVAIL)
-
-KOKKOSBLAS1_DSCAL_TPL_SPEC_DECL_BLAS(true)
-KOKKOSBLAS1_DSCAL_TPL_SPEC_DECL_BLAS(false)
-
-KOKKOSBLAS1_SSCAL_TPL_SPEC_DECL_BLAS(true)
-KOKKOSBLAS1_SSCAL_TPL_SPEC_DECL_BLAS(false)
-
-KOKKOSBLAS1_ZSCAL_TPL_SPEC_DECL_BLAS(true)
-KOKKOSBLAS1_ZSCAL_TPL_SPEC_DECL_BLAS(false)
-
-KOKKOSBLAS1_CSCAL_TPL_SPEC_DECL_BLAS(true)
-KOKKOSBLAS1_CSCAL_TPL_SPEC_DECL_BLAS(false)
+KOKKOSBLAS1_XSCAL_TPL_SPEC_DECL_BLAS(Kokkos::complex<float>, std::complex<float>)
 
 }  // namespace Impl
 }  // namespace KokkosBlas
@@ -91,8 +75,8 @@ KOKKOSBLAS1_CSCAL_TPL_SPEC_DECL_BLAS(false)
 namespace KokkosBlas {
 namespace Impl {
 
-#define KOKKOSBLAS1_XSCAL_TPL_SPEC_DECL_CUBLAS(SCALAR_TYPE, CUDA_SCALAR_TYPE, CUBLAS_FN, ETI_SPEC_AVAIL)               \
-  template <>                                                                                                          \
+#define KOKKOSBLAS1_XSCAL_TPL_SPEC_DECL_CUBLAS(SCALAR_TYPE, CUDA_SCALAR_TYPE, CUBLAS_FN)                               \
+  template <bool ETI_SPEC_AVAIL>                                                                                       \
   struct Scal<                                                                                                         \
       Kokkos::Cuda,                                                                                                    \
       Kokkos::View<SCALAR_TYPE*, Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,          \
@@ -125,29 +109,13 @@ namespace Impl {
     }                                                                                                                  \
   };
 
-#define KOKKOSBLAS1_DSCAL_TPL_SPEC_DECL_CUBLAS(ETI_SPEC_AVAIL) \
-  KOKKOSBLAS1_XSCAL_TPL_SPEC_DECL_CUBLAS(double, double, cublasDscal, ETI_SPEC_AVAIL)
+KOKKOSBLAS1_XSCAL_TPL_SPEC_DECL_CUBLAS(double, double, cublasDscal)
 
-#define KOKKOSBLAS1_SSCAL_TPL_SPEC_DECL_CUBLAS(ETI_SPEC_AVAIL) \
-  KOKKOSBLAS1_XSCAL_TPL_SPEC_DECL_CUBLAS(float, float, cublasSscal, ETI_SPEC_AVAIL)
+KOKKOSBLAS1_XSCAL_TPL_SPEC_DECL_CUBLAS(float, float, cublasSscal)
 
-#define KOKKOSBLAS1_ZSCAL_TPL_SPEC_DECL_CUBLAS(ETI_SPEC_AVAIL) \
-  KOKKOSBLAS1_XSCAL_TPL_SPEC_DECL_CUBLAS(Kokkos::complex<double>, cuDoubleComplex, cublasZscal, ETI_SPEC_AVAIL)
+KOKKOSBLAS1_XSCAL_TPL_SPEC_DECL_CUBLAS(Kokkos::complex<double>, cuDoubleComplex, cublasZscal)
 
-#define KOKKOSBLAS1_CSCAL_TPL_SPEC_DECL_CUBLAS(ETI_SPEC_AVAIL) \
-  KOKKOSBLAS1_XSCAL_TPL_SPEC_DECL_CUBLAS(Kokkos::complex<float>, cuComplex, cublasCscal, ETI_SPEC_AVAIL)
-
-KOKKOSBLAS1_DSCAL_TPL_SPEC_DECL_CUBLAS(true)
-KOKKOSBLAS1_DSCAL_TPL_SPEC_DECL_CUBLAS(false)
-
-KOKKOSBLAS1_SSCAL_TPL_SPEC_DECL_CUBLAS(true)
-KOKKOSBLAS1_SSCAL_TPL_SPEC_DECL_CUBLAS(false)
-
-KOKKOSBLAS1_ZSCAL_TPL_SPEC_DECL_CUBLAS(true)
-KOKKOSBLAS1_ZSCAL_TPL_SPEC_DECL_CUBLAS(false)
-
-KOKKOSBLAS1_CSCAL_TPL_SPEC_DECL_CUBLAS(true)
-KOKKOSBLAS1_CSCAL_TPL_SPEC_DECL_CUBLAS(false)
+KOKKOSBLAS1_XSCAL_TPL_SPEC_DECL_CUBLAS(Kokkos::complex<float>, cuComplex, cublasCscal)
 
 }  // namespace Impl
 }  // namespace KokkosBlas
@@ -161,8 +129,8 @@ KOKKOSBLAS1_CSCAL_TPL_SPEC_DECL_CUBLAS(false)
 namespace KokkosBlas {
 namespace Impl {
 
-#define KOKKOSBLAS1_XSCAL_TPL_SPEC_DECL_ROCBLAS(SCALAR_TYPE, ROCBLAS_SCALAR_TYPE, ROCBLAS_FN, ETI_SPEC_AVAIL)         \
-  template <>                                                                                                         \
+#define KOKKOSBLAS1_XSCAL_TPL_SPEC_DECL_ROCBLAS(SCALAR_TYPE, ROCBLAS_SCALAR_TYPE, ROCBLAS_FN)                         \
+  template <bool ETI_SPEC_AVAIL>                                                                                      \
   struct Scal<                                                                                                        \
       Kokkos::HIP,                                                                                                    \
       Kokkos::View<SCALAR_TYPE*, Kokkos::LayoutLeft, Kokkos::HIP, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,          \
@@ -199,30 +167,13 @@ namespace Impl {
     }                                                                                                                 \
   };
 
-#define KOKKOSBLAS1_DSCAL_TPL_SPEC_DECL_ROCBLAS(ETI_SPEC_AVAIL) \
-  KOKKOSBLAS1_XSCAL_TPL_SPEC_DECL_ROCBLAS(double, double, rocblas_dscal, ETI_SPEC_AVAIL)
+KOKKOSBLAS1_XSCAL_TPL_SPEC_DECL_ROCBLAS(double, double, rocblas_dscal)
 
-#define KOKKOSBLAS1_SSCAL_TPL_SPEC_DECL_ROCBLAS(ETI_SPEC_AVAIL) \
-  KOKKOSBLAS1_XSCAL_TPL_SPEC_DECL_ROCBLAS(float, float, rocblas_sscal, ETI_SPEC_AVAIL)
+KOKKOSBLAS1_XSCAL_TPL_SPEC_DECL_ROCBLAS(float, float, rocblas_sscal)
 
-#define KOKKOSBLAS1_ZSCAL_TPL_SPEC_DECL_ROCBLAS(ETI_SPEC_AVAIL)                                           \
-  KOKKOSBLAS1_XSCAL_TPL_SPEC_DECL_ROCBLAS(Kokkos::complex<double>, rocblas_double_complex, rocblas_zscal, \
-                                          ETI_SPEC_AVAIL)
+KOKKOSBLAS1_XSCAL_TPL_SPEC_DECL_ROCBLAS(Kokkos::complex<double>, rocblas_double_complex, rocblas_zscal)
 
-#define KOKKOSBLAS1_CSCAL_TPL_SPEC_DECL_ROCBLAS(ETI_SPEC_AVAIL) \
-  KOKKOSBLAS1_XSCAL_TPL_SPEC_DECL_ROCBLAS(Kokkos::complex<float>, rocblas_float_complex, rocblas_cscal, ETI_SPEC_AVAIL)
-
-KOKKOSBLAS1_DSCAL_TPL_SPEC_DECL_ROCBLAS(true)
-KOKKOSBLAS1_DSCAL_TPL_SPEC_DECL_ROCBLAS(false)
-
-KOKKOSBLAS1_SSCAL_TPL_SPEC_DECL_ROCBLAS(true)
-KOKKOSBLAS1_SSCAL_TPL_SPEC_DECL_ROCBLAS(false)
-
-KOKKOSBLAS1_ZSCAL_TPL_SPEC_DECL_ROCBLAS(true)
-KOKKOSBLAS1_ZSCAL_TPL_SPEC_DECL_ROCBLAS(false)
-
-KOKKOSBLAS1_CSCAL_TPL_SPEC_DECL_ROCBLAS(true)
-KOKKOSBLAS1_CSCAL_TPL_SPEC_DECL_ROCBLAS(false)
+KOKKOSBLAS1_XSCAL_TPL_SPEC_DECL_ROCBLAS(Kokkos::complex<float>, rocblas_float_complex, rocblas_cscal)
 
 }  // namespace Impl
 }  // namespace KokkosBlas

--- a/blas/tpls/KokkosBlas1_swap_tpl_spec_decl.hpp
+++ b/blas/tpls/KokkosBlas1_swap_tpl_spec_decl.hpp
@@ -26,95 +26,75 @@ inline void swap_print_specialization() {
 namespace KokkosBlas {
 namespace Impl {
 
-#define KOKKOSBLAS1_DSWAP_TPL_SPEC_DECL_BLAS(ETI_SPEC_AVAIL)                                                         \
-  template <typename ExecSpace>                                                                                      \
-    requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)                                    \
-  struct Swap<ExecSpace,                                                                                             \
-              Kokkos::View<double*, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
-              Kokkos::View<double*, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
-              true, ETI_SPEC_AVAIL> {                                                                                \
-    using XVector =                                                                                                  \
-        Kokkos::View<double*, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;       \
-    using YVector =                                                                                                  \
-        Kokkos::View<double*, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;       \
-    static void swap(ExecSpace const& /*space*/, XVector const& X, YVector const& Y) {                               \
-      Kokkos::Profiling::pushRegion("KokkosBlas::swap[TPL_BLAS,double]");                                            \
-      HostBlas<double>::swap(X.extent_int(0), X.data(), 1, Y.data(), 1);                                             \
-      Kokkos::Profiling::popRegion();                                                                                \
-    }                                                                                                                \
-  };
+template <typename ExecSpace, bool ETI_SPEC_AVAIL>
+  requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)
+struct Swap<ExecSpace,
+            Kokkos::View<double*, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,
+            Kokkos::View<double*, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, true,
+            ETI_SPEC_AVAIL> {
+  using XVector = Kokkos::View<double*, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+  using YVector = Kokkos::View<double*, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+  static void swap(ExecSpace const& /*space*/, XVector const& X, YVector const& Y) {
+    Kokkos::Profiling::pushRegion("KokkosBlas::swap[TPL_BLAS,double]");
+    HostBlas<double>::swap(X.extent_int(0), X.data(), 1, Y.data(), 1);
+    Kokkos::Profiling::popRegion();
+  }
+};
 
-#define KOKKOSBLAS1_SSWAP_TPL_SPEC_DECL_BLAS(ETI_SPEC_AVAIL)                                                        \
-  template <typename ExecSpace>                                                                                     \
-    requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)                                   \
-  struct Swap<ExecSpace,                                                                                            \
-              Kokkos::View<float*, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
-              Kokkos::View<float*, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
-              true, ETI_SPEC_AVAIL> {                                                                               \
-    using XVector =                                                                                                 \
-        Kokkos::View<float*, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;       \
-    using YVector =                                                                                                 \
-        Kokkos::View<float*, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;       \
-    static void swap(ExecSpace const& /*space*/, XVector const& X, YVector const& Y) {                              \
-      Kokkos::Profiling::pushRegion("KokkosBlas::swap[TPL_BLAS,float]");                                            \
-      HostBlas<float>::swap(X.extent_int(0), X.data(), 1, Y.data(), 1);                                             \
-      Kokkos::Profiling::popRegion();                                                                               \
-    }                                                                                                               \
-  };
+template <typename ExecSpace, bool ETI_SPEC_AVAIL>
+  requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)
+struct Swap<ExecSpace,
+            Kokkos::View<float*, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,
+            Kokkos::View<float*, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, true,
+            ETI_SPEC_AVAIL> {
+  using XVector = Kokkos::View<float*, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+  using YVector = Kokkos::View<float*, Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+  static void swap(ExecSpace const& /*space*/, XVector const& X, YVector const& Y) {
+    Kokkos::Profiling::pushRegion("KokkosBlas::swap[TPL_BLAS,float]");
+    HostBlas<float>::swap(X.extent_int(0), X.data(), 1, Y.data(), 1);
+    Kokkos::Profiling::popRegion();
+  }
+};
 
-#define KOKKOSBLAS1_ZSWAP_TPL_SPEC_DECL_BLAS(ETI_SPEC_AVAIL)                                                      \
-  template <typename ExecSpace>                                                                                   \
-    requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)                                 \
-  struct Swap<ExecSpace,                                                                                          \
-              Kokkos::View<Kokkos::complex<double>*, Kokkos::LayoutLeft, Kokkos::HostSpace,                       \
-                           Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                              \
-              Kokkos::View<Kokkos::complex<double>*, Kokkos::LayoutLeft, Kokkos::HostSpace,                       \
-                           Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                              \
-              true, ETI_SPEC_AVAIL> {                                                                             \
-    using XVector = Kokkos::View<Kokkos::complex<double>*, Kokkos::LayoutLeft, Kokkos::HostSpace,                 \
-                                 Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                        \
-    using YVector = Kokkos::View<Kokkos::complex<double>*, Kokkos::LayoutLeft, Kokkos::HostSpace,                 \
-                                 Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                        \
-    static void swap(ExecSpace const& /*space*/, XVector const& X, YVector const& Y) {                            \
-      Kokkos::Profiling::pushRegion("KokkosBlas::swap[TPL_BLAS,complex<double>]");                                \
-      HostBlas<std::complex<double>>::swap(X.extent_int(0), reinterpret_cast<std::complex<double>*>(X.data()), 1, \
-                                           reinterpret_cast<std::complex<double>*>(Y.data()), 1);                 \
-      Kokkos::Profiling::popRegion();                                                                             \
-    }                                                                                                             \
-  };
+template <typename ExecSpace, bool ETI_SPEC_AVAIL>
+  requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)
+struct Swap<ExecSpace,
+            Kokkos::View<Kokkos::complex<double>*, Kokkos::LayoutLeft, Kokkos::HostSpace,
+                         Kokkos::MemoryTraits<Kokkos::Unmanaged>>,
+            Kokkos::View<Kokkos::complex<double>*, Kokkos::LayoutLeft, Kokkos::HostSpace,
+                         Kokkos::MemoryTraits<Kokkos::Unmanaged>>,
+            true, ETI_SPEC_AVAIL> {
+  using XVector = Kokkos::View<Kokkos::complex<double>*, Kokkos::LayoutLeft, Kokkos::HostSpace,
+                               Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+  using YVector = Kokkos::View<Kokkos::complex<double>*, Kokkos::LayoutLeft, Kokkos::HostSpace,
+                               Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+  static void swap(ExecSpace const& /*space*/, XVector const& X, YVector const& Y) {
+    Kokkos::Profiling::pushRegion("KokkosBlas::swap[TPL_BLAS,complex<double>]");
+    HostBlas<std::complex<double>>::swap(X.extent_int(0), reinterpret_cast<std::complex<double>*>(X.data()), 1,
+                                         reinterpret_cast<std::complex<double>*>(Y.data()), 1);
+    Kokkos::Profiling::popRegion();
+  }
+};
 
-#define KOKKOSBLAS1_CSWAP_TPL_SPEC_DECL_BLAS(ETI_SPEC_AVAIL)                                                    \
-  template <typename ExecSpace>                                                                                 \
-    requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)                               \
-  struct Swap<ExecSpace,                                                                                        \
-              Kokkos::View<Kokkos::complex<float>*, Kokkos::LayoutLeft, Kokkos::HostSpace,                      \
-                           Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                            \
-              Kokkos::View<Kokkos::complex<float>*, Kokkos::LayoutLeft, Kokkos::HostSpace,                      \
-                           Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                            \
-              true, ETI_SPEC_AVAIL> {                                                                           \
-    using XVector = Kokkos::View<Kokkos::complex<float>*, Kokkos::LayoutLeft, Kokkos::HostSpace,                \
-                                 Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                      \
-    using YVector = Kokkos::View<Kokkos::complex<float>*, Kokkos::LayoutLeft, Kokkos::HostSpace,                \
-                                 Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                      \
-    static void swap(ExecSpace const& /*space*/, XVector const& X, YVector const& Y) {                          \
-      Kokkos::Profiling::pushRegion("KokkosBlas::swap[TPL_BLAS,complex<float>]");                               \
-      HostBlas<std::complex<float>>::swap(X.extent_int(0), reinterpret_cast<std::complex<float>*>(X.data()), 1, \
-                                          reinterpret_cast<std::complex<float>*>(Y.data()), 1);                 \
-      Kokkos::Profiling::popRegion();                                                                           \
-    }                                                                                                           \
-  };
-
-KOKKOSBLAS1_DSWAP_TPL_SPEC_DECL_BLAS(true)
-KOKKOSBLAS1_DSWAP_TPL_SPEC_DECL_BLAS(false)
-
-KOKKOSBLAS1_SSWAP_TPL_SPEC_DECL_BLAS(true)
-KOKKOSBLAS1_SSWAP_TPL_SPEC_DECL_BLAS(false)
-
-KOKKOSBLAS1_ZSWAP_TPL_SPEC_DECL_BLAS(true)
-KOKKOSBLAS1_ZSWAP_TPL_SPEC_DECL_BLAS(false)
-
-KOKKOSBLAS1_CSWAP_TPL_SPEC_DECL_BLAS(true)
-KOKKOSBLAS1_CSWAP_TPL_SPEC_DECL_BLAS(false)
+template <typename ExecSpace, bool ETI_SPEC_AVAIL>
+  requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)
+struct Swap<ExecSpace,
+            Kokkos::View<Kokkos::complex<float>*, Kokkos::LayoutLeft, Kokkos::HostSpace,
+                         Kokkos::MemoryTraits<Kokkos::Unmanaged>>,
+            Kokkos::View<Kokkos::complex<float>*, Kokkos::LayoutLeft, Kokkos::HostSpace,
+                         Kokkos::MemoryTraits<Kokkos::Unmanaged>>,
+            true, ETI_SPEC_AVAIL> {
+  using XVector = Kokkos::View<Kokkos::complex<float>*, Kokkos::LayoutLeft, Kokkos::HostSpace,
+                               Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+  using YVector = Kokkos::View<Kokkos::complex<float>*, Kokkos::LayoutLeft, Kokkos::HostSpace,
+                               Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+  static void swap(ExecSpace const& /*space*/, XVector const& X, YVector const& Y) {
+    Kokkos::Profiling::pushRegion("KokkosBlas::swap[TPL_BLAS,complex<float>]");
+    HostBlas<std::complex<float>>::swap(X.extent_int(0), reinterpret_cast<std::complex<float>*>(X.data()), 1,
+                                        reinterpret_cast<std::complex<float>*>(Y.data()), 1);
+    Kokkos::Profiling::popRegion();
+  }
+};
 
 }  // namespace Impl
 }  // namespace KokkosBlas
@@ -128,8 +108,8 @@ KOKKOSBLAS1_CSWAP_TPL_SPEC_DECL_BLAS(false)
 namespace KokkosBlas {
 namespace Impl {
 
-#define KOKKOSBLAS1_DSWAP_TPL_SPEC_DECL_CUBLAS(LAYOUT, ETI_SPEC_AVAIL)                                            \
-  template <>                                                                                                     \
+#define KOKKOSBLAS1_DSWAP_TPL_SPEC_DECL_CUBLAS(LAYOUT)                                                            \
+  template <bool ETI_SPEC_AVAIL>                                                                                  \
   struct Swap<Kokkos::Cuda, Kokkos::View<double*, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
               Kokkos::View<double*, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, true,         \
               ETI_SPEC_AVAIL> {                                                                                   \
@@ -145,8 +125,8 @@ namespace Impl {
     }                                                                                                             \
   };
 
-#define KOKKOSBLAS1_SSWAP_TPL_SPEC_DECL_CUBLAS(LAYOUT, ETI_SPEC_AVAIL)                                            \
-  template <>                                                                                                     \
+#define KOKKOSBLAS1_SSWAP_TPL_SPEC_DECL_CUBLAS(LAYOUT)                                                            \
+  template <bool ETI_SPEC_AVAIL>                                                                                  \
   struct Swap<Kokkos::Cuda, Kokkos::View<float*, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,  \
               Kokkos::View<float*, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, true,          \
               ETI_SPEC_AVAIL> {                                                                                   \
@@ -162,8 +142,8 @@ namespace Impl {
     }                                                                                                             \
   };
 
-#define KOKKOSBLAS1_ZSWAP_TPL_SPEC_DECL_CUBLAS(LAYOUT, ETI_SPEC_AVAIL)                                               \
-  template <>                                                                                                        \
+#define KOKKOSBLAS1_ZSWAP_TPL_SPEC_DECL_CUBLAS(LAYOUT)                                                               \
+  template <bool ETI_SPEC_AVAIL>                                                                                     \
   struct Swap<Kokkos::Cuda,                                                                                          \
               Kokkos::View<Kokkos::complex<double>*, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
               Kokkos::View<Kokkos::complex<double>*, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
@@ -184,8 +164,8 @@ namespace Impl {
     }                                                                                                                \
   };
 
-#define KOKKOSBLAS1_CSWAP_TPL_SPEC_DECL_CUBLAS(LAYOUT, ETI_SPEC_AVAIL)                                              \
-  template <>                                                                                                       \
+#define KOKKOSBLAS1_CSWAP_TPL_SPEC_DECL_CUBLAS(LAYOUT)                                                              \
+  template <bool ETI_SPEC_AVAIL>                                                                                    \
   struct Swap<Kokkos::Cuda,                                                                                         \
               Kokkos::View<Kokkos::complex<float>*, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
               Kokkos::View<Kokkos::complex<float>*, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
@@ -206,25 +186,17 @@ namespace Impl {
     }                                                                                                               \
   };
 
-KOKKOSBLAS1_DSWAP_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS1_DSWAP_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS1_DSWAP_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS1_DSWAP_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutRight, false)
+KOKKOSBLAS1_DSWAP_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS1_DSWAP_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutRight)
 
-KOKKOSBLAS1_SSWAP_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS1_SSWAP_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS1_SSWAP_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS1_SSWAP_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutRight, false)
+KOKKOSBLAS1_SSWAP_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS1_SSWAP_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutRight)
 
-KOKKOSBLAS1_ZSWAP_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS1_ZSWAP_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS1_ZSWAP_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS1_ZSWAP_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutRight, false)
+KOKKOSBLAS1_ZSWAP_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS1_ZSWAP_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutRight)
 
-KOKKOSBLAS1_CSWAP_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS1_CSWAP_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS1_CSWAP_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS1_CSWAP_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutRight, false)
+KOKKOSBLAS1_CSWAP_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS1_CSWAP_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutRight)
 }  // namespace Impl
 }  // namespace KokkosBlas
 #endif  // KOKKOSKERNELS_ENABLE_TPL_CUBLAS
@@ -236,8 +208,8 @@ KOKKOSBLAS1_CSWAP_TPL_SPEC_DECL_CUBLAS(Kokkos::LayoutRight, false)
 namespace KokkosBlas {
 namespace Impl {
 
-#define KOKKOSBLAS1_DSWAP_TPL_SPEC_DECL_ROCBLAS(LAYOUT, ETI_SPEC_AVAIL)                                              \
-  template <>                                                                                                        \
+#define KOKKOSBLAS1_DSWAP_TPL_SPEC_DECL_ROCBLAS(LAYOUT)                                                              \
+  template <bool ETI_SPEC_AVAIL>                                                                                     \
   struct Swap<Kokkos::HIP, Kokkos::View<double*, LAYOUT, Kokkos::HIP, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,      \
               Kokkos::View<double*, LAYOUT, Kokkos::HIP, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, true,             \
               ETI_SPEC_AVAIL> {                                                                                      \
@@ -253,8 +225,8 @@ namespace Impl {
     }                                                                                                                \
   };
 
-#define KOKKOSBLAS1_SSWAP_TPL_SPEC_DECL_ROCBLAS(LAYOUT, ETI_SPEC_AVAIL)                                              \
-  template <>                                                                                                        \
+#define KOKKOSBLAS1_SSWAP_TPL_SPEC_DECL_ROCBLAS(LAYOUT)                                                              \
+  template <bool ETI_SPEC_AVAIL>                                                                                     \
   struct Swap<Kokkos::HIP, Kokkos::View<float*, LAYOUT, Kokkos::HIP, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,       \
               Kokkos::View<float*, LAYOUT, Kokkos::HIP, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, true,              \
               ETI_SPEC_AVAIL> {                                                                                      \
@@ -270,8 +242,8 @@ namespace Impl {
     }                                                                                                                \
   };
 
-#define KOKKOSBLAS1_ZSWAP_TPL_SPEC_DECL_ROCBLAS(LAYOUT, ETI_SPEC_AVAIL)                                             \
-  template <>                                                                                                       \
+#define KOKKOSBLAS1_ZSWAP_TPL_SPEC_DECL_ROCBLAS(LAYOUT)                                                             \
+  template <bool ETI_SPEC_AVAIL>                                                                                    \
   struct Swap<Kokkos::HIP,                                                                                          \
               Kokkos::View<Kokkos::complex<double>*, LAYOUT, Kokkos::HIP, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
               Kokkos::View<Kokkos::complex<double>*, LAYOUT, Kokkos::HIP, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
@@ -292,8 +264,8 @@ namespace Impl {
     }                                                                                                               \
   };
 
-#define KOKKOSBLAS1_CSWAP_TPL_SPEC_DECL_ROCBLAS(LAYOUT, ETI_SPEC_AVAIL)                                            \
-  template <>                                                                                                      \
+#define KOKKOSBLAS1_CSWAP_TPL_SPEC_DECL_ROCBLAS(LAYOUT)                                                            \
+  template <bool ETI_SPEC_AVAIL>                                                                                   \
   struct Swap<Kokkos::HIP,                                                                                         \
               Kokkos::View<Kokkos::complex<float>*, LAYOUT, Kokkos::HIP, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
               Kokkos::View<Kokkos::complex<float>*, LAYOUT, Kokkos::HIP, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
@@ -314,25 +286,17 @@ namespace Impl {
     }                                                                                                              \
   };
 
-KOKKOSBLAS1_DSWAP_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS1_DSWAP_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS1_DSWAP_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS1_DSWAP_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutRight, false)
+KOKKOSBLAS1_DSWAP_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS1_DSWAP_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutRight)
 
-KOKKOSBLAS1_SSWAP_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS1_SSWAP_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS1_SSWAP_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS1_SSWAP_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutRight, false)
+KOKKOSBLAS1_SSWAP_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS1_SSWAP_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutRight)
 
-KOKKOSBLAS1_ZSWAP_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS1_ZSWAP_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS1_ZSWAP_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS1_ZSWAP_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutRight, false)
+KOKKOSBLAS1_ZSWAP_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS1_ZSWAP_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutRight)
 
-KOKKOSBLAS1_CSWAP_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS1_CSWAP_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS1_CSWAP_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS1_CSWAP_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutRight, false)
+KOKKOSBLAS1_CSWAP_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS1_CSWAP_TPL_SPEC_DECL_ROCBLAS(Kokkos::LayoutRight)
 }  // namespace Impl
 }  // namespace KokkosBlas
 #endif  // KOKKOSKERNELS_ENABLE_TPL_ROCBLAS

--- a/blas/tpls/KokkosBlas2_gemv_tpl_spec_decl.hpp
+++ b/blas/tpls/KokkosBlas2_gemv_tpl_spec_decl.hpp
@@ -30,8 +30,8 @@ namespace Impl {
     transa = 'C';                                                            \
   }
 
-#define KOKKOSBLAS2_DGEMV_BLAS(LAYOUT, ETI_SPEC_AVAIL)                                                              \
-  template <typename ExecSpace>                                                                                     \
+#define KOKKOSBLAS2_DGEMV_BLAS(LAYOUT)                                                                              \
+  template <typename ExecSpace, bool ETI_SPEC_AVAIL>                                                                \
     requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)                                   \
   struct GEMV<ExecSpace, Kokkos::View<const double**, LAYOUT, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
               Kokkos::View<const double*, LAYOUT, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,             \
@@ -52,8 +52,8 @@ namespace Impl {
     }                                                                                                               \
   };
 
-#define KOKKOSBLAS2_SGEMV_BLAS(LAYOUT, ETI_SPEC_AVAIL)                                                              \
-  template <typename ExecSpace>                                                                                     \
+#define KOKKOSBLAS2_SGEMV_BLAS(LAYOUT)                                                                              \
+  template <typename ExecSpace, bool ETI_SPEC_AVAIL>                                                                \
     requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)                                   \
   struct GEMV<ExecSpace, Kokkos::View<const float**, LAYOUT, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,  \
               Kokkos::View<const float*, LAYOUT, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,              \
@@ -74,8 +74,8 @@ namespace Impl {
     }                                                                                                               \
   };
 
-#define KOKKOSBLAS2_ZGEMV_BLAS(LAYOUT, ETI_SPEC_AVAIL)                                                              \
-  template <typename ExecSpace>                                                                                     \
+#define KOKKOSBLAS2_ZGEMV_BLAS(LAYOUT)                                                                              \
+  template <typename ExecSpace, bool ETI_SPEC_AVAIL>                                                                \
     requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)                                   \
   struct GEMV<                                                                                                      \
       ExecSpace,                                                                                                    \
@@ -102,8 +102,8 @@ namespace Impl {
     }                                                                                                               \
   };
 
-#define KOKKOSBLAS2_CGEMV_BLAS(LAYOUT, ETI_SPEC_AVAIL)                                                              \
-  template <typename ExecSpace>                                                                                     \
+#define KOKKOSBLAS2_CGEMV_BLAS(LAYOUT)                                                                              \
+  template <typename ExecSpace, bool ETI_SPEC_AVAIL>                                                                \
     requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)                                   \
   struct GEMV<                                                                                                      \
       ExecSpace,                                                                                                    \
@@ -130,25 +130,17 @@ namespace Impl {
     }                                                                                                               \
   };
 
-KOKKOSBLAS2_DGEMV_BLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS2_DGEMV_BLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS2_DGEMV_BLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS2_DGEMV_BLAS(Kokkos::LayoutRight, false)
+KOKKOSBLAS2_DGEMV_BLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS2_DGEMV_BLAS(Kokkos::LayoutRight)
 
-KOKKOSBLAS2_SGEMV_BLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS2_SGEMV_BLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS2_SGEMV_BLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS2_SGEMV_BLAS(Kokkos::LayoutRight, false)
+KOKKOSBLAS2_SGEMV_BLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS2_SGEMV_BLAS(Kokkos::LayoutRight)
 
-KOKKOSBLAS2_ZGEMV_BLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS2_ZGEMV_BLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS2_ZGEMV_BLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS2_ZGEMV_BLAS(Kokkos::LayoutRight, false)
+KOKKOSBLAS2_ZGEMV_BLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS2_ZGEMV_BLAS(Kokkos::LayoutRight)
 
-KOKKOSBLAS2_CGEMV_BLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS2_CGEMV_BLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS2_CGEMV_BLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS2_CGEMV_BLAS(Kokkos::LayoutRight, false)
+KOKKOSBLAS2_CGEMV_BLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS2_CGEMV_BLAS(Kokkos::LayoutRight)
 
 }  // namespace Impl
 }  // namespace KokkosBlas
@@ -181,8 +173,8 @@ namespace Impl {
     transa = CUBLAS_OP_C;                                                    \
   }
 
-#define KOKKOSBLAS2_DGEMV_CUBLAS(LAYOUT, ETI_SPEC_AVAIL)                                                             \
-  template <>                                                                                                        \
+#define KOKKOSBLAS2_DGEMV_CUBLAS(LAYOUT)                                                                             \
+  template <bool ETI_SPEC_AVAIL>                                                                                     \
   struct GEMV<                                                                                                       \
       Kokkos::Cuda, Kokkos::View<const double**, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,    \
       Kokkos::View<const double*, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                   \
@@ -206,8 +198,8 @@ namespace Impl {
     }                                                                                                                \
   };
 
-#define KOKKOSBLAS2_SGEMV_CUBLAS(LAYOUT, ETI_SPEC_AVAIL)                                                            \
-  template <>                                                                                                       \
+#define KOKKOSBLAS2_SGEMV_CUBLAS(LAYOUT)                                                                            \
+  template <bool ETI_SPEC_AVAIL>                                                                                    \
   struct GEMV<                                                                                                      \
       Kokkos::Cuda, Kokkos::View<const float**, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,    \
       Kokkos::View<const float*, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                   \
@@ -231,8 +223,8 @@ namespace Impl {
     }                                                                                                               \
   };
 
-#define KOKKOSBLAS2_ZGEMV_CUBLAS(LAYOUT, ETI_SPEC_AVAIL)                                                               \
-  template <>                                                                                                          \
+#define KOKKOSBLAS2_ZGEMV_CUBLAS(LAYOUT)                                                                               \
+  template <bool ETI_SPEC_AVAIL>                                                                                       \
   struct GEMV<                                                                                                         \
       Kokkos::Cuda,                                                                                                    \
       Kokkos::View<const Kokkos::complex<double>**, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,   \
@@ -260,8 +252,8 @@ namespace Impl {
     }                                                                                                                  \
   };
 
-#define KOKKOSBLAS2_CGEMV_CUBLAS(LAYOUT, ETI_SPEC_AVAIL)                                                               \
-  template <>                                                                                                          \
+#define KOKKOSBLAS2_CGEMV_CUBLAS(LAYOUT)                                                                               \
+  template <bool ETI_SPEC_AVAIL>                                                                                       \
   struct GEMV<                                                                                                         \
       Kokkos::Cuda,                                                                                                    \
       Kokkos::View<const Kokkos::complex<float>**, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,    \
@@ -289,25 +281,17 @@ namespace Impl {
     }                                                                                                                  \
   };
 
-KOKKOSBLAS2_DGEMV_CUBLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS2_DGEMV_CUBLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS2_DGEMV_CUBLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS2_DGEMV_CUBLAS(Kokkos::LayoutRight, false)
+KOKKOSBLAS2_DGEMV_CUBLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS2_DGEMV_CUBLAS(Kokkos::LayoutRight)
 
-KOKKOSBLAS2_SGEMV_CUBLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS2_SGEMV_CUBLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS2_SGEMV_CUBLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS2_SGEMV_CUBLAS(Kokkos::LayoutRight, false)
+KOKKOSBLAS2_SGEMV_CUBLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS2_SGEMV_CUBLAS(Kokkos::LayoutRight)
 
-KOKKOSBLAS2_ZGEMV_CUBLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS2_ZGEMV_CUBLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS2_ZGEMV_CUBLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS2_ZGEMV_CUBLAS(Kokkos::LayoutRight, false)
+KOKKOSBLAS2_ZGEMV_CUBLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS2_ZGEMV_CUBLAS(Kokkos::LayoutRight)
 
-KOKKOSBLAS2_CGEMV_CUBLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS2_CGEMV_CUBLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS2_CGEMV_CUBLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS2_CGEMV_CUBLAS(Kokkos::LayoutRight, false)
+KOKKOSBLAS2_CGEMV_CUBLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS2_CGEMV_CUBLAS(Kokkos::LayoutRight)
 
 }  // namespace Impl
 }  // namespace KokkosBlas
@@ -340,8 +324,8 @@ namespace Impl {
     transa = rocblas_operation_conjugate_transpose;                          \
   }
 
-#define KOKKOSBLAS2_DGEMV_ROCBLAS(LAYOUT, ETI_SPEC_AVAIL)                                                           \
-  template <>                                                                                                       \
+#define KOKKOSBLAS2_DGEMV_ROCBLAS(LAYOUT)                                                                           \
+  template <bool ETI_SPEC_AVAIL>                                                                                    \
   struct GEMV<                                                                                                      \
       Kokkos::HIP, Kokkos::View<const double**, LAYOUT, Kokkos::HIP, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,     \
       Kokkos::View<const double*, LAYOUT, Kokkos::HIP, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                   \
@@ -365,8 +349,8 @@ namespace Impl {
     }                                                                                                               \
   };
 
-#define KOKKOSBLAS2_SGEMV_ROCBLAS(LAYOUT, ETI_SPEC_AVAIL)                                                              \
-  template <>                                                                                                          \
+#define KOKKOSBLAS2_SGEMV_ROCBLAS(LAYOUT)                                                                              \
+  template <bool ETI_SPEC_AVAIL>                                                                                       \
   struct GEMV<Kokkos::HIP, Kokkos::View<const float**, LAYOUT, Kokkos::HIP, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
               Kokkos::View<const float*, LAYOUT, Kokkos::HIP, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,               \
               Kokkos::View<float*, LAYOUT, Kokkos::HIP, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, true,               \
@@ -390,8 +374,8 @@ namespace Impl {
     }                                                                                                                  \
   };
 
-#define KOKKOSBLAS2_ZGEMV_ROCBLAS(LAYOUT, ETI_SPEC_AVAIL)                                                             \
-  template <>                                                                                                         \
+#define KOKKOSBLAS2_ZGEMV_ROCBLAS(LAYOUT)                                                                             \
+  template <bool ETI_SPEC_AVAIL>                                                                                      \
   struct GEMV<                                                                                                        \
       Kokkos::HIP,                                                                                                    \
       Kokkos::View<const Kokkos::complex<double>**, LAYOUT, Kokkos::HIP, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,   \
@@ -421,8 +405,8 @@ namespace Impl {
     }                                                                                                                 \
   };
 
-#define KOKKOSBLAS2_CGEMV_ROCBLAS(LAYOUT, ETI_SPEC_AVAIL)                                                            \
-  template <>                                                                                                        \
+#define KOKKOSBLAS2_CGEMV_ROCBLAS(LAYOUT)                                                                            \
+  template <bool ETI_SPEC_AVAIL>                                                                                     \
   struct GEMV<                                                                                                       \
       Kokkos::HIP,                                                                                                   \
       Kokkos::View<const Kokkos::complex<float>**, LAYOUT, Kokkos::HIP, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,   \
@@ -452,25 +436,17 @@ namespace Impl {
     }                                                                                                                \
   };
 
-KOKKOSBLAS2_DGEMV_ROCBLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS2_DGEMV_ROCBLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS2_DGEMV_ROCBLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS2_DGEMV_ROCBLAS(Kokkos::LayoutRight, false)
+KOKKOSBLAS2_DGEMV_ROCBLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS2_DGEMV_ROCBLAS(Kokkos::LayoutRight)
 
-KOKKOSBLAS2_SGEMV_ROCBLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS2_SGEMV_ROCBLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS2_SGEMV_ROCBLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS2_SGEMV_ROCBLAS(Kokkos::LayoutRight, false)
+KOKKOSBLAS2_SGEMV_ROCBLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS2_SGEMV_ROCBLAS(Kokkos::LayoutRight)
 
-KOKKOSBLAS2_ZGEMV_ROCBLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS2_ZGEMV_ROCBLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS2_ZGEMV_ROCBLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS2_ZGEMV_ROCBLAS(Kokkos::LayoutRight, false)
+KOKKOSBLAS2_ZGEMV_ROCBLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS2_ZGEMV_ROCBLAS(Kokkos::LayoutRight)
 
-KOKKOSBLAS2_CGEMV_ROCBLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS2_CGEMV_ROCBLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS2_CGEMV_ROCBLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS2_CGEMV_ROCBLAS(Kokkos::LayoutRight, false)
+KOKKOSBLAS2_CGEMV_ROCBLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS2_CGEMV_ROCBLAS(Kokkos::LayoutRight)
 
 }  // namespace Impl
 }  // namespace KokkosBlas
@@ -485,8 +461,8 @@ KOKKOSBLAS2_CGEMV_ROCBLAS(Kokkos::LayoutRight, false)
 namespace KokkosBlas {
 namespace Impl {
 
-#define KOKKOSBLAS2_GEMV_ONEMKL(SCALAR, LAYOUT, ETI_SPEC_AVAIL)                                                         \
-  template <>                                                                                                           \
+#define KOKKOSBLAS2_GEMV_ONEMKL(SCALAR, LAYOUT)                                                                         \
+  template <bool ETI_SPEC_AVAIL>                                                                                        \
   struct GEMV<                                                                                                          \
       Kokkos::SYCL, Kokkos::View<const SCALAR**, LAYOUT, Kokkos::SYCL, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,       \
       Kokkos::View<const SCALAR*, LAYOUT, Kokkos::SYCL, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                      \
@@ -524,14 +500,14 @@ namespace Impl {
     }                                                                                                                   \
   };
 
-KOKKOSBLAS2_GEMV_ONEMKL(float, Kokkos::LayoutLeft, true)
-KOKKOSBLAS2_GEMV_ONEMKL(float, Kokkos::LayoutRight, true)
-KOKKOSBLAS2_GEMV_ONEMKL(double, Kokkos::LayoutLeft, true)
-KOKKOSBLAS2_GEMV_ONEMKL(double, Kokkos::LayoutRight, true)
-KOKKOSBLAS2_GEMV_ONEMKL(Kokkos::complex<float>, Kokkos::LayoutLeft, true)
-KOKKOSBLAS2_GEMV_ONEMKL(Kokkos::complex<float>, Kokkos::LayoutRight, true)
-KOKKOSBLAS2_GEMV_ONEMKL(Kokkos::complex<double>, Kokkos::LayoutLeft, true)
-KOKKOSBLAS2_GEMV_ONEMKL(Kokkos::complex<double>, Kokkos::LayoutRight, true)
+KOKKOSBLAS2_GEMV_ONEMKL(float, Kokkos::LayoutLeft)
+KOKKOSBLAS2_GEMV_ONEMKL(float, Kokkos::LayoutRight)
+KOKKOSBLAS2_GEMV_ONEMKL(double, Kokkos::LayoutLeft)
+KOKKOSBLAS2_GEMV_ONEMKL(double, Kokkos::LayoutRight)
+KOKKOSBLAS2_GEMV_ONEMKL(Kokkos::complex<float>, Kokkos::LayoutLeft)
+KOKKOSBLAS2_GEMV_ONEMKL(Kokkos::complex<float>, Kokkos::LayoutRight)
+KOKKOSBLAS2_GEMV_ONEMKL(Kokkos::complex<double>, Kokkos::LayoutLeft)
+KOKKOSBLAS2_GEMV_ONEMKL(Kokkos::complex<double>, Kokkos::LayoutRight)
 }  // namespace Impl
 }  // namespace KokkosBlas
 #endif

--- a/blas/tpls/KokkosBlas3_gemm_tpl_spec_decl.hpp
+++ b/blas/tpls/KokkosBlas3_gemm_tpl_spec_decl.hpp
@@ -10,8 +10,8 @@
 namespace KokkosBlas {
 namespace Impl {
 
-#define KOKKOSBLAS3_XGEMM_BLAS(SCALAR_TYPE, BASE_SCALAR_TYPE, LAYOUT, ETI_SPEC_AVAIL)                            \
-  template <typename ExecSpace>                                                                                  \
+#define KOKKOSBLAS3_XGEMM_BLAS(SCALAR_TYPE, BASE_SCALAR_TYPE, LAYOUT)                                            \
+  template <typename ExecSpace, bool ETI_SPEC_AVAIL>                                                             \
     requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)                                \
   struct GEMM<ExecSpace,                                                                                         \
               Kokkos::View<const SCALAR_TYPE**, LAYOUT, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,    \
@@ -55,32 +55,22 @@ namespace Impl {
     }                                                                                                            \
   };
 
-#define KOKKOSBLAS3_DGEMM_BLAS(LAYOUT, ETI_SPEC_AVAIL) KOKKOSBLAS3_XGEMM_BLAS(double, double, LAYOUT, ETI_SPEC_AVAIL)
+#define KOKKOSBLAS3_DGEMM_BLAS(LAYOUT) KOKKOSBLAS3_XGEMM_BLAS(double, double, LAYOUT)
 
-#define KOKKOSBLAS3_SGEMM_BLAS(LAYOUT, ETI_SPEC_AVAIL) KOKKOSBLAS3_XGEMM_BLAS(float, float, LAYOUT, ETI_SPEC_AVAIL)
+#define KOKKOSBLAS3_SGEMM_BLAS(LAYOUT) KOKKOSBLAS3_XGEMM_BLAS(float, float, LAYOUT)
 
-#define KOKKOSBLAS3_ZGEMM_BLAS(LAYOUT, ETI_SPEC_AVAIL) \
-  KOKKOSBLAS3_XGEMM_BLAS(Kokkos::complex<double>, std::complex<double>, LAYOUT, ETI_SPEC_AVAIL)
+#define KOKKOSBLAS3_ZGEMM_BLAS(LAYOUT) KOKKOSBLAS3_XGEMM_BLAS(Kokkos::complex<double>, std::complex<double>, LAYOUT)
 
-#define KOKKOSBLAS3_CGEMM_BLAS(LAYOUT, ETI_SPEC_AVAIL) \
-  KOKKOSBLAS3_XGEMM_BLAS(Kokkos::complex<float>, std::complex<float>, LAYOUT, ETI_SPEC_AVAIL)
+#define KOKKOSBLAS3_CGEMM_BLAS(LAYOUT) KOKKOSBLAS3_XGEMM_BLAS(Kokkos::complex<float>, std::complex<float>, LAYOUT)
 
-KOKKOSBLAS3_DGEMM_BLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS3_DGEMM_BLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS3_DGEMM_BLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS3_DGEMM_BLAS(Kokkos::LayoutRight, false)
-KOKKOSBLAS3_SGEMM_BLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS3_SGEMM_BLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS3_SGEMM_BLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS3_SGEMM_BLAS(Kokkos::LayoutRight, false)
-KOKKOSBLAS3_ZGEMM_BLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS3_ZGEMM_BLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS3_ZGEMM_BLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS3_ZGEMM_BLAS(Kokkos::LayoutRight, false)
-KOKKOSBLAS3_CGEMM_BLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS3_CGEMM_BLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS3_CGEMM_BLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS3_CGEMM_BLAS(Kokkos::LayoutRight, false)
+KOKKOSBLAS3_DGEMM_BLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS3_DGEMM_BLAS(Kokkos::LayoutRight)
+KOKKOSBLAS3_SGEMM_BLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS3_SGEMM_BLAS(Kokkos::LayoutRight)
+KOKKOSBLAS3_ZGEMM_BLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS3_ZGEMM_BLAS(Kokkos::LayoutRight)
+KOKKOSBLAS3_CGEMM_BLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS3_CGEMM_BLAS(Kokkos::LayoutRight)
 
 }  // namespace Impl
 }  // namespace KokkosBlas
@@ -94,8 +84,8 @@ KOKKOSBLAS3_CGEMM_BLAS(Kokkos::LayoutRight, false)
 namespace KokkosBlas {
 namespace Impl {
 
-#define KOKKOSBLAS3_XGEMM_CUBLAS(SCALAR_TYPE, CUDA_SCALAR_TYPE, CUBLAS_FN, LAYOUT, ETI_SPEC_AVAIL)                    \
-  template <>                                                                                                         \
+#define KOKKOSBLAS3_XGEMM_CUBLAS(SCALAR_TYPE, CUDA_SCALAR_TYPE, CUBLAS_FN, LAYOUT)                                    \
+  template <bool ETI_SPEC_AVAIL>                                                                                      \
   struct GEMM<Kokkos::Cuda,                                                                                           \
               Kokkos::View<const SCALAR_TYPE**, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,      \
               Kokkos::View<const SCALAR_TYPE**, LAYOUT, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,      \
@@ -156,37 +146,27 @@ namespace Impl {
     }                                                                                                                 \
   };
 
-#define KOKKOSBLAS3_DGEMM_CUBLAS(LAYOUT, ETI_SPEC_AVAIL) \
-  KOKKOSBLAS3_XGEMM_CUBLAS(double, double, cublasDgemm, LAYOUT, ETI_SPEC_AVAIL)
+#define KOKKOSBLAS3_DGEMM_CUBLAS(LAYOUT) KOKKOSBLAS3_XGEMM_CUBLAS(double, double, cublasDgemm, LAYOUT)
 
-#define KOKKOSBLAS3_SGEMM_CUBLAS(LAYOUT, ETI_SPEC_AVAIL) \
-  KOKKOSBLAS3_XGEMM_CUBLAS(float, float, cublasSgemm, LAYOUT, ETI_SPEC_AVAIL)
+#define KOKKOSBLAS3_SGEMM_CUBLAS(LAYOUT) KOKKOSBLAS3_XGEMM_CUBLAS(float, float, cublasSgemm, LAYOUT)
 
-#define KOKKOSBLAS3_ZGEMM_CUBLAS(LAYOUT, ETI_SPEC_AVAIL) \
-  KOKKOSBLAS3_XGEMM_CUBLAS(Kokkos::complex<double>, cuDoubleComplex, cublasZgemm, LAYOUT, ETI_SPEC_AVAIL)
+#define KOKKOSBLAS3_ZGEMM_CUBLAS(LAYOUT) \
+  KOKKOSBLAS3_XGEMM_CUBLAS(Kokkos::complex<double>, cuDoubleComplex, cublasZgemm, LAYOUT)
 
-#define KOKKOSBLAS3_CGEMM_CUBLAS(LAYOUT, ETI_SPEC_AVAIL) \
-  KOKKOSBLAS3_XGEMM_CUBLAS(Kokkos::complex<float>, cuComplex, cublasCgemm, LAYOUT, ETI_SPEC_AVAIL)
+#define KOKKOSBLAS3_CGEMM_CUBLAS(LAYOUT) \
+  KOKKOSBLAS3_XGEMM_CUBLAS(Kokkos::complex<float>, cuComplex, cublasCgemm, LAYOUT)
 
-KOKKOSBLAS3_DGEMM_CUBLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS3_DGEMM_CUBLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS3_DGEMM_CUBLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS3_DGEMM_CUBLAS(Kokkos::LayoutRight, false)
+KOKKOSBLAS3_DGEMM_CUBLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS3_DGEMM_CUBLAS(Kokkos::LayoutRight)
 
-KOKKOSBLAS3_SGEMM_CUBLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS3_SGEMM_CUBLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS3_SGEMM_CUBLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS3_SGEMM_CUBLAS(Kokkos::LayoutRight, false)
+KOKKOSBLAS3_SGEMM_CUBLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS3_SGEMM_CUBLAS(Kokkos::LayoutRight)
 
-KOKKOSBLAS3_ZGEMM_CUBLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS3_ZGEMM_CUBLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS3_ZGEMM_CUBLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS3_ZGEMM_CUBLAS(Kokkos::LayoutRight, false)
+KOKKOSBLAS3_ZGEMM_CUBLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS3_ZGEMM_CUBLAS(Kokkos::LayoutRight)
 
-KOKKOSBLAS3_CGEMM_CUBLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS3_CGEMM_CUBLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS3_CGEMM_CUBLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS3_CGEMM_CUBLAS(Kokkos::LayoutRight, false)
+KOKKOSBLAS3_CGEMM_CUBLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS3_CGEMM_CUBLAS(Kokkos::LayoutRight)
 
 }  // namespace Impl
 }  // namespace KokkosBlas
@@ -200,8 +180,8 @@ KOKKOSBLAS3_CGEMM_CUBLAS(Kokkos::LayoutRight, false)
 namespace KokkosBlas {
 namespace Impl {
 
-#define KOKKOSBLAS3_XGEMM_ROCBLAS(SCALAR_TYPE, ROCBLAS_SCALAR_TYPE, ROCBLAS_FN, LAYOUT, ETI_SPEC_AVAIL)             \
-  template <>                                                                                                       \
+#define KOKKOSBLAS3_XGEMM_ROCBLAS(SCALAR_TYPE, ROCBLAS_SCALAR_TYPE, ROCBLAS_FN, LAYOUT)                             \
+  template <bool ETI_SPEC_AVAIL>                                                                                    \
   struct GEMM<Kokkos::HIP,                                                                                          \
               Kokkos::View<const SCALAR_TYPE**, LAYOUT, Kokkos::HIP, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,     \
               Kokkos::View<const SCALAR_TYPE**, LAYOUT, Kokkos::HIP, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,     \
@@ -265,37 +245,27 @@ namespace Impl {
     }                                                                                                               \
   };
 
-#define KOKKOSBLAS3_DGEMM_ROCBLAS(LAYOUT, ETI_SPEC_AVAIL) \
-  KOKKOSBLAS3_XGEMM_ROCBLAS(double, double, rocblas_dgemm, LAYOUT, ETI_SPEC_AVAIL)
+#define KOKKOSBLAS3_DGEMM_ROCBLAS(LAYOUT) KOKKOSBLAS3_XGEMM_ROCBLAS(double, double, rocblas_dgemm, LAYOUT)
 
-#define KOKKOSBLAS3_SGEMM_ROCBLAS(LAYOUT, ETI_SPEC_AVAIL) \
-  KOKKOSBLAS3_XGEMM_ROCBLAS(float, float, rocblas_sgemm, LAYOUT, ETI_SPEC_AVAIL)
+#define KOKKOSBLAS3_SGEMM_ROCBLAS(LAYOUT) KOKKOSBLAS3_XGEMM_ROCBLAS(float, float, rocblas_sgemm, LAYOUT)
 
-#define KOKKOSBLAS3_ZGEMM_ROCBLAS(LAYOUT, ETI_SPEC_AVAIL) \
-  KOKKOSBLAS3_XGEMM_ROCBLAS(Kokkos::complex<double>, rocblas_double_complex, rocblas_zgemm, LAYOUT, ETI_SPEC_AVAIL)
+#define KOKKOSBLAS3_ZGEMM_ROCBLAS(LAYOUT) \
+  KOKKOSBLAS3_XGEMM_ROCBLAS(Kokkos::complex<double>, rocblas_double_complex, rocblas_zgemm, LAYOUT)
 
-#define KOKKOSBLAS3_CGEMM_ROCBLAS(LAYOUT, ETI_SPEC_AVAIL) \
-  KOKKOSBLAS3_XGEMM_ROCBLAS(Kokkos::complex<float>, rocblas_float_complex, rocblas_cgemm, LAYOUT, ETI_SPEC_AVAIL)
+#define KOKKOSBLAS3_CGEMM_ROCBLAS(LAYOUT) \
+  KOKKOSBLAS3_XGEMM_ROCBLAS(Kokkos::complex<float>, rocblas_float_complex, rocblas_cgemm, LAYOUT)
 
-KOKKOSBLAS3_DGEMM_ROCBLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS3_DGEMM_ROCBLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS3_DGEMM_ROCBLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS3_DGEMM_ROCBLAS(Kokkos::LayoutRight, false)
+KOKKOSBLAS3_DGEMM_ROCBLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS3_DGEMM_ROCBLAS(Kokkos::LayoutRight)
 
-KOKKOSBLAS3_SGEMM_ROCBLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS3_SGEMM_ROCBLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS3_SGEMM_ROCBLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS3_SGEMM_ROCBLAS(Kokkos::LayoutRight, false)
+KOKKOSBLAS3_SGEMM_ROCBLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS3_SGEMM_ROCBLAS(Kokkos::LayoutRight)
 
-KOKKOSBLAS3_ZGEMM_ROCBLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS3_ZGEMM_ROCBLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS3_ZGEMM_ROCBLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS3_ZGEMM_ROCBLAS(Kokkos::LayoutRight, false)
+KOKKOSBLAS3_ZGEMM_ROCBLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS3_ZGEMM_ROCBLAS(Kokkos::LayoutRight)
 
-KOKKOSBLAS3_CGEMM_ROCBLAS(Kokkos::LayoutLeft, true)
-KOKKOSBLAS3_CGEMM_ROCBLAS(Kokkos::LayoutLeft, false)
-KOKKOSBLAS3_CGEMM_ROCBLAS(Kokkos::LayoutRight, true)
-KOKKOSBLAS3_CGEMM_ROCBLAS(Kokkos::LayoutRight, false)
+KOKKOSBLAS3_CGEMM_ROCBLAS(Kokkos::LayoutLeft)
+KOKKOSBLAS3_CGEMM_ROCBLAS(Kokkos::LayoutRight)
 
 }  // namespace Impl
 }  // namespace KokkosBlas

--- a/blas/tpls/KokkosBlas3_trmm_tpl_spec_decl.hpp
+++ b/blas/tpls/KokkosBlas3_trmm_tpl_spec_decl.hpp
@@ -11,8 +11,8 @@
 namespace KokkosBlas {
 namespace Impl {
 
-#define KOKKOSBLAS3_TRMM_BLAS(SCALAR_TYPE, BASE_SCALAR_TYPE, LAYOUTA, LAYOUTB, ETI_SPEC_AVAIL)                    \
-  template <typename ExecSpace>                                                                                   \
+#define KOKKOSBLAS3_TRMM_BLAS(SCALAR_TYPE, BASE_SCALAR_TYPE, LAYOUTA, LAYOUTB)                                    \
+  template <typename ExecSpace, bool ETI_SPEC_AVAIL>                                                              \
     requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)                                 \
   struct TRMM<ExecSpace,                                                                                          \
               Kokkos::View<const SCALAR_TYPE**, LAYOUTA, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,    \
@@ -70,39 +70,29 @@ namespace Impl {
     }                                                                                                             \
   };
 
-#define KOKKOSBLAS3_DTRMM_BLAS(LAYOUTA, LAYOUTB, ETI_SPEC_AVAIL) \
-  KOKKOSBLAS3_TRMM_BLAS(double, double, LAYOUTA, LAYOUTB, ETI_SPEC_AVAIL)
+#define KOKKOSBLAS3_DTRMM_BLAS(LAYOUTA, LAYOUTB) KOKKOSBLAS3_TRMM_BLAS(double, double, LAYOUTA, LAYOUTB)
 
-#define KOKKOSBLAS3_STRMM_BLAS(LAYOUTA, LAYOUTB, ETI_SPEC_AVAIL) \
-  KOKKOSBLAS3_TRMM_BLAS(float, float, LAYOUTA, LAYOUTB, ETI_SPEC_AVAIL)
+#define KOKKOSBLAS3_STRMM_BLAS(LAYOUTA, LAYOUTB) KOKKOSBLAS3_TRMM_BLAS(float, float, LAYOUTA, LAYOUTB)
 
-#define KOKKOSBLAS3_ZTRMM_BLAS(LAYOUTA, LAYOUTB, ETI_SPEC_AVAIL) \
-  KOKKOSBLAS3_TRMM_BLAS(Kokkos::complex<double>, std::complex<double>, LAYOUTA, LAYOUTB, ETI_SPEC_AVAIL)
+#define KOKKOSBLAS3_ZTRMM_BLAS(LAYOUTA, LAYOUTB) \
+  KOKKOSBLAS3_TRMM_BLAS(Kokkos::complex<double>, std::complex<double>, LAYOUTA, LAYOUTB)
 
-#define KOKKOSBLAS3_CTRMM_BLAS(LAYOUTA, LAYOUTB, ETI_SPEC_AVAIL) \
-  KOKKOSBLAS3_TRMM_BLAS(Kokkos::complex<float>, std::complex<float>, LAYOUTA, LAYOUTB, ETI_SPEC_AVAIL)
+#define KOKKOSBLAS3_CTRMM_BLAS(LAYOUTA, LAYOUTB) \
+  KOKKOSBLAS3_TRMM_BLAS(Kokkos::complex<float>, std::complex<float>, LAYOUTA, LAYOUTB)
 
 // Explicitly define the TRMM class for all permutations listed below
 
-KOKKOSBLAS3_DTRMM_BLAS(Kokkos::LayoutLeft, Kokkos::LayoutLeft, true)
-KOKKOSBLAS3_DTRMM_BLAS(Kokkos::LayoutLeft, Kokkos::LayoutLeft, false)
-KOKKOSBLAS3_DTRMM_BLAS(Kokkos::LayoutRight, Kokkos::LayoutRight, true)
-KOKKOSBLAS3_DTRMM_BLAS(Kokkos::LayoutRight, Kokkos::LayoutRight, false)
+KOKKOSBLAS3_DTRMM_BLAS(Kokkos::LayoutLeft, Kokkos::LayoutLeft)
+KOKKOSBLAS3_DTRMM_BLAS(Kokkos::LayoutRight, Kokkos::LayoutRight)
 
-KOKKOSBLAS3_STRMM_BLAS(Kokkos::LayoutLeft, Kokkos::LayoutLeft, true)
-KOKKOSBLAS3_STRMM_BLAS(Kokkos::LayoutLeft, Kokkos::LayoutLeft, false)
-KOKKOSBLAS3_STRMM_BLAS(Kokkos::LayoutRight, Kokkos::LayoutRight, true)
-KOKKOSBLAS3_STRMM_BLAS(Kokkos::LayoutRight, Kokkos::LayoutRight, false)
+KOKKOSBLAS3_STRMM_BLAS(Kokkos::LayoutLeft, Kokkos::LayoutLeft)
+KOKKOSBLAS3_STRMM_BLAS(Kokkos::LayoutRight, Kokkos::LayoutRight)
 
-KOKKOSBLAS3_ZTRMM_BLAS(Kokkos::LayoutLeft, Kokkos::LayoutLeft, true)
-KOKKOSBLAS3_ZTRMM_BLAS(Kokkos::LayoutLeft, Kokkos::LayoutLeft, false)
-KOKKOSBLAS3_ZTRMM_BLAS(Kokkos::LayoutRight, Kokkos::LayoutRight, true)
-KOKKOSBLAS3_ZTRMM_BLAS(Kokkos::LayoutRight, Kokkos::LayoutRight, false)
+KOKKOSBLAS3_ZTRMM_BLAS(Kokkos::LayoutLeft, Kokkos::LayoutLeft)
+KOKKOSBLAS3_ZTRMM_BLAS(Kokkos::LayoutRight, Kokkos::LayoutRight)
 
-KOKKOSBLAS3_CTRMM_BLAS(Kokkos::LayoutLeft, Kokkos::LayoutLeft, true)
-KOKKOSBLAS3_CTRMM_BLAS(Kokkos::LayoutLeft, Kokkos::LayoutLeft, false)
-KOKKOSBLAS3_CTRMM_BLAS(Kokkos::LayoutRight, Kokkos::LayoutRight, true)
-KOKKOSBLAS3_CTRMM_BLAS(Kokkos::LayoutRight, Kokkos::LayoutRight, false)
+KOKKOSBLAS3_CTRMM_BLAS(Kokkos::LayoutLeft, Kokkos::LayoutLeft)
+KOKKOSBLAS3_CTRMM_BLAS(Kokkos::LayoutRight, Kokkos::LayoutRight)
 
 }  // namespace Impl
 }  // namespace KokkosBlas
@@ -115,8 +105,8 @@ KOKKOSBLAS3_CTRMM_BLAS(Kokkos::LayoutRight, Kokkos::LayoutRight, false)
 namespace KokkosBlas {
 namespace Impl {
 
-#define KOKKOSBLAS3_TRMM_CUBLAS(SCALAR_TYPE, CUDA_SCALAR_TYPE, CUBLAS_FN, LAYOUTA, LAYOUTB, ETI_SPEC_AVAIL)          \
-  template <>                                                                                                        \
+#define KOKKOSBLAS3_TRMM_CUBLAS(SCALAR_TYPE, CUDA_SCALAR_TYPE, CUBLAS_FN, LAYOUTA, LAYOUTB)                          \
+  template <bool ETI_SPEC_AVAIL>                                                                                     \
   struct TRMM<Kokkos::Cuda,                                                                                          \
               Kokkos::View<const SCALAR_TYPE**, LAYOUTA, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,    \
               Kokkos::View<SCALAR_TYPE**, LAYOUTB, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, true,    \
@@ -192,39 +182,30 @@ namespace Impl {
     }                                                                                                                \
   };
 
-#define KOKKOSBLAS3_DTRMM_CUBLAS(LAYOUTA, LAYOUTB, ETI_SPEC_AVAIL) \
-  KOKKOSBLAS3_TRMM_CUBLAS(double, double, cublasDtrmm, LAYOUTA, LAYOUTB, ETI_SPEC_AVAIL)
+#define KOKKOSBLAS3_DTRMM_CUBLAS(LAYOUTA, LAYOUTB) \
+  KOKKOSBLAS3_TRMM_CUBLAS(double, double, cublasDtrmm, LAYOUTA, LAYOUTB)
 
-#define KOKKOSBLAS3_STRMM_CUBLAS(LAYOUTA, LAYOUTB, ETI_SPEC_AVAIL) \
-  KOKKOSBLAS3_TRMM_CUBLAS(float, float, cublasStrmm, LAYOUTA, LAYOUTB, ETI_SPEC_AVAIL)
+#define KOKKOSBLAS3_STRMM_CUBLAS(LAYOUTA, LAYOUTB) KOKKOSBLAS3_TRMM_CUBLAS(float, float, cublasStrmm, LAYOUTA, LAYOUTB)
 
-#define KOKKOSBLAS3_ZTRMM_CUBLAS(LAYOUTA, LAYOUTB, ETI_SPEC_AVAIL) \
-  KOKKOSBLAS3_TRMM_CUBLAS(Kokkos::complex<double>, cuDoubleComplex, cublasZtrmm, LAYOUTA, LAYOUTB, ETI_SPEC_AVAIL)
+#define KOKKOSBLAS3_ZTRMM_CUBLAS(LAYOUTA, LAYOUTB) \
+  KOKKOSBLAS3_TRMM_CUBLAS(Kokkos::complex<double>, cuDoubleComplex, cublasZtrmm, LAYOUTA, LAYOUTB)
 
-#define KOKKOSBLAS3_CTRMM_CUBLAS(LAYOUTA, LAYOUTB, ETI_SPEC_AVAIL) \
-  KOKKOSBLAS3_TRMM_CUBLAS(Kokkos::complex<float>, cuComplex, cublasCtrmm, LAYOUTA, LAYOUTB, ETI_SPEC_AVAIL)
+#define KOKKOSBLAS3_CTRMM_CUBLAS(LAYOUTA, LAYOUTB) \
+  KOKKOSBLAS3_TRMM_CUBLAS(Kokkos::complex<float>, cuComplex, cublasCtrmm, LAYOUTA, LAYOUTB)
 
 // Explicitly define the TRMM class for all permutations listed below
 
-KOKKOSBLAS3_DTRMM_CUBLAS(Kokkos::LayoutLeft, Kokkos::LayoutLeft, true)
-KOKKOSBLAS3_DTRMM_CUBLAS(Kokkos::LayoutLeft, Kokkos::LayoutLeft, false)
-KOKKOSBLAS3_DTRMM_CUBLAS(Kokkos::LayoutRight, Kokkos::LayoutRight, true)
-KOKKOSBLAS3_DTRMM_CUBLAS(Kokkos::LayoutRight, Kokkos::LayoutRight, false)
+KOKKOSBLAS3_DTRMM_CUBLAS(Kokkos::LayoutLeft, Kokkos::LayoutLeft)
+KOKKOSBLAS3_DTRMM_CUBLAS(Kokkos::LayoutRight, Kokkos::LayoutRight)
 
-KOKKOSBLAS3_STRMM_CUBLAS(Kokkos::LayoutLeft, Kokkos::LayoutLeft, true)
-KOKKOSBLAS3_STRMM_CUBLAS(Kokkos::LayoutLeft, Kokkos::LayoutLeft, false)
-KOKKOSBLAS3_STRMM_CUBLAS(Kokkos::LayoutRight, Kokkos::LayoutRight, true)
-KOKKOSBLAS3_STRMM_CUBLAS(Kokkos::LayoutRight, Kokkos::LayoutRight, false)
+KOKKOSBLAS3_STRMM_CUBLAS(Kokkos::LayoutLeft, Kokkos::LayoutLeft)
+KOKKOSBLAS3_STRMM_CUBLAS(Kokkos::LayoutRight, Kokkos::LayoutRight)
 
-KOKKOSBLAS3_ZTRMM_CUBLAS(Kokkos::LayoutLeft, Kokkos::LayoutLeft, true)
-KOKKOSBLAS3_ZTRMM_CUBLAS(Kokkos::LayoutLeft, Kokkos::LayoutLeft, false)
-KOKKOSBLAS3_ZTRMM_CUBLAS(Kokkos::LayoutRight, Kokkos::LayoutRight, true)
-KOKKOSBLAS3_ZTRMM_CUBLAS(Kokkos::LayoutRight, Kokkos::LayoutRight, false)
+KOKKOSBLAS3_ZTRMM_CUBLAS(Kokkos::LayoutLeft, Kokkos::LayoutLeft)
+KOKKOSBLAS3_ZTRMM_CUBLAS(Kokkos::LayoutRight, Kokkos::LayoutRight)
 
-KOKKOSBLAS3_CTRMM_CUBLAS(Kokkos::LayoutLeft, Kokkos::LayoutLeft, true)
-KOKKOSBLAS3_CTRMM_CUBLAS(Kokkos::LayoutLeft, Kokkos::LayoutLeft, false)
-KOKKOSBLAS3_CTRMM_CUBLAS(Kokkos::LayoutRight, Kokkos::LayoutRight, true)
-KOKKOSBLAS3_CTRMM_CUBLAS(Kokkos::LayoutRight, Kokkos::LayoutRight, false)
+KOKKOSBLAS3_CTRMM_CUBLAS(Kokkos::LayoutLeft, Kokkos::LayoutLeft)
+KOKKOSBLAS3_CTRMM_CUBLAS(Kokkos::LayoutRight, Kokkos::LayoutRight)
 
 }  // namespace Impl
 }  // namespace KokkosBlas

--- a/blas/tpls/KokkosBlas3_trsm_tpl_spec_decl.hpp
+++ b/blas/tpls/KokkosBlas3_trsm_tpl_spec_decl.hpp
@@ -10,8 +10,8 @@
 namespace KokkosBlas {
 namespace Impl {
 
-#define KOKKOSBLAS3_DTRSM_BLAS(LAYOUTA, LAYOUTB, ETI_SPEC_AVAIL)                                                     \
-  template <typename ExecSpace>                                                                                      \
+#define KOKKOSBLAS3_DTRSM_BLAS(LAYOUTA, LAYOUTB)                                                                     \
+  template <typename ExecSpace, bool ETI_SPEC_AVAIL>                                                                 \
     requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)                                    \
   struct TRSM<ExecSpace, Kokkos::View<const double**, LAYOUTA, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
               Kokkos::View<double**, LAYOUTB, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, true,            \
@@ -64,8 +64,8 @@ namespace Impl {
     }                                                                                                                \
   };
 
-#define KOKKOSBLAS3_STRSM_BLAS(LAYOUTA, LAYOUTB, ETI_SPEC_AVAIL)                                                    \
-  template <typename ExecSpace>                                                                                     \
+#define KOKKOSBLAS3_STRSM_BLAS(LAYOUTA, LAYOUTB)                                                                    \
+  template <typename ExecSpace, bool ETI_SPEC_AVAIL>                                                                \
     requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)                                   \
   struct TRSM<ExecSpace, Kokkos::View<const float**, LAYOUTA, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
               Kokkos::View<float**, LAYOUTB, ExecSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, true,            \
@@ -118,8 +118,8 @@ namespace Impl {
     }                                                                                                               \
   };
 
-#define KOKKOSBLAS3_ZTRSM_BLAS(LAYOUTA, LAYOUTB, ETI_SPEC_AVAIL)                                                   \
-  template <typename ExecSpace>                                                                                    \
+#define KOKKOSBLAS3_ZTRSM_BLAS(LAYOUTA, LAYOUTB)                                                                   \
+  template <typename ExecSpace, bool ETI_SPEC_AVAIL>                                                               \
     requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)                                  \
   struct TRSM<                                                                                                     \
       ExecSpace,                                                                                                   \
@@ -179,8 +179,8 @@ namespace Impl {
     }                                                                                                              \
   };
 
-#define KOKKOSBLAS3_CTRSM_BLAS(LAYOUTA, LAYOUTB, ETI_SPEC_AVAIL)                                                  \
-  template <typename ExecSpace>                                                                                   \
+#define KOKKOSBLAS3_CTRSM_BLAS(LAYOUTA, LAYOUTB)                                                                  \
+  template <typename ExecSpace, bool ETI_SPEC_AVAIL>                                                              \
     requires(std::is_same_v<typename ExecSpace::memory_space, Kokkos::HostSpace>)                                 \
   struct TRSM<                                                                                                    \
       ExecSpace,                                                                                                  \
@@ -240,25 +240,17 @@ namespace Impl {
     }                                                                                                             \
   };
 
-KOKKOSBLAS3_DTRSM_BLAS(Kokkos::LayoutLeft, Kokkos::LayoutLeft, true)
-KOKKOSBLAS3_DTRSM_BLAS(Kokkos::LayoutLeft, Kokkos::LayoutLeft, false)
-KOKKOSBLAS3_DTRSM_BLAS(Kokkos::LayoutRight, Kokkos::LayoutRight, true)
-KOKKOSBLAS3_DTRSM_BLAS(Kokkos::LayoutRight, Kokkos::LayoutRight, false)
+KOKKOSBLAS3_DTRSM_BLAS(Kokkos::LayoutLeft, Kokkos::LayoutLeft)
+KOKKOSBLAS3_DTRSM_BLAS(Kokkos::LayoutRight, Kokkos::LayoutRight)
 
-KOKKOSBLAS3_STRSM_BLAS(Kokkos::LayoutLeft, Kokkos::LayoutLeft, true)
-KOKKOSBLAS3_STRSM_BLAS(Kokkos::LayoutLeft, Kokkos::LayoutLeft, false)
-KOKKOSBLAS3_STRSM_BLAS(Kokkos::LayoutRight, Kokkos::LayoutRight, true)
-KOKKOSBLAS3_STRSM_BLAS(Kokkos::LayoutRight, Kokkos::LayoutRight, false)
+KOKKOSBLAS3_STRSM_BLAS(Kokkos::LayoutLeft, Kokkos::LayoutLeft)
+KOKKOSBLAS3_STRSM_BLAS(Kokkos::LayoutRight, Kokkos::LayoutRight)
 
-KOKKOSBLAS3_ZTRSM_BLAS(Kokkos::LayoutLeft, Kokkos::LayoutLeft, true)
-KOKKOSBLAS3_ZTRSM_BLAS(Kokkos::LayoutLeft, Kokkos::LayoutLeft, false)
-KOKKOSBLAS3_ZTRSM_BLAS(Kokkos::LayoutRight, Kokkos::LayoutRight, true)
-KOKKOSBLAS3_ZTRSM_BLAS(Kokkos::LayoutRight, Kokkos::LayoutRight, false)
+KOKKOSBLAS3_ZTRSM_BLAS(Kokkos::LayoutLeft, Kokkos::LayoutLeft)
+KOKKOSBLAS3_ZTRSM_BLAS(Kokkos::LayoutRight, Kokkos::LayoutRight)
 
-KOKKOSBLAS3_CTRSM_BLAS(Kokkos::LayoutLeft, Kokkos::LayoutLeft, true)
-KOKKOSBLAS3_CTRSM_BLAS(Kokkos::LayoutLeft, Kokkos::LayoutLeft, false)
-KOKKOSBLAS3_CTRSM_BLAS(Kokkos::LayoutRight, Kokkos::LayoutRight, true)
-KOKKOSBLAS3_CTRSM_BLAS(Kokkos::LayoutRight, Kokkos::LayoutRight, false)
+KOKKOSBLAS3_CTRSM_BLAS(Kokkos::LayoutLeft, Kokkos::LayoutLeft)
+KOKKOSBLAS3_CTRSM_BLAS(Kokkos::LayoutRight, Kokkos::LayoutRight)
 
 }  // namespace Impl
 }  // namespace KokkosBlas
@@ -271,8 +263,8 @@ KOKKOSBLAS3_CTRSM_BLAS(Kokkos::LayoutRight, Kokkos::LayoutRight, false)
 namespace KokkosBlas {
 namespace Impl {
 
-#define KOKKOSBLAS3_DTRSM_CUBLAS(LAYOUTA, LAYOUTB, ETI_SPEC_AVAIL)                                                     \
-  template <>                                                                                                          \
+#define KOKKOSBLAS3_DTRSM_CUBLAS(LAYOUTA, LAYOUTB)                                                                     \
+  template <bool ETI_SPEC_AVAIL>                                                                                       \
   struct TRSM<                                                                                                         \
       Kokkos::Cuda, Kokkos::View<const double**, LAYOUTA, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,     \
       Kokkos::View<double**, LAYOUTB, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, true, ETI_SPEC_AVAIL> { \
@@ -343,8 +335,8 @@ namespace Impl {
     }                                                                                                                  \
   };
 
-#define KOKKOSBLAS3_STRSM_CUBLAS(LAYOUTA, LAYOUTB, ETI_SPEC_AVAIL)                                                    \
-  template <>                                                                                                         \
+#define KOKKOSBLAS3_STRSM_CUBLAS(LAYOUTA, LAYOUTB)                                                                    \
+  template <bool ETI_SPEC_AVAIL>                                                                                      \
   struct TRSM<                                                                                                        \
       Kokkos::Cuda, Kokkos::View<const float**, LAYOUTA, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,     \
       Kokkos::View<float**, LAYOUTB, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, true, ETI_SPEC_AVAIL> { \
@@ -416,8 +408,8 @@ namespace Impl {
     }                                                                                                                 \
   };
 
-#define KOKKOSBLAS3_ZTRSM_CUBLAS(LAYOUTA, LAYOUTB, ETI_SPEC_AVAIL)                                                    \
-  template <>                                                                                                         \
+#define KOKKOSBLAS3_ZTRSM_CUBLAS(LAYOUTA, LAYOUTB)                                                                    \
+  template <bool ETI_SPEC_AVAIL>                                                                                      \
   struct TRSM<                                                                                                        \
       Kokkos::Cuda,                                                                                                   \
       Kokkos::View<const Kokkos::complex<double>**, LAYOUTA, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
@@ -495,8 +487,8 @@ namespace Impl {
     }                                                                                                                 \
   };
 
-#define KOKKOSBLAS3_CTRSM_CUBLAS(LAYOUTA, LAYOUTB, ETI_SPEC_AVAIL)                                                   \
-  template <>                                                                                                        \
+#define KOKKOSBLAS3_CTRSM_CUBLAS(LAYOUTA, LAYOUTB)                                                                   \
+  template <bool ETI_SPEC_AVAIL>                                                                                     \
   struct TRSM<                                                                                                       \
       Kokkos::Cuda,                                                                                                  \
       Kokkos::View<const Kokkos::complex<float>**, LAYOUTA, Kokkos::Cuda, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
@@ -572,25 +564,17 @@ namespace Impl {
     }                                                                                                                \
   };
 
-KOKKOSBLAS3_DTRSM_CUBLAS(Kokkos::LayoutLeft, Kokkos::LayoutLeft, true)
-KOKKOSBLAS3_DTRSM_CUBLAS(Kokkos::LayoutLeft, Kokkos::LayoutLeft, false)
-KOKKOSBLAS3_DTRSM_CUBLAS(Kokkos::LayoutRight, Kokkos::LayoutRight, true)
-KOKKOSBLAS3_DTRSM_CUBLAS(Kokkos::LayoutRight, Kokkos::LayoutRight, false)
+KOKKOSBLAS3_DTRSM_CUBLAS(Kokkos::LayoutLeft, Kokkos::LayoutLeft)
+KOKKOSBLAS3_DTRSM_CUBLAS(Kokkos::LayoutRight, Kokkos::LayoutRight)
 
-KOKKOSBLAS3_STRSM_CUBLAS(Kokkos::LayoutLeft, Kokkos::LayoutLeft, true)
-KOKKOSBLAS3_STRSM_CUBLAS(Kokkos::LayoutLeft, Kokkos::LayoutLeft, false)
-KOKKOSBLAS3_STRSM_CUBLAS(Kokkos::LayoutRight, Kokkos::LayoutRight, true)
-KOKKOSBLAS3_STRSM_CUBLAS(Kokkos::LayoutRight, Kokkos::LayoutRight, false)
+KOKKOSBLAS3_STRSM_CUBLAS(Kokkos::LayoutLeft, Kokkos::LayoutLeft)
+KOKKOSBLAS3_STRSM_CUBLAS(Kokkos::LayoutRight, Kokkos::LayoutRight)
 
-KOKKOSBLAS3_ZTRSM_CUBLAS(Kokkos::LayoutLeft, Kokkos::LayoutLeft, true)
-KOKKOSBLAS3_ZTRSM_CUBLAS(Kokkos::LayoutLeft, Kokkos::LayoutLeft, false)
-KOKKOSBLAS3_ZTRSM_CUBLAS(Kokkos::LayoutRight, Kokkos::LayoutRight, true)
-KOKKOSBLAS3_ZTRSM_CUBLAS(Kokkos::LayoutRight, Kokkos::LayoutRight, false)
+KOKKOSBLAS3_ZTRSM_CUBLAS(Kokkos::LayoutLeft, Kokkos::LayoutLeft)
+KOKKOSBLAS3_ZTRSM_CUBLAS(Kokkos::LayoutRight, Kokkos::LayoutRight)
 
-KOKKOSBLAS3_CTRSM_CUBLAS(Kokkos::LayoutLeft, Kokkos::LayoutLeft, true)
-KOKKOSBLAS3_CTRSM_CUBLAS(Kokkos::LayoutLeft, Kokkos::LayoutLeft, false)
-KOKKOSBLAS3_CTRSM_CUBLAS(Kokkos::LayoutRight, Kokkos::LayoutRight, true)
-KOKKOSBLAS3_CTRSM_CUBLAS(Kokkos::LayoutRight, Kokkos::LayoutRight, false)
+KOKKOSBLAS3_CTRSM_CUBLAS(Kokkos::LayoutLeft, Kokkos::LayoutLeft)
+KOKKOSBLAS3_CTRSM_CUBLAS(Kokkos::LayoutRight, Kokkos::LayoutRight)
 
 }  // namespace Impl
 }  // namespace KokkosBlas

--- a/lapack/tpls/KokkosLapack_gegqr_tpl_spec_decl.hpp
+++ b/lapack/tpls/KokkosLapack_gegqr_tpl_spec_decl.hpp
@@ -78,19 +78,13 @@ void lapackGegqrWrapper(const int k, const AViewType& A, const TauViewType& Tau,
 }
 
 #define KOKKOSLAPACK_GEGQR_LAPACK(SCALAR, LAYOUT, EXECSPACE, MEM_SPACE)                                                \
-  template <>                                                                                                          \
+  template <bool ETI_SPEC_AVAIL>                                                                                       \
   struct GEGQR<                                                                                                        \
       EXECSPACE,                                                                                                       \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,   \
       Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,    \
       Kokkos::View<int*, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, true, \
-      gegqr_eti_spec_avail<EXECSPACE,                                                                                  \
-                           Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>,                        \
-                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                      \
-                           Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>,                         \
-                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                      \
-                           Kokkos::View<int*, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>,                            \
-                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>>::value> {                            \
+      ETI_SPEC_AVAIL> {                                                                                                \
     using AViewType =                                                                                                  \
         Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>; \
     using TauViewType =                                                                                                \
@@ -196,21 +190,14 @@ void cusolverGegqrWrapper(const ExecutionSpace& space, const int k, const AViewT
 }
 
 #define KOKKOSLAPACK_GEGQR_CUSOLVER(SCALAR, LAYOUT, MEM_SPACE)                                                         \
-  template <>                                                                                                          \
+  template <bool ETI_SPEC_AVAIL>                                                                                       \
   struct GEGQR<                                                                                                        \
       Kokkos::Cuda,                                                                                                    \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                                          \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                           \
       Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
       Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,    \
-      true,                                                                                                            \
-      gegqr_eti_spec_avail<Kokkos::Cuda,                                                                               \
-                           Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                     \
-                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                      \
-                           Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                      \
-                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                      \
-                           Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                         \
-                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>>::value> {                            \
+      true, ETI_SPEC_AVAIL> {                                                                                          \
     using AViewType   = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                        \
                                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                         \
     using TauViewType = Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                         \
@@ -287,20 +274,13 @@ void rocsolverGegqrWrapper(const ExecutionSpace& space, const int k, const AView
 }
 
 #define KOKKOSLAPACK_GEGQR_ROCSOLVER(SCALAR, LAYOUT, MEM_SPACE)                                                        \
-  template <>                                                                                                          \
+  template <bool ETI_SPEC_AVAIL>                                                                                       \
   struct GEGQR<                                                                                                        \
       Kokkos::HIP,                                                                                                     \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
       Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,  \
       Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,     \
-      true,                                                                                                            \
-      gegqr_eti_spec_avail<Kokkos::HIP,                                                                                \
-                           Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                      \
-                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                      \
-                           Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                       \
-                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                      \
-                           Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                          \
-                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>>::value> {                            \
+      true, ETI_SPEC_AVAIL> {                                                                                          \
     using AViewType   = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                         \
                                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                         \
     using TauViewType = Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                          \

--- a/lapack/tpls/KokkosLapack_gemqr_tpl_spec_decl.hpp
+++ b/lapack/tpls/KokkosLapack_gemqr_tpl_spec_decl.hpp
@@ -85,22 +85,14 @@ void lapackGemqrWrapper(const char side[], const char trans[], const AViewType& 
 }
 
 #define KOKKOSLAPACK_GEMQR_LAPACK(SCALAR, LAYOUT, EXECSPACE, MEM_SPACE)                                                \
-  template <>                                                                                                          \
+  template <bool ETI_SPEC_AVAIL>                                                                                       \
   struct GEMQR<                                                                                                        \
       EXECSPACE,                                                                                                       \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,   \
       Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,    \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,   \
       Kokkos::View<int*, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, true, \
-      gemqr_eti_spec_avail<EXECSPACE,                                                                                  \
-                           Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>,                        \
-                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                      \
-                           Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>,                         \
-                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                      \
-                           Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>,                        \
-                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                      \
-                           Kokkos::View<int*, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>,                            \
-                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>>::value> {                            \
+      ETI_SPEC_AVAIL> {                                                                                                \
     using AViewType =                                                                                                  \
         Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>; \
     using TauViewType =                                                                                                \
@@ -216,7 +208,7 @@ void cusolverGemqrWrapper(const ExecutionSpace& space, const char side[], const 
 }
 
 #define KOKKOSLAPACK_GEMQR_CUSOLVER(SCALAR, LAYOUT, MEM_SPACE)                                                         \
-  template <>                                                                                                          \
+  template <bool ETI_SPEC_AVAIL>                                                                                       \
   struct GEMQR<                                                                                                        \
       Kokkos::Cuda,                                                                                                    \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                                          \
@@ -225,16 +217,7 @@ void cusolverGemqrWrapper(const ExecutionSpace& space, const char side[], const 
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                                          \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                           \
       Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,    \
-      true,                                                                                                            \
-      gemqr_eti_spec_avail<Kokkos::Cuda,                                                                               \
-                           Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                     \
-                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                      \
-                           Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                      \
-                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                      \
-                           Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                     \
-                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                      \
-                           Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                         \
-                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>>::value> {                            \
+      true, ETI_SPEC_AVAIL> {                                                                                          \
     using AViewType   = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                        \
                                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                         \
     using TauViewType = Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                         \
@@ -321,23 +304,14 @@ void rocsolverGemqrWrapper(const ExecutionSpace& space, const char side[], const
 }
 
 #define KOKKOSLAPACK_GEMQR_ROCSOLVER(SCALAR, LAYOUT, MEM_SPACE)                                                        \
-  template <>                                                                                                          \
+  template <bool ETI_SPEC_AVAIL>                                                                                       \
   struct GEMQR<                                                                                                        \
       Kokkos::HIP,                                                                                                     \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
       Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,  \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
       Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,     \
-      true,                                                                                                            \
-      gemqr_eti_spec_avail<Kokkos::HIP,                                                                                \
-                           Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                      \
-                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                      \
-                           Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                       \
-                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                      \
-                           Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                      \
-                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                      \
-                           Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                          \
-                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>>::value> {                            \
+      true, ETI_SPEC_AVAIL> {                                                                                          \
     using AViewType   = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                         \
                                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                         \
     using TauViewType = Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                          \

--- a/lapack/tpls/KokkosLapack_geqrf_tpl_spec_decl.hpp
+++ b/lapack/tpls/KokkosLapack_geqrf_tpl_spec_decl.hpp
@@ -77,19 +77,13 @@ void lapackGeqrfWrapper(const AViewType& A, const TauViewType& Tau, const InfoVi
 }
 
 #define KOKKOSLAPACK_GEQRF_LAPACK(SCALAR, LAYOUT, EXECSPACE, MEM_SPACE)                                                \
-  template <>                                                                                                          \
+  template <bool ETI_SPEC_AVAIL>                                                                                       \
   struct GEQRF<                                                                                                        \
       EXECSPACE,                                                                                                       \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,   \
       Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,    \
       Kokkos::View<int*, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, true, \
-      geqrf_eti_spec_avail<EXECSPACE,                                                                                  \
-                           Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>,                        \
-                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                      \
-                           Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>,                         \
-                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                      \
-                           Kokkos::View<int*, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>,                            \
-                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>>::value> {                            \
+      ETI_SPEC_AVAIL> {                                                                                                \
     using AViewType =                                                                                                  \
         Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>; \
     using TauViewType =                                                                                                \
@@ -191,21 +185,14 @@ void cusolverGeqrfWrapper(const ExecutionSpace& space, const AViewType& A, const
 }
 
 #define KOKKOSLAPACK_GEQRF_CUSOLVER(SCALAR, LAYOUT, MEM_SPACE)                                                         \
-  template <>                                                                                                          \
+  template <bool ETI_SPEC_AVAIL>                                                                                       \
   struct GEQRF<                                                                                                        \
       Kokkos::Cuda,                                                                                                    \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                                          \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                           \
       Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
       Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,    \
-      true,                                                                                                            \
-      geqrf_eti_spec_avail<Kokkos::Cuda,                                                                               \
-                           Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                     \
-                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                      \
-                           Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                      \
-                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                      \
-                           Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                         \
-                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>>::value> {                            \
+      true, ETI_SPEC_AVAIL> {                                                                                          \
     using AViewType   = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                        \
                                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                         \
     using TauViewType = Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                         \
@@ -282,20 +269,13 @@ void rocsolverGeqrfWrapper(const ExecutionSpace& space, const AViewType& A, cons
 }
 
 #define KOKKOSLAPACK_GEQRF_ROCSOLVER(SCALAR, LAYOUT, MEM_SPACE)                                                        \
-  template <>                                                                                                          \
+  template <bool ETI_SPEC_AVAIL>                                                                                       \
   struct GEQRF<                                                                                                        \
       Kokkos::HIP,                                                                                                     \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
       Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,  \
       Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,     \
-      true,                                                                                                            \
-      geqrf_eti_spec_avail<Kokkos::HIP,                                                                                \
-                           Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                      \
-                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                      \
-                           Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                       \
-                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                      \
-                           Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                          \
-                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>>::value> {                            \
+      true, ETI_SPEC_AVAIL> {                                                                                          \
     using AViewType   = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                         \
                                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                         \
     using TauViewType = Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                          \

--- a/lapack/tpls/KokkosLapack_gesv_tpl_spec_decl.hpp
+++ b/lapack/tpls/KokkosLapack_gesv_tpl_spec_decl.hpp
@@ -59,21 +59,14 @@ void lapackGesvWrapper(const AViewType& A, const BViewType& B, const IPIVViewTyp
 }
 
 #define KOKKOSLAPACK_GESV_LAPACK(SCALAR, LAYOUT, EXECSPACE, MEM_SPACE)                                                 \
-  template <>                                                                                                          \
+  template <bool ETI_SPEC_AVAIL>                                                                                       \
   struct GESV<                                                                                                         \
       EXECSPACE,                                                                                                       \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,   \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,   \
       Kokkos::View<int*, LAYOUT, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,                                         \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                           \
-      true,                                                                                                            \
-      gesv_eti_spec_avail<EXECSPACE,                                                                                   \
-                          Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>,                         \
-                                       Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                       \
-                          Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>,                         \
-                                       Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                       \
-                          Kokkos::View<int*, LAYOUT, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,                     \
-                                       Kokkos::MemoryTraits<Kokkos::Unmanaged>>>::value> {                             \
+      true, ETI_SPEC_AVAIL> {                                                                                          \
     using AViewType =                                                                                                  \
         Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>; \
     using BViewType =                                                                                                  \
@@ -186,22 +179,14 @@ void magmaGesvWrapper(const ExecSpace& space, const AViewType& A, const BViewTyp
 }
 
 #define KOKKOSLAPACK_GESV_MAGMA(SCALAR, LAYOUT, EXEC_SPACE, MEM_SPACE)                                                \
-  template <>                                                                                                         \
+  template <bool ETI_SPEC_AVAIL>                                                                                      \
   struct GESV<                                                                                                        \
       EXEC_SPACE,                                                                                                     \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
       Kokkos::View<magma_int_t*, LAYOUT, Kokkos::Device<Kokkos::DefaultHostExecutionSpace, Kokkos::HostSpace>,        \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                          \
-      true,                                                                                                           \
-      gesv_eti_spec_avail<                                                                                            \
-          EXEC_SPACE,                                                                                                 \
-          Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                                       \
-                       Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                      \
-          Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                                       \
-                       Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                      \
-          Kokkos::View<magma_int_t*, LAYOUT, Kokkos::Device<Kokkos::DefaultHostExecutionSpace, Kokkos::HostSpace>,    \
-                       Kokkos::MemoryTraits<Kokkos::Unmanaged>>>::value> {                                            \
+      true, ETI_SPEC_AVAIL> {                                                                                         \
     using AViewType = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                           \
                                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                          \
     using BViewType = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, MEM_SPACE>,                           \
@@ -309,7 +294,7 @@ void cusolverGesvWrapper(const ExecutionSpace& space, const IPIVViewType& IPIV, 
 }
 
 #define KOKKOSLAPACK_GESV_CUSOLVER(SCALAR, LAYOUT, MEM_SPACE)                                                         \
-  template <>                                                                                                         \
+  template <bool ETI_SPEC_AVAIL>                                                                                      \
   struct GESV<                                                                                                        \
       Kokkos::Cuda,                                                                                                   \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                                         \
@@ -317,14 +302,7 @@ void cusolverGesvWrapper(const ExecutionSpace& space, const IPIVViewType& IPIV, 
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                                         \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                          \
       Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,   \
-      true,                                                                                                           \
-      gesv_eti_spec_avail<Kokkos::Cuda,                                                                               \
-                          Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                     \
-                                       Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                      \
-                          Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                     \
-                                       Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                      \
-                          Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                         \
-                                       Kokkos::MemoryTraits<Kokkos::Unmanaged>>>::value> {                            \
+      true, ETI_SPEC_AVAIL> {                                                                                         \
     using AViewType = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                         \
                                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                          \
     using BViewType = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                         \
@@ -402,21 +380,14 @@ void rocsolverGesvWrapper(const ExecutionSpace& space, const IPIVViewType& IPIV,
 }
 
 #define KOKKOSLAPACK_GESV_ROCSOLVER(SCALAR, LAYOUT, MEM_SPACE)                                                         \
-  template <>                                                                                                          \
+  template <bool ETI_SPEC_AVAIL>                                                                                       \
   struct GESV<                                                                                                         \
       Kokkos::HIP,                                                                                                     \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
       Kokkos::View<rocblas_int*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                                       \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                           \
-      true,                                                                                                            \
-      gesv_eti_spec_avail<Kokkos::HIP,                                                                                 \
-                          Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                       \
-                                       Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                       \
-                          Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                       \
-                                       Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                       \
-                          Kokkos::View<rocblas_int*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                   \
-                                       Kokkos::MemoryTraits<Kokkos::Unmanaged>>>::value> {                             \
+      true, ETI_SPEC_AVAIL> {                                                                                          \
     using AViewType = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                           \
                                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                           \
     using BViewType = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                           \

--- a/lapack/tpls/KokkosLapack_getrf_tpl_spec_decl.hpp
+++ b/lapack/tpls/KokkosLapack_getrf_tpl_spec_decl.hpp
@@ -53,19 +53,13 @@ void lapackGetrfWrapper(const AViewType& A, const IpivView& Ipiv, const InfoView
 }
 
 #define KOKKOSLAPACK_GETRF_LAPACK(SCALAR, LAYOUT, EXECSPACE, MEM_SPACE)                                                \
-  template <>                                                                                                          \
+  template <bool ETI_SPEC_AVAIL>                                                                                       \
   struct GETRF<                                                                                                        \
       EXECSPACE,                                                                                                       \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,   \
       Kokkos::View<int*, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,       \
       Kokkos::View<int*, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, true, \
-      getrf_eti_spec_avail<                                                                                            \
-          EXECSPACE,                                                                                                   \
-          Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>,                                         \
-                       Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                       \
-          Kokkos::View<int*, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,   \
-          Kokkos::View<int*, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>,                                             \
-                       Kokkos::MemoryTraits<Kokkos::Unmanaged>>>::value> {                                             \
+      ETI_SPEC_AVAIL> {                                                                                                \
     using AViewType =                                                                                                  \
         Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>; \
     using IpivView =                                                                                                   \
@@ -168,21 +162,14 @@ void cusolverGetrfWrapper(const ExecutionSpace& space, const AViewType& A, const
 }
 
 #define KOKKOSLAPACK_GETRF_CUSOLVER(SCALAR, LAYOUT, MEM_SPACE)                                                        \
-  template <>                                                                                                         \
+  template <bool ETI_SPEC_AVAIL>                                                                                      \
   struct GETRF<                                                                                                       \
       Kokkos::Cuda,                                                                                                   \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                                         \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                          \
       Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,   \
       Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,   \
-      true,                                                                                                           \
-      getrf_eti_spec_avail<Kokkos::Cuda,                                                                              \
-                           Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                    \
-                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                     \
-                           Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                        \
-                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                     \
-                           Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                        \
-                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>>::value> {                           \
+      true, ETI_SPEC_AVAIL> {                                                                                         \
     using AViewType = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                         \
                                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                          \
     using IpivViewType =                                                                                              \
@@ -257,20 +244,13 @@ void rocsolverGetrfWrapper(const ExecutionSpace& space, const AViewType& A, cons
 }
 
 #define KOKKOSLAPACK_GETRF_ROCSOLVER(SCALAR, LAYOUT, MEM_SPACE)                                                        \
-  template <>                                                                                                          \
+  template <bool ETI_SPEC_AVAIL>                                                                                       \
   struct GETRF<                                                                                                        \
       Kokkos::HIP,                                                                                                     \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
       Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,     \
       Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,     \
-      true,                                                                                                            \
-      getrf_eti_spec_avail<                                                                                            \
-          Kokkos::HIP,                                                                                                 \
-          Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                                       \
-                       Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                       \
-          Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
-          Kokkos::View<int*, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                                           \
-                       Kokkos::MemoryTraits<Kokkos::Unmanaged>>>::value> {                                             \
+      true, ETI_SPEC_AVAIL> {                                                                                          \
     using AViewType = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                           \
                                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                           \
     using IpivViewType =                                                                                               \

--- a/lapack/tpls/KokkosLapack_potrf_tpl_spec_decl.hpp
+++ b/lapack/tpls/KokkosLapack_potrf_tpl_spec_decl.hpp
@@ -61,13 +61,11 @@ void lapackPotrfWrapper(const ExecutionSpace& /* space */, const char uplo[], AV
 }
 
 #define KOKKOSLAPACK_POTRF_LAPACK(SCALAR, LAYOUT, EXECSPACE, MEM_SPACE)                                                \
-  template <>                                                                                                          \
+  template <bool ETI_SPEC_AVAIL>                                                                                       \
   struct Potrf<                                                                                                        \
       EXECSPACE,                                                                                                       \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,   \
-      true,                                                                                                            \
-      potrf_eti_spec_avail<EXECSPACE, Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>,             \
-                                                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>>::value> {                 \
+      true, ETI_SPEC_AVAIL> {                                                                                          \
     using AViewType =                                                                                                  \
         Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>; \
     static void potrf(const EXECSPACE& space, const char uplo[], AViewType& A) {                                       \
@@ -167,23 +165,20 @@ void cusolverPotrfWrapper(const Kokkos::Cuda& space, const char uplo[], AViewTyp
   }
 }
 
-#define KOKKOSLAPACK_POTRF_CUSOLVER(SCALAR, LAYOUT, MEM_SPACE)                                                   \
-  template <>                                                                                                    \
-  struct Potrf<                                                                                                  \
-      Kokkos::Cuda,                                                                                              \
-      Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                                    \
-                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                     \
-      true,                                                                                                      \
-      potrf_eti_spec_avail<Kokkos::Cuda, Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>, \
-                                                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>>::value> {        \
-    using AViewType = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                    \
-                                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                     \
-    static void potrf(const Kokkos::Cuda& space, const char uplo[], AViewType& A) {                              \
-      Kokkos::Profiling::pushRegion("KokkosLapack::potrf[TPL_CUSOLVER," #SCALAR "]");                            \
-      potrf_print_specialization<AViewType>();                                                                   \
-      cusolverPotrfWrapper(space, uplo, A);                                                                      \
-      Kokkos::Profiling::popRegion();                                                                            \
-    }                                                                                                            \
+#define KOKKOSLAPACK_POTRF_CUSOLVER(SCALAR, LAYOUT, MEM_SPACE)                                \
+  template <bool ETI_SPEC_AVAIL>                                                              \
+  struct Potrf<Kokkos::Cuda,                                                                  \
+               Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,        \
+                            Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                         \
+               true, ETI_SPEC_AVAIL> {                                                        \
+    using AViewType = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>, \
+                                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                  \
+    static void potrf(const Kokkos::Cuda& space, const char uplo[], AViewType& A) {           \
+      Kokkos::Profiling::pushRegion("KokkosLapack::potrf[TPL_CUSOLVER," #SCALAR "]");         \
+      potrf_print_specialization<AViewType>();                                                \
+      cusolverPotrfWrapper(space, uplo, A);                                                   \
+      Kokkos::Profiling::popRegion();                                                         \
+    }                                                                                         \
   };
 
 KOKKOSLAPACK_POTRF_CUSOLVER(float, Kokkos::LayoutLeft, Kokkos::CudaSpace)
@@ -255,13 +250,11 @@ void rocsolverPotrfWrapper(const Kokkos::HIP& space, const char uplo[], AViewTyp
 }
 
 #define KOKKOSLAPACK_POTRF_ROCSOLVER(SCALAR, LAYOUT, MEM_SPACE)                                                        \
-  template <>                                                                                                          \
+  template <bool ETI_SPEC_AVAIL>                                                                                       \
   struct Potrf<                                                                                                        \
       Kokkos::HIP,                                                                                                     \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
-      true,                                                                                                            \
-      potrf_eti_spec_avail<Kokkos::HIP, Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,         \
-                                                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>>::value> {               \
+      true, ETI_SPEC_AVAIL> {                                                                                          \
     using AViewType = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                           \
                                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                           \
     static void potrf(const Kokkos::HIP& space, const char uplo[], AViewType& A) {                                     \

--- a/lapack/tpls/KokkosLapack_potrs_tpl_spec_decl.hpp
+++ b/lapack/tpls/KokkosLapack_potrs_tpl_spec_decl.hpp
@@ -66,18 +66,13 @@ void lapackPotrsWrapper(const ExecutionSpace& /* space */, const char uplo[], co
 }
 
 #define KOKKOSLAPACK_POTRS_LAPACK(SCALAR, LAYOUT, EXECSPACE, MEM_SPACE)                                                \
-  template <>                                                                                                          \
+  template <bool ETI_SPEC_AVAIL>                                                                                       \
   struct Potrs<                                                                                                        \
       EXECSPACE,                                                                                                       \
       Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>,                                       \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                           \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,   \
-      true,                                                                                                            \
-      potrs_eti_spec_avail<EXECSPACE,                                                                                  \
-                           Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>,                  \
-                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                      \
-                           Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>,                        \
-                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>>::value> {                            \
+      true, ETI_SPEC_AVAIL> {                                                                                          \
     using AViewType = Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<EXECSPACE, MEM_SPACE>,                       \
                                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                           \
     using BViewType =                                                                                                  \
@@ -169,29 +164,24 @@ void cusolverPotrsWrapper(const Kokkos::Cuda& space, const char uplo[], const AV
   }
 }
 
-#define KOKKOSLAPACK_POTRS_CUSOLVER(SCALAR, LAYOUT, MEM_SPACE)                                                    \
-  template <>                                                                                                     \
-  struct Potrs<Kokkos::Cuda,                                                                                      \
-               Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                      \
-                            Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                             \
-               Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                            \
-                            Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                             \
-               true,                                                                                              \
-               potrs_eti_spec_avail<Kokkos::Cuda,                                                                 \
-                                    Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>, \
-                                                 Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                        \
-                                    Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,       \
-                                                 Kokkos::MemoryTraits<Kokkos::Unmanaged>>>::value> {              \
-    using AViewType = Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,               \
-                                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                      \
-    using BViewType = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                     \
-                                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                      \
-    static void potrs(const Kokkos::Cuda& space, const char uplo[], const AViewType& A, BViewType& B) {           \
-      Kokkos::Profiling::pushRegion("KokkosLapack::potrs[TPL_CUSOLVER," #SCALAR "]");                             \
-      potrs_print_specialization<AViewType, BViewType>();                                                         \
-      cusolverPotrsWrapper(space, uplo, A, B);                                                                    \
-      Kokkos::Profiling::popRegion();                                                                             \
-    }                                                                                                             \
+#define KOKKOSLAPACK_POTRS_CUSOLVER(SCALAR, LAYOUT, MEM_SPACE)                                          \
+  template <bool ETI_SPEC_AVAIL>                                                                        \
+  struct Potrs<Kokkos::Cuda,                                                                            \
+               Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,            \
+                            Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                   \
+               Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                  \
+                            Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                   \
+               true, ETI_SPEC_AVAIL> {                                                                  \
+    using AViewType = Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,     \
+                                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                            \
+    using BViewType = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,           \
+                                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                            \
+    static void potrs(const Kokkos::Cuda& space, const char uplo[], const AViewType& A, BViewType& B) { \
+      Kokkos::Profiling::pushRegion("KokkosLapack::potrs[TPL_CUSOLVER," #SCALAR "]");                   \
+      potrs_print_specialization<AViewType, BViewType>();                                               \
+      cusolverPotrsWrapper(space, uplo, A, B);                                                          \
+      Kokkos::Profiling::popRegion();                                                                   \
+    }                                                                                                   \
   };
 
 KOKKOSLAPACK_POTRS_CUSOLVER(float, Kokkos::LayoutLeft, Kokkos::CudaSpace)
@@ -262,18 +252,13 @@ void rocsolverPotrsWrapper(const Kokkos::HIP& space, const char uplo[], const AV
 }
 
 #define KOKKOSLAPACK_POTRS_ROCSOLVER(SCALAR, LAYOUT, MEM_SPACE)                                                        \
-  template <>                                                                                                          \
+  template <bool ETI_SPEC_AVAIL>                                                                                       \
   struct Potrs<                                                                                                        \
       Kokkos::HIP,                                                                                                     \
       Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                                     \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                           \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
-      true,                                                                                                            \
-      potrs_eti_spec_avail<Kokkos::HIP,                                                                                \
-                           Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                \
-                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                      \
-                           Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                      \
-                                        Kokkos::MemoryTraits<Kokkos::Unmanaged>>>::value> {                            \
+      true, ETI_SPEC_AVAIL> {                                                                                          \
     using AViewType = Kokkos::View<const SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                     \
                                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                           \
     using BViewType = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                           \

--- a/lapack/tpls/KokkosLapack_svd_tpl_spec_decl.hpp
+++ b/lapack/tpls/KokkosLapack_svd_tpl_spec_decl.hpp
@@ -87,46 +87,36 @@ void lapackSvdWrapper(const ExecutionSpace& /* space */, const char jobu[], cons
   }
 }
 
-#define KOKKOSLAPACK_SVD_LAPACK(SCALAR, LAYOUT, EXEC_SPACE)                                                            \
-  template <>                                                                                                          \
-  struct SVD<EXEC_SPACE,                                                                                               \
-             Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>,                             \
-                          Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                    \
-             Kokkos::View<KokkosKernels::ArithTraits<SCALAR>::mag_type*, Kokkos::LayoutLeft,                           \
-                          Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,     \
-             Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>,                             \
-                          Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                    \
-             Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>,                             \
-                          Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                    \
-             true,                                                                                                     \
-             svd_eti_spec_avail<                                                                                       \
-                 EXEC_SPACE,                                                                                           \
-                 Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>,                         \
-                              Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                \
-                 Kokkos::View<KokkosKernels::ArithTraits<SCALAR>::mag_type*, Kokkos::LayoutLeft,                       \
-                              Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
-                 Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>,                         \
-                              Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                \
-                 Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>,                         \
-                              Kokkos::MemoryTraits<Kokkos::Unmanaged>>>::value> {                                      \
-    using AMatrix = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>,                      \
-                                 Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                             \
-    using SVector =                                                                                                    \
-        Kokkos::View<KokkosKernels::ArithTraits<SCALAR>::mag_type*, Kokkos::LayoutLeft,                                \
-                     Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;          \
-    using UMatrix = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>,                      \
-                                 Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                             \
-    using VMatrix = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>,                      \
-                                 Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                             \
-                                                                                                                       \
-    static void svd(const EXEC_SPACE& space, const char jobu[], const char jobvt[], const AMatrix& A,                  \
-                    const SVector& S, const UMatrix& U, const VMatrix& Vt) {                                           \
-      Kokkos::Profiling::pushRegion("KokkosLapack::svd[TPL_LAPACK," #SCALAR "]");                                      \
-      svd_print_specialization<EXEC_SPACE, AMatrix, SVector, UMatrix, VMatrix>();                                      \
-                                                                                                                       \
-      lapackSvdWrapper(space, jobu, jobvt, A, S, U, Vt);                                                               \
-      Kokkos::Profiling::popRegion();                                                                                  \
-    }                                                                                                                  \
+#define KOKKOSLAPACK_SVD_LAPACK(SCALAR, LAYOUT, EXEC_SPACE)                                                        \
+  template <bool ETI_SPEC_AVAIL>                                                                                   \
+  struct SVD<EXEC_SPACE,                                                                                           \
+             Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>,                         \
+                          Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                \
+             Kokkos::View<KokkosKernels::ArithTraits<SCALAR>::mag_type*, Kokkos::LayoutLeft,                       \
+                          Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
+             Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>,                         \
+                          Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                \
+             Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>,                         \
+                          Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                \
+             true, ETI_SPEC_AVAIL> {                                                                               \
+    using AMatrix = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>,                  \
+                                 Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                         \
+    using SVector =                                                                                                \
+        Kokkos::View<KokkosKernels::ArithTraits<SCALAR>::mag_type*, Kokkos::LayoutLeft,                            \
+                     Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;      \
+    using UMatrix = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>,                  \
+                                 Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                         \
+    using VMatrix = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>,                  \
+                                 Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                         \
+                                                                                                                   \
+    static void svd(const EXEC_SPACE& space, const char jobu[], const char jobvt[], const AMatrix& A,              \
+                    const SVector& S, const UMatrix& U, const VMatrix& Vt) {                                       \
+      Kokkos::Profiling::pushRegion("KokkosLapack::svd[TPL_LAPACK," #SCALAR "]");                                  \
+      svd_print_specialization<EXEC_SPACE, AMatrix, SVector, UMatrix, VMatrix>();                                  \
+                                                                                                                   \
+      lapackSvdWrapper(space, jobu, jobvt, A, S, U, Vt);                                                           \
+      Kokkos::Profiling::popRegion();                                                                              \
+    }                                                                                                              \
   };
 
 #if defined(KOKKOS_ENABLE_SERIAL)
@@ -211,46 +201,36 @@ void mklSvdWrapper(const ExecutionSpace& /* space */, const char jobu[], const c
   }
 }
 
-#define KOKKOSLAPACK_SVD_MKL(SCALAR, LAYOUT, EXEC_SPACE)                                                               \
-  template <>                                                                                                          \
-  struct SVD<EXEC_SPACE,                                                                                               \
-             Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>,                             \
-                          Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                    \
-             Kokkos::View<KokkosKernels::ArithTraits<SCALAR>::mag_type*, Kokkos::LayoutLeft,                           \
-                          Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,     \
-             Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>,                             \
-                          Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                    \
-             Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>,                             \
-                          Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                    \
-             true,                                                                                                     \
-             svd_eti_spec_avail<                                                                                       \
-                 EXEC_SPACE,                                                                                           \
-                 Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>,                         \
-                              Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                \
-                 Kokkos::View<KokkosKernels::ArithTraits<SCALAR>::mag_type*, Kokkos::LayoutLeft,                       \
-                              Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
-                 Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>,                         \
-                              Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                \
-                 Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>,                         \
-                              Kokkos::MemoryTraits<Kokkos::Unmanaged>>>::value> {                                      \
-    using AMatrix = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>,                      \
-                                 Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                             \
-    using SVector =                                                                                                    \
-        Kokkos::View<KokkosKernels::ArithTraits<SCALAR>::mag_type*, Kokkos::LayoutLeft,                                \
-                     Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;          \
-    using UMatrix = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>,                      \
-                                 Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                             \
-    using VMatrix = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>,                      \
-                                 Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                             \
-                                                                                                                       \
-    static void svd(const EXEC_SPACE& space, const char jobu[], const char jobvt[], const AMatrix& A,                  \
-                    const SVector& S, const UMatrix& U, const VMatrix& Vt) {                                           \
-      Kokkos::Profiling::pushRegion("KokkosLapack::svd[TPL_LAPACK," #SCALAR "]");                                      \
-      svd_print_specialization<EXEC_SPACE, AMatrix, SVector, UMatrix, VMatrix>();                                      \
-                                                                                                                       \
-      mklSvdWrapper(space, jobu, jobvt, A, S, U, Vt);                                                                  \
-      Kokkos::Profiling::popRegion();                                                                                  \
-    }                                                                                                                  \
+#define KOKKOSLAPACK_SVD_MKL(SCALAR, LAYOUT, EXEC_SPACE)                                                           \
+  template <bool ETI_SPEC_AVAIL>                                                                                   \
+  struct SVD<EXEC_SPACE,                                                                                           \
+             Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>,                         \
+                          Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                \
+             Kokkos::View<KokkosKernels::ArithTraits<SCALAR>::mag_type*, Kokkos::LayoutLeft,                       \
+                          Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
+             Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>,                         \
+                          Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                \
+             Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>,                         \
+                          Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                \
+             true, ETI_SPEC_AVAIL> {                                                                               \
+    using AMatrix = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>,                  \
+                                 Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                         \
+    using SVector =                                                                                                \
+        Kokkos::View<KokkosKernels::ArithTraits<SCALAR>::mag_type*, Kokkos::LayoutLeft,                            \
+                     Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;      \
+    using UMatrix = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>,                  \
+                                 Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                         \
+    using VMatrix = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<EXEC_SPACE, Kokkos::HostSpace>,                  \
+                                 Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                         \
+                                                                                                                   \
+    static void svd(const EXEC_SPACE& space, const char jobu[], const char jobvt[], const AMatrix& A,              \
+                    const SVector& S, const UMatrix& U, const VMatrix& Vt) {                                       \
+      Kokkos::Profiling::pushRegion("KokkosLapack::svd[TPL_LAPACK," #SCALAR "]");                                  \
+      svd_print_specialization<EXEC_SPACE, AMatrix, SVector, UMatrix, VMatrix>();                                  \
+                                                                                                                   \
+      mklSvdWrapper(space, jobu, jobvt, A, S, U, Vt);                                                              \
+      Kokkos::Profiling::popRegion();                                                                              \
+    }                                                                                                              \
   };
 
 #if defined(KOKKOS_ENABLE_SERIAL)
@@ -352,7 +332,7 @@ void cusolverSvdWrapper(const ExecutionSpace& space, const char jobu[], const ch
 }
 
 #define KOKKOSLAPACK_SVD_CUSOLVER(SCALAR, LAYOUT, MEM_SPACE)                                                        \
-  template <>                                                                                                       \
+  template <bool ETI_SPEC_AVAIL>                                                                                    \
   struct SVD<Kokkos::Cuda,                                                                                          \
              Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                                \
                           Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                 \
@@ -362,17 +342,7 @@ void cusolverSvdWrapper(const ExecutionSpace& space, const char jobu[], const ch
                           Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                 \
              Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                                \
                           Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                 \
-             true,                                                                                                  \
-             svd_eti_spec_avail<                                                                                    \
-                 Kokkos::Cuda,                                                                                      \
-                 Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                            \
-                              Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                             \
-                 Kokkos::View<KokkosKernels::ArithTraits<SCALAR>::mag_type*, Kokkos::LayoutLeft,                    \
-                              Kokkos::Device<Kokkos::Cuda, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,    \
-                 Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                            \
-                              Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                             \
-                 Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                            \
-                              Kokkos::MemoryTraits<Kokkos::Unmanaged>>>::value> {                                   \
+             true, ETI_SPEC_AVAIL> {                                                                                \
     using AMatrix = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::Cuda, MEM_SPACE>,                         \
                                  Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                          \
     using SVector = Kokkos::View<KokkosKernels::ArithTraits<SCALAR>::mag_type*, Kokkos::LayoutLeft,                 \
@@ -489,7 +459,7 @@ void rocsolverSvdWrapper(const ExecutionSpace& space, const char jobu[], const c
 }
 
 #define KOKKOSLAPACK_SVD_ROCSOLVER(SCALAR, LAYOUT, MEM_SPACE)                                                          \
-  template <>                                                                                                          \
+  template <bool ETI_SPEC_AVAIL>                                                                                       \
   struct SVD<                                                                                                          \
       Kokkos::HIP,                                                                                                     \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
@@ -497,17 +467,7 @@ void rocsolverSvdWrapper(const ExecutionSpace& space, const char jobu[], const c
                    Kokkos::Device<Kokkos::HIP, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                   \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
       Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
-      true,                                                                                                            \
-      svd_eti_spec_avail<                                                                                              \
-          Kokkos::HIP,                                                                                                 \
-          Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                                       \
-                       Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                       \
-          Kokkos::View<KokkosKernels::ArithTraits<SCALAR>::mag_type*, Kokkos::LayoutLeft,                              \
-                       Kokkos::Device<Kokkos::HIP, MEM_SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,               \
-          Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                                       \
-                       Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                       \
-          Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                                       \
-                       Kokkos::MemoryTraits<Kokkos::Unmanaged>>>::value> {                                             \
+      true, ETI_SPEC_AVAIL> {                                                                                          \
     using AMatrix = Kokkos::View<SCALAR**, LAYOUT, Kokkos::Device<Kokkos::HIP, MEM_SPACE>,                             \
                                  Kokkos::MemoryTraits<Kokkos::Unmanaged>>;                                             \
     using SVector = Kokkos::View<KokkosKernels::ArithTraits<SCALAR>::mag_type*, Kokkos::LayoutLeft,                    \

--- a/lapack/tpls/KokkosLapack_trtri_tpl_spec_decl.hpp
+++ b/lapack/tpls/KokkosLapack_trtri_tpl_spec_decl.hpp
@@ -14,8 +14,8 @@ namespace KokkosLapack {
 namespace Impl {
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_LAPACK
-#define KOKKOSLAPACK_TRTRI_LAPACK_HOST(SCALAR_TYPE, BASE_SCALAR_TYPE, LAYOUTA, MEM_SPACE, ETI_SPEC_AVAIL)           \
-  template <class ExecSpace>                                                                                        \
+#define KOKKOSLAPACK_TRTRI_LAPACK_HOST(SCALAR_TYPE, BASE_SCALAR_TYPE, LAYOUTA, MEM_SPACE)                           \
+  template <class ExecSpace, bool ETI_SPEC_AVAIL>                                                                   \
   struct TRTRI<Kokkos::View<int, Kokkos::LayoutRight, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
                Kokkos::View<SCALAR_TYPE**, LAYOUTA, Kokkos::Device<ExecSpace, MEM_SPACE>,                           \
                             Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                              \
@@ -48,52 +48,52 @@ namespace Impl {
     }                                                                                                               \
   };
 #else
-#define KOKKOSLAPACK_TRTRI_LAPACK_HOST(SCALAR_TYPE, BASE_SCALAR_TYPE, LAYOUTA, MEM_SPACE, ETI_SPEC_AVAIL)
+#define KOKKOSLAPACK_TRTRI_LAPACK_HOST(SCALAR_TYPE, BASE_SCALAR_TYPE, LAYOUTA, MEM_SPACE)
 #endif  // KOKKOSKERNELS_ENABLE_TPL_LAPACK
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_MAGMA
-#define KOKKOSLAPACK_TRTRI_LAPACK_MAGMA(SCALAR_TYPE, BASE_SCALAR_TYPE, MAGMA_FN, LAYOUTA, MEM_SPACE, ETI_SPEC_AVAIL) \
-  template <class ExecSpace>                                                                                         \
-  struct TRTRI<Kokkos::View<int, Kokkos::LayoutRight, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,  \
-               Kokkos::View<SCALAR_TYPE**, LAYOUTA, Kokkos::Device<ExecSpace, MEM_SPACE>,                            \
-                            Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                               \
-               true, ETI_SPEC_AVAIL> {                                                                               \
-    typedef SCALAR_TYPE SCALAR;                                                                                      \
-    typedef Kokkos::View<int, Kokkos::LayoutRight, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >      \
-        RViewType;                                                                                                   \
-    typedef Kokkos::View<const SCALAR_TYPE**, LAYOUTA, Kokkos::Device<ExecSpace, MEM_SPACE>,                         \
-                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >                                                   \
-        AViewType;                                                                                                   \
-                                                                                                                     \
-    static void trtri(const RViewType& R, const char uplo[], const char diag[], const AViewType& A) {                \
-      Kokkos::Profiling::pushRegion("KokkosLapack::trtri[TPL_LAPACK," #SCALAR_TYPE "]");                             \
-      magma_int_t M = static_cast<magma_int_t>(A.extent(0));                                                         \
-                                                                                                                     \
-      bool A_is_layout_left = std::is_same<Kokkos::LayoutLeft, LAYOUTA>::value;                                      \
-                                                                                                                     \
-      magma_int_t AST = A_is_layout_left ? A.stride(1) : A.stride(0), LDA = (AST == 0) ? 1 : AST;                    \
-      magma_int_t info = 0;                                                                                          \
-      magma_uplo_t uplo_;                                                                                            \
-      magma_diag_t diag_;                                                                                            \
-                                                                                                                     \
-      if ((uplo[0] == 'L') || (uplo[0] == 'l'))                                                                      \
-        uplo_ = A_is_layout_left ? MagmaLower : MagmaUpper;                                                          \
-      else                                                                                                           \
-        uplo_ = A_is_layout_left ? MagmaUpper : MagmaLower;                                                          \
-                                                                                                                     \
-      if (diag[0] == 'U' || diag[0] == 'u')                                                                          \
-        diag_ = MagmaUnit;                                                                                           \
-      else                                                                                                           \
-        diag_ = MagmaNonUnit;                                                                                        \
-                                                                                                                     \
-      KokkosLapack::Impl::MagmaSingleton& s = KokkosLapack::Impl::MagmaSingleton::singleton();                       \
-      R() = MAGMA_FN(uplo_, diag_, M, reinterpret_cast<BASE_SCALAR_TYPE>(const_cast<SCALAR_TYPE*>(A.data())), LDA,   \
-                     &info);                                                                                         \
-      Kokkos::Profiling::popRegion();                                                                                \
-    }                                                                                                                \
+#define KOKKOSLAPACK_TRTRI_LAPACK_MAGMA(SCALAR_TYPE, BASE_SCALAR_TYPE, MAGMA_FN, LAYOUTA, MEM_SPACE)                \
+  template <class ExecSpace, bool ETI_SPEC_AVAIL>                                                                   \
+  struct TRTRI<Kokkos::View<int, Kokkos::LayoutRight, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, \
+               Kokkos::View<SCALAR_TYPE**, LAYOUTA, Kokkos::Device<ExecSpace, MEM_SPACE>,                           \
+                            Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                                              \
+               true, ETI_SPEC_AVAIL> {                                                                              \
+    typedef SCALAR_TYPE SCALAR;                                                                                     \
+    typedef Kokkos::View<int, Kokkos::LayoutRight, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >     \
+        RViewType;                                                                                                  \
+    typedef Kokkos::View<const SCALAR_TYPE**, LAYOUTA, Kokkos::Device<ExecSpace, MEM_SPACE>,                        \
+                         Kokkos::MemoryTraits<Kokkos::Unmanaged> >                                                  \
+        AViewType;                                                                                                  \
+                                                                                                                    \
+    static void trtri(const RViewType& R, const char uplo[], const char diag[], const AViewType& A) {               \
+      Kokkos::Profiling::pushRegion("KokkosLapack::trtri[TPL_LAPACK," #SCALAR_TYPE "]");                            \
+      magma_int_t M = static_cast<magma_int_t>(A.extent(0));                                                        \
+                                                                                                                    \
+      bool A_is_layout_left = std::is_same<Kokkos::LayoutLeft, LAYOUTA>::value;                                     \
+                                                                                                                    \
+      magma_int_t AST = A_is_layout_left ? A.stride(1) : A.stride(0), LDA = (AST == 0) ? 1 : AST;                   \
+      magma_int_t info = 0;                                                                                         \
+      magma_uplo_t uplo_;                                                                                           \
+      magma_diag_t diag_;                                                                                           \
+                                                                                                                    \
+      if ((uplo[0] == 'L') || (uplo[0] == 'l'))                                                                     \
+        uplo_ = A_is_layout_left ? MagmaLower : MagmaUpper;                                                         \
+      else                                                                                                          \
+        uplo_ = A_is_layout_left ? MagmaUpper : MagmaLower;                                                         \
+                                                                                                                    \
+      if (diag[0] == 'U' || diag[0] == 'u')                                                                         \
+        diag_ = MagmaUnit;                                                                                          \
+      else                                                                                                          \
+        diag_ = MagmaNonUnit;                                                                                       \
+                                                                                                                    \
+      KokkosLapack::Impl::MagmaSingleton& s = KokkosLapack::Impl::MagmaSingleton::singleton();                      \
+      R() = MAGMA_FN(uplo_, diag_, M, reinterpret_cast<BASE_SCALAR_TYPE>(const_cast<SCALAR_TYPE*>(A.data())), LDA,  \
+                     &info);                                                                                        \
+      Kokkos::Profiling::popRegion();                                                                               \
+    }                                                                                                               \
   };
 #else
-#define KOKKOSLAPACK_TRTRI_LAPACK_MAGMA(SCALAR_TYPE, BASE_SCALAR_TYPE, MAGMA_FN, LAYOUTA, MEM_SPACE, ETI_SPEC_AVAIL)
+#define KOKKOSLAPACK_TRTRI_LAPACK_MAGMA(SCALAR_TYPE, BASE_SCALAR_TYPE, MAGMA_FN, LAYOUTA, MEM_SPACE)
 #endif  // KOKKOSKERNELS_ENABLE_TPL_MAGMA
 
 // Explicitly define the TRTRI class for all permutations listed below
@@ -101,73 +101,56 @@ namespace Impl {
 // Handle type and space permutations
 #ifdef KOKKOS_ENABLE_CUDA
 
-#define KOKKOSLAPACK_DTRTRI_LAPACK(LAYOUTA, ETI_SPEC_AVAIL)                                                 \
-  KOKKOSLAPACK_TRTRI_LAPACK_HOST(double, double, LAYOUTA, Kokkos::HostSpace, ETI_SPEC_AVAIL)                \
-  KOKKOSLAPACK_TRTRI_LAPACK_MAGMA(double, magmaDouble_ptr, magma_dtrtri_gpu, LAYOUTA, Kokkos::CudaSpace,    \
-                                  ETI_SPEC_AVAIL)                                                           \
-  KOKKOSLAPACK_TRTRI_LAPACK_MAGMA(double, magmaDouble_ptr, magma_dtrtri_gpu, LAYOUTA, Kokkos::CudaUVMSpace, \
-                                  ETI_SPEC_AVAIL)
+#define KOKKOSLAPACK_DTRTRI_LAPACK(LAYOUTA)                                                              \
+  KOKKOSLAPACK_TRTRI_LAPACK_HOST(double, double, LAYOUTA, Kokkos::HostSpace)                             \
+  KOKKOSLAPACK_TRTRI_LAPACK_MAGMA(double, magmaDouble_ptr, magma_dtrtri_gpu, LAYOUTA, Kokkos::CudaSpace) \
+  KOKKOSLAPACK_TRTRI_LAPACK_MAGMA(double, magmaDouble_ptr, magma_dtrtri_gpu, LAYOUTA, Kokkos::CudaUVMSpace)
 
-#define KOKKOSLAPACK_STRTRI_LAPACK(LAYOUTA, ETI_SPEC_AVAIL)                                                            \
-  KOKKOSLAPACK_TRTRI_LAPACK_HOST(float, float, LAYOUTA, Kokkos::HostSpace, ETI_SPEC_AVAIL)                             \
-  KOKKOSLAPACK_TRTRI_LAPACK_MAGMA(float, magmaFloat_ptr, magma_strtri_gpu, LAYOUTA, Kokkos::CudaSpace, ETI_SPEC_AVAIL) \
-  KOKKOSLAPACK_TRTRI_LAPACK_MAGMA(float, magmaFloat_ptr, magma_strtri_gpu, LAYOUTA, Kokkos::CudaUVMSpace,              \
-                                  ETI_SPEC_AVAIL)
+#define KOKKOSLAPACK_STRTRI_LAPACK(LAYOUTA)                                                            \
+  KOKKOSLAPACK_TRTRI_LAPACK_HOST(float, float, LAYOUTA, Kokkos::HostSpace)                             \
+  KOKKOSLAPACK_TRTRI_LAPACK_MAGMA(float, magmaFloat_ptr, magma_strtri_gpu, LAYOUTA, Kokkos::CudaSpace) \
+  KOKKOSLAPACK_TRTRI_LAPACK_MAGMA(float, magmaFloat_ptr, magma_strtri_gpu, LAYOUTA, Kokkos::CudaUVMSpace)
 
-#define KOKKOSLAPACK_ZTRTRI_LAPACK(LAYOUTA, ETI_SPEC_AVAIL)                                                   \
-  KOKKOSLAPACK_TRTRI_LAPACK_HOST(Kokkos::complex<double>, std::complex<double>, LAYOUTA, Kokkos::HostSpace,   \
-                                 ETI_SPEC_AVAIL)                                                              \
+#define KOKKOSLAPACK_ZTRTRI_LAPACK(LAYOUTA)                                                                   \
+  KOKKOSLAPACK_TRTRI_LAPACK_HOST(Kokkos::complex<double>, std::complex<double>, LAYOUTA, Kokkos::HostSpace)   \
   KOKKOSLAPACK_TRTRI_LAPACK_MAGMA(Kokkos::complex<double>, magmaDoubleComplex_ptr, magma_ztrtri_gpu, LAYOUTA, \
-                                  Kokkos::CudaSpace, ETI_SPEC_AVAIL)                                          \
+                                  Kokkos::CudaSpace)                                                          \
   KOKKOSLAPACK_TRTRI_LAPACK_MAGMA(Kokkos::complex<double>, magmaDoubleComplex_ptr, magma_ztrtri_gpu, LAYOUTA, \
-                                  Kokkos::CudaUVMSpace, ETI_SPEC_AVAIL)
+                                  Kokkos::CudaUVMSpace)
 
-#define KOKKOSLAPACK_CTRTRI_LAPACK(LAYOUTA, ETI_SPEC_AVAIL)                                                 \
-  KOKKOSLAPACK_TRTRI_LAPACK_HOST(Kokkos::complex<float>, std::complex<float>, LAYOUTA, Kokkos::HostSpace,   \
-                                 ETI_SPEC_AVAIL)                                                            \
+#define KOKKOSLAPACK_CTRTRI_LAPACK(LAYOUTA)                                                                 \
+  KOKKOSLAPACK_TRTRI_LAPACK_HOST(Kokkos::complex<float>, std::complex<float>, LAYOUTA, Kokkos::HostSpace)   \
   KOKKOSLAPACK_TRTRI_LAPACK_MAGMA(Kokkos::complex<float>, magmaFloatComplex_ptr, magma_ctrtri_gpu, LAYOUTA, \
-                                  Kokkos::CudaSpace, ETI_SPEC_AVAIL)                                        \
+                                  Kokkos::CudaSpace)                                                        \
   KOKKOSLAPACK_TRTRI_LAPACK_MAGMA(Kokkos::complex<float>, magmaFloatComplex_ptr, magma_ctrtri_gpu, LAYOUTA, \
-                                  Kokkos::CudaUVMSpace, ETI_SPEC_AVAIL)
+                                  Kokkos::CudaUVMSpace)
 
 #else
 
-#define KOKKOSLAPACK_DTRTRI_LAPACK(LAYOUTA, ETI_SPEC_AVAIL) \
-  KOKKOSLAPACK_TRTRI_LAPACK_HOST(double, double, LAYOUTA, Kokkos::HostSpace, ETI_SPEC_AVAIL)
+#define KOKKOSLAPACK_DTRTRI_LAPACK(LAYOUTA) KOKKOSLAPACK_TRTRI_LAPACK_HOST(double, double, LAYOUTA, Kokkos::HostSpace)
 
-#define KOKKOSLAPACK_STRTRI_LAPACK(LAYOUTA, ETI_SPEC_AVAIL) \
-  KOKKOSLAPACK_TRTRI_LAPACK_HOST(float, float, LAYOUTA, Kokkos::HostSpace, ETI_SPEC_AVAIL)
+#define KOKKOSLAPACK_STRTRI_LAPACK(LAYOUTA) KOKKOSLAPACK_TRTRI_LAPACK_HOST(float, float, LAYOUTA, Kokkos::HostSpace)
 
-#define KOKKOSLAPACK_ZTRTRI_LAPACK(LAYOUTA, ETI_SPEC_AVAIL)                                                 \
-  KOKKOSLAPACK_TRTRI_LAPACK_HOST(Kokkos::complex<double>, std::complex<double>, LAYOUTA, Kokkos::HostSpace, \
-                                 ETI_SPEC_AVAIL)
+#define KOKKOSLAPACK_ZTRTRI_LAPACK(LAYOUTA) \
+  KOKKOSLAPACK_TRTRI_LAPACK_HOST(Kokkos::complex<double>, std::complex<double>, LAYOUTA, Kokkos::HostSpace)
 
-#define KOKKOSLAPACK_CTRTRI_LAPACK(LAYOUTA, ETI_SPEC_AVAIL)                                               \
-  KOKKOSLAPACK_TRTRI_LAPACK_HOST(Kokkos::complex<float>, std::complex<float>, LAYOUTA, Kokkos::HostSpace, \
-                                 ETI_SPEC_AVAIL)
+#define KOKKOSLAPACK_CTRTRI_LAPACK(LAYOUTA) \
+  KOKKOSLAPACK_TRTRI_LAPACK_HOST(Kokkos::complex<float>, std::complex<float>, LAYOUTA, Kokkos::HostSpace)
 
 #endif
 
 // Handle layout permutations
-KOKKOSLAPACK_DTRTRI_LAPACK(Kokkos::LayoutLeft, true)
-KOKKOSLAPACK_DTRTRI_LAPACK(Kokkos::LayoutLeft, false)
-KOKKOSLAPACK_DTRTRI_LAPACK(Kokkos::LayoutRight, true)
-KOKKOSLAPACK_DTRTRI_LAPACK(Kokkos::LayoutRight, false)
+KOKKOSLAPACK_DTRTRI_LAPACK(Kokkos::LayoutLeft)
+KOKKOSLAPACK_DTRTRI_LAPACK(Kokkos::LayoutRight)
 
-KOKKOSLAPACK_STRTRI_LAPACK(Kokkos::LayoutLeft, true)
-KOKKOSLAPACK_STRTRI_LAPACK(Kokkos::LayoutLeft, false)
-KOKKOSLAPACK_STRTRI_LAPACK(Kokkos::LayoutRight, true)
-KOKKOSLAPACK_STRTRI_LAPACK(Kokkos::LayoutRight, false)
+KOKKOSLAPACK_STRTRI_LAPACK(Kokkos::LayoutLeft)
+KOKKOSLAPACK_STRTRI_LAPACK(Kokkos::LayoutRight)
 
-KOKKOSLAPACK_ZTRTRI_LAPACK(Kokkos::LayoutLeft, true)
-KOKKOSLAPACK_ZTRTRI_LAPACK(Kokkos::LayoutLeft, false)
-KOKKOSLAPACK_ZTRTRI_LAPACK(Kokkos::LayoutRight, true)
-KOKKOSLAPACK_ZTRTRI_LAPACK(Kokkos::LayoutRight, false)
+KOKKOSLAPACK_ZTRTRI_LAPACK(Kokkos::LayoutLeft)
+KOKKOSLAPACK_ZTRTRI_LAPACK(Kokkos::LayoutRight)
 
-KOKKOSLAPACK_CTRTRI_LAPACK(Kokkos::LayoutLeft, true)
-KOKKOSLAPACK_CTRTRI_LAPACK(Kokkos::LayoutLeft, false)
-KOKKOSLAPACK_CTRTRI_LAPACK(Kokkos::LayoutRight, true)
-KOKKOSLAPACK_CTRTRI_LAPACK(Kokkos::LayoutRight, false)
+KOKKOSLAPACK_CTRTRI_LAPACK(Kokkos::LayoutLeft)
+KOKKOSLAPACK_CTRTRI_LAPACK(Kokkos::LayoutRight)
 
 }  // namespace Impl
 }  // nameSpace KokkosLapack

--- a/sparse/tpls/KokkosSparse_spadd_numeric_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spadd_numeric_tpl_spec_decl.hpp
@@ -10,9 +10,8 @@ namespace Impl {
 #ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
 
 #define KOKKOSSPARSE_SPADD_NUMERIC_TPL_SPEC_DECL_CUSPARSE(TOKEN, KOKKOS_SCALAR_TYPE, TPL_SCALAR_TYPE, ORDINAL_TYPE,    \
-                                                          OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, MEM_SPACE_TYPE,   \
-                                                          ETI_SPEC_AVAIL)                                              \
-  template <>                                                                                                          \
+                                                          OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, MEM_SPACE_TYPE)   \
+  template <bool ETI_SPEC_AVAIL>                                                                                       \
   struct SPADD_NUMERIC<                                                                                                \
       EXEC_SPACE_TYPE,                                                                                                 \
       KokkosKernels::Experimental::KokkosKernelsHandle<const OFFSET_TYPE, const ORDINAL_TYPE,                          \
@@ -91,28 +90,21 @@ namespace Impl {
     }                                                                                                                  \
   };
 
-#define KOKKOSSPARSE_SPADD_NUMERIC_TPL_SPEC_DECL_CUSPARSE_EXT(ETI_SPEC_AVAIL)                                      \
-  KOKKOSSPARSE_SPADD_NUMERIC_TPL_SPEC_DECL_CUSPARSE(S, float, float, int, int, Kokkos::LayoutLeft, Kokkos::Cuda,   \
-                                                    Kokkos::CudaSpace, ETI_SPEC_AVAIL)                             \
-  KOKKOSSPARSE_SPADD_NUMERIC_TPL_SPEC_DECL_CUSPARSE(D, double, double, int, int, Kokkos::LayoutLeft, Kokkos::Cuda, \
-                                                    Kokkos::CudaSpace, ETI_SPEC_AVAIL)                             \
-  KOKKOSSPARSE_SPADD_NUMERIC_TPL_SPEC_DECL_CUSPARSE(C, Kokkos::complex<float>, cuComplex, int, int,                \
-                                                    Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::CudaSpace,           \
-                                                    ETI_SPEC_AVAIL)                                                \
-  KOKKOSSPARSE_SPADD_NUMERIC_TPL_SPEC_DECL_CUSPARSE(Z, Kokkos::complex<double>, cuDoubleComplex, int, int,         \
-                                                    Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::CudaSpace,           \
-                                                    ETI_SPEC_AVAIL)
-
-KOKKOSSPARSE_SPADD_NUMERIC_TPL_SPEC_DECL_CUSPARSE_EXT(true)
-KOKKOSSPARSE_SPADD_NUMERIC_TPL_SPEC_DECL_CUSPARSE_EXT(false)
+KOKKOSSPARSE_SPADD_NUMERIC_TPL_SPEC_DECL_CUSPARSE(S, float, float, int, int, Kokkos::LayoutLeft, Kokkos::Cuda,
+                                                  Kokkos::CudaSpace)
+KOKKOSSPARSE_SPADD_NUMERIC_TPL_SPEC_DECL_CUSPARSE(D, double, double, int, int, Kokkos::LayoutLeft, Kokkos::Cuda,
+                                                  Kokkos::CudaSpace)
+KOKKOSSPARSE_SPADD_NUMERIC_TPL_SPEC_DECL_CUSPARSE(C, Kokkos::complex<float>, cuComplex, int, int, Kokkos::LayoutLeft,
+                                                  Kokkos::Cuda, Kokkos::CudaSpace)
+KOKKOSSPARSE_SPADD_NUMERIC_TPL_SPEC_DECL_CUSPARSE(Z, Kokkos::complex<double>, cuDoubleComplex, int, int,
+                                                  Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::CudaSpace)
 #endif
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_ROCSPARSE
 
 #define KOKKOSSPARSE_SPADD_NUMERIC_TPL_SPEC_DECL_ROCSPARSE(TOKEN, KOKKOS_SCALAR_TYPE, TPL_SCALAR_TYPE, ORDINAL_TYPE,   \
-                                                           OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, MEM_SPACE_TYPE,  \
-                                                           ETI_SPEC_AVAIL)                                             \
-  template <>                                                                                                          \
+                                                           OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, MEM_SPACE_TYPE)  \
+  template <bool ETI_SPEC_AVAIL>                                                                                       \
   struct SPADD_NUMERIC<                                                                                                \
       EXEC_SPACE_TYPE,                                                                                                 \
       KokkosKernels::Experimental::KokkosKernelsHandle<const OFFSET_TYPE, const ORDINAL_TYPE,                          \
@@ -191,20 +183,14 @@ KOKKOSSPARSE_SPADD_NUMERIC_TPL_SPEC_DECL_CUSPARSE_EXT(false)
     }                                                                                                                  \
   };
 
-#define KOKKOSSPARSE_SPADD_NUMERIC_TPL_SPEC_DECL_ROCSPARSE_EXT(ETI_SPEC_AVAIL)                                       \
-  KOKKOSSPARSE_SPADD_NUMERIC_TPL_SPEC_DECL_ROCSPARSE(s, float, float, int, int, Kokkos::LayoutLeft, Kokkos::HIP,     \
-                                                     Kokkos::HIPSpace, ETI_SPEC_AVAIL)                               \
-  KOKKOSSPARSE_SPADD_NUMERIC_TPL_SPEC_DECL_ROCSPARSE(d, double, double, int, int, Kokkos::LayoutLeft, Kokkos::HIP,   \
-                                                     Kokkos::HIPSpace, ETI_SPEC_AVAIL)                               \
-  KOKKOSSPARSE_SPADD_NUMERIC_TPL_SPEC_DECL_ROCSPARSE(c, Kokkos::complex<float>, rocsparse_float_complex, int, int,   \
-                                                     Kokkos::LayoutLeft, Kokkos::HIP, Kokkos::HIPSpace,              \
-                                                     ETI_SPEC_AVAIL)                                                 \
-  KOKKOSSPARSE_SPADD_NUMERIC_TPL_SPEC_DECL_ROCSPARSE(z, Kokkos::complex<double>, rocsparse_double_complex, int, int, \
-                                                     Kokkos::LayoutLeft, Kokkos::HIP, Kokkos::HIPSpace,              \
-                                                     ETI_SPEC_AVAIL)
-
-KOKKOSSPARSE_SPADD_NUMERIC_TPL_SPEC_DECL_ROCSPARSE_EXT(true)
-KOKKOSSPARSE_SPADD_NUMERIC_TPL_SPEC_DECL_ROCSPARSE_EXT(false)
+KOKKOSSPARSE_SPADD_NUMERIC_TPL_SPEC_DECL_ROCSPARSE(s, float, float, int, int, Kokkos::LayoutLeft, Kokkos::HIP,
+                                                   Kokkos::HIPSpace)
+KOKKOSSPARSE_SPADD_NUMERIC_TPL_SPEC_DECL_ROCSPARSE(d, double, double, int, int, Kokkos::LayoutLeft, Kokkos::HIP,
+                                                   Kokkos::HIPSpace)
+KOKKOSSPARSE_SPADD_NUMERIC_TPL_SPEC_DECL_ROCSPARSE(c, Kokkos::complex<float>, rocsparse_float_complex, int, int,
+                                                   Kokkos::LayoutLeft, Kokkos::HIP, Kokkos::HIPSpace)
+KOKKOSSPARSE_SPADD_NUMERIC_TPL_SPEC_DECL_ROCSPARSE(z, Kokkos::complex<double>, rocsparse_double_complex, int, int,
+                                                   Kokkos::LayoutLeft, Kokkos::HIP, Kokkos::HIPSpace)
 #endif
 
 }  // namespace Impl

--- a/sparse/tpls/KokkosSparse_spadd_symbolic_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spadd_symbolic_tpl_spec_decl.hpp
@@ -10,9 +10,8 @@ namespace Impl {
 #ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
 
 #define KOKKOSSPARSE_SPADD_SYMBOLIC_TPL_SPEC_DECL_CUSPARSE(TOKEN, KOKKOS_SCALAR_TYPE, TPL_SCALAR_TYPE, ORDINAL_TYPE,   \
-                                                           OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, MEM_SPACE_TYPE,  \
-                                                           ETI_SPEC_AVAIL)                                             \
-  template <>                                                                                                          \
+                                                           OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, MEM_SPACE_TYPE)  \
+  template <bool ETI_SPEC_AVAIL>                                                                                       \
   struct SPADD_SYMBOLIC<                                                                                               \
       EXEC_SPACE_TYPE,                                                                                                 \
       KokkosKernels::Experimental::KokkosKernelsHandle<const OFFSET_TYPE, const ORDINAL_TYPE,                          \
@@ -85,27 +84,21 @@ namespace Impl {
     }                                                                                                                  \
   };
 
-#define KOKKOSSPARSE_SPADD_SYMBOLIC_TPL_SPEC_DECL_CUSPARSE_EXT(ETI_SPEC_AVAIL)                                      \
-  KOKKOSSPARSE_SPADD_SYMBOLIC_TPL_SPEC_DECL_CUSPARSE(S, float, float, int, int, Kokkos::LayoutLeft, Kokkos::Cuda,   \
-                                                     Kokkos::CudaSpace, ETI_SPEC_AVAIL)                             \
-  KOKKOSSPARSE_SPADD_SYMBOLIC_TPL_SPEC_DECL_CUSPARSE(D, double, double, int, int, Kokkos::LayoutLeft, Kokkos::Cuda, \
-                                                     Kokkos::CudaSpace, ETI_SPEC_AVAIL)                             \
-  KOKKOSSPARSE_SPADD_SYMBOLIC_TPL_SPEC_DECL_CUSPARSE(C, Kokkos::complex<float>, cuComplex, int, int,                \
-                                                     Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::CudaSpace,           \
-                                                     ETI_SPEC_AVAIL)                                                \
-  KOKKOSSPARSE_SPADD_SYMBOLIC_TPL_SPEC_DECL_CUSPARSE(Z, Kokkos::complex<double>, cuDoubleComplex, int, int,         \
-                                                     Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::CudaSpace,           \
-                                                     ETI_SPEC_AVAIL)
-
-KOKKOSSPARSE_SPADD_SYMBOLIC_TPL_SPEC_DECL_CUSPARSE_EXT(true)
-KOKKOSSPARSE_SPADD_SYMBOLIC_TPL_SPEC_DECL_CUSPARSE_EXT(false)
+KOKKOSSPARSE_SPADD_SYMBOLIC_TPL_SPEC_DECL_CUSPARSE(S, float, float, int, int, Kokkos::LayoutLeft, Kokkos::Cuda,
+                                                   Kokkos::CudaSpace)
+KOKKOSSPARSE_SPADD_SYMBOLIC_TPL_SPEC_DECL_CUSPARSE(D, double, double, int, int, Kokkos::LayoutLeft, Kokkos::Cuda,
+                                                   Kokkos::CudaSpace)
+KOKKOSSPARSE_SPADD_SYMBOLIC_TPL_SPEC_DECL_CUSPARSE(C, Kokkos::complex<float>, cuComplex, int, int, Kokkos::LayoutLeft,
+                                                   Kokkos::Cuda, Kokkos::CudaSpace)
+KOKKOSSPARSE_SPADD_SYMBOLIC_TPL_SPEC_DECL_CUSPARSE(Z, Kokkos::complex<double>, cuDoubleComplex, int, int,
+                                                   Kokkos::LayoutLeft, Kokkos::Cuda, Kokkos::CudaSpace)
 #endif
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_ROCSPARSE
 
-#define KOKKOSSPARSE_SPADD_SYMBOLIC_TPL_SPEC_DECL_ROCSPARSE(                                                           \
-    KOKKOS_SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE, LAYOUT_TYPE, EXEC_SPACE_TYPE, MEM_SPACE_TYPE, ETI_SPEC_AVAIL)       \
-  template <>                                                                                                          \
+#define KOKKOSSPARSE_SPADD_SYMBOLIC_TPL_SPEC_DECL_ROCSPARSE(KOKKOS_SCALAR_TYPE, ORDINAL_TYPE, OFFSET_TYPE,             \
+                                                            LAYOUT_TYPE, EXEC_SPACE_TYPE, MEM_SPACE_TYPE)              \
+  template <bool ETI_SPEC_AVAIL>                                                                                       \
   struct SPADD_SYMBOLIC<                                                                                               \
       EXEC_SPACE_TYPE,                                                                                                 \
       KokkosKernels::Experimental::KokkosKernelsHandle<const OFFSET_TYPE, const ORDINAL_TYPE,                          \
@@ -160,20 +153,14 @@ KOKKOSSPARSE_SPADD_SYMBOLIC_TPL_SPEC_DECL_CUSPARSE_EXT(false)
     }                                                                                                                  \
   };
 
-#define KOKKOSSPARSE_SPADD_SYMBOLIC_TPL_SPEC_DECL_ROCSPARSE_EXT(ETI_SPEC_AVAIL)                                 \
-  KOKKOSSPARSE_SPADD_SYMBOLIC_TPL_SPEC_DECL_ROCSPARSE(float, rocsparse_int, rocsparse_int, Kokkos::LayoutLeft,  \
-                                                      Kokkos::HIP, Kokkos::HIPSpace, ETI_SPEC_AVAIL)            \
-  KOKKOSSPARSE_SPADD_SYMBOLIC_TPL_SPEC_DECL_ROCSPARSE(double, rocsparse_int, rocsparse_int, Kokkos::LayoutLeft, \
-                                                      Kokkos::HIP, Kokkos::HIPSpace, ETI_SPEC_AVAIL)            \
-  KOKKOSSPARSE_SPADD_SYMBOLIC_TPL_SPEC_DECL_ROCSPARSE(Kokkos::complex<float>, rocsparse_int, rocsparse_int,     \
-                                                      Kokkos::LayoutLeft, Kokkos::HIP, Kokkos::HIPSpace,        \
-                                                      ETI_SPEC_AVAIL)                                           \
-  KOKKOSSPARSE_SPADD_SYMBOLIC_TPL_SPEC_DECL_ROCSPARSE(Kokkos::complex<double>, rocsparse_int, rocsparse_int,    \
-                                                      Kokkos::LayoutLeft, Kokkos::HIP, Kokkos::HIPSpace,        \
-                                                      ETI_SPEC_AVAIL)
-
-KOKKOSSPARSE_SPADD_SYMBOLIC_TPL_SPEC_DECL_ROCSPARSE_EXT(true)
-KOKKOSSPARSE_SPADD_SYMBOLIC_TPL_SPEC_DECL_ROCSPARSE_EXT(false)
+KOKKOSSPARSE_SPADD_SYMBOLIC_TPL_SPEC_DECL_ROCSPARSE(float, rocsparse_int, rocsparse_int, Kokkos::LayoutLeft,
+                                                    Kokkos::HIP, Kokkos::HIPSpace)
+KOKKOSSPARSE_SPADD_SYMBOLIC_TPL_SPEC_DECL_ROCSPARSE(double, rocsparse_int, rocsparse_int, Kokkos::LayoutLeft,
+                                                    Kokkos::HIP, Kokkos::HIPSpace)
+KOKKOSSPARSE_SPADD_SYMBOLIC_TPL_SPEC_DECL_ROCSPARSE(Kokkos::complex<float>, rocsparse_int, rocsparse_int,
+                                                    Kokkos::LayoutLeft, Kokkos::HIP, Kokkos::HIPSpace)
+KOKKOSSPARSE_SPADD_SYMBOLIC_TPL_SPEC_DECL_ROCSPARSE(Kokkos::complex<double>, rocsparse_int, rocsparse_int,
+                                                    Kokkos::LayoutLeft, Kokkos::HIP, Kokkos::HIPSpace)
 #endif
 
 }  // namespace Impl

--- a/sparse/tpls/KokkosSparse_spgemm_noreuse_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spgemm_noreuse_tpl_spec_decl.hpp
@@ -117,14 +117,14 @@ Matrix spgemm_noreuse_cusparse(KokkosSparse::SPGEMMAlgorithm algo, const MatrixC
   return Matrix("C", m, k, c_nnz, valuesC, row_mapC, entriesC);
 }
 
-#define SPGEMM_NOREUSE_DECL_CUSPARSE(SCALAR, MEMSPACE, TPL_AVAIL)                                                  \
-  template <>                                                                                                      \
+#define SPGEMM_NOREUSE_DECL_CUSPARSE(SCALAR, MEMSPACE)                                                             \
+  template <bool ETI_SPEC_AVAIL>                                                                                   \
   struct SPGEMM_NOREUSE<KokkosSparse::CrsMatrix<SCALAR, int, Kokkos::Device<Kokkos::Cuda, MEMSPACE>, void, int>,   \
                         KokkosSparse::CrsMatrix<const SCALAR, const int, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,   \
                                                 Kokkos::MemoryTraits<Kokkos::Unmanaged>, const int>,               \
                         KokkosSparse::CrsMatrix<const SCALAR, const int, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,   \
                                                 Kokkos::MemoryTraits<Kokkos::Unmanaged>, const int>,               \
-                        true, TPL_AVAIL> {                                                                         \
+                        true, ETI_SPEC_AVAIL> {                                                                    \
     using Matrix      = KokkosSparse::CrsMatrix<SCALAR, int, Kokkos::Device<Kokkos::Cuda, MEMSPACE>, void, int>;   \
     using ConstMatrix = KokkosSparse::CrsMatrix<const SCALAR, const int, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,   \
                                                 Kokkos::MemoryTraits<Kokkos::Unmanaged>, const int>;               \
@@ -139,19 +139,14 @@ Matrix spgemm_noreuse_cusparse(KokkosSparse::SPGEMMAlgorithm algo, const MatrixC
     }                                                                                                              \
   };
 
-#define SPGEMM_NOREUSE_DECL_CUSPARSE_S(SCALAR, TPL_AVAIL)            \
-  SPGEMM_NOREUSE_DECL_CUSPARSE(SCALAR, Kokkos::CudaSpace, TPL_AVAIL) \
-  SPGEMM_NOREUSE_DECL_CUSPARSE(SCALAR, Kokkos::CudaUVMSpace, TPL_AVAIL)
+#define SPGEMM_NOREUSE_DECL_CUSPARSE_S(SCALAR)            \
+  SPGEMM_NOREUSE_DECL_CUSPARSE(SCALAR, Kokkos::CudaSpace) \
+  SPGEMM_NOREUSE_DECL_CUSPARSE(SCALAR, Kokkos::CudaUVMSpace)
 
-SPGEMM_NOREUSE_DECL_CUSPARSE_S(float, true)
-SPGEMM_NOREUSE_DECL_CUSPARSE_S(double, true)
-SPGEMM_NOREUSE_DECL_CUSPARSE_S(Kokkos::complex<float>, true)
-SPGEMM_NOREUSE_DECL_CUSPARSE_S(Kokkos::complex<double>, true)
-
-SPGEMM_NOREUSE_DECL_CUSPARSE_S(float, false)
-SPGEMM_NOREUSE_DECL_CUSPARSE_S(double, false)
-SPGEMM_NOREUSE_DECL_CUSPARSE_S(Kokkos::complex<float>, false)
-SPGEMM_NOREUSE_DECL_CUSPARSE_S(Kokkos::complex<double>, false)
+SPGEMM_NOREUSE_DECL_CUSPARSE_S(float)
+SPGEMM_NOREUSE_DECL_CUSPARSE_S(double)
+SPGEMM_NOREUSE_DECL_CUSPARSE_S(Kokkos::complex<float>)
+SPGEMM_NOREUSE_DECL_CUSPARSE_S(Kokkos::complex<double>)
 
 #endif
 
@@ -207,15 +202,15 @@ Matrix spgemm_noreuse_mkl(const MatrixConst &A, const MatrixConst &B) {
   return Matrix("C", m, k, c_nnz, valuesC, row_mapC, entriesC);
 }
 
-#define SPGEMM_NOREUSE_DECL_MKL(SCALAR, EXEC, TPL_AVAIL)                                                              \
-  template <>                                                                                                         \
+#define SPGEMM_NOREUSE_DECL_MKL(SCALAR, EXEC)                                                                         \
+  template <bool ETI_SPEC_AVAIL>                                                                                      \
   struct SPGEMM_NOREUSE<                                                                                              \
       KokkosSparse::CrsMatrix<SCALAR, MKL_INT, Kokkos::Device<EXEC, Kokkos::HostSpace>, void, MKL_INT>,               \
       KokkosSparse::CrsMatrix<const SCALAR, const MKL_INT, Kokkos::Device<EXEC, Kokkos::HostSpace>,                   \
                               Kokkos::MemoryTraits<Kokkos::Unmanaged>, const MKL_INT>,                                \
       KokkosSparse::CrsMatrix<const SCALAR, const MKL_INT, Kokkos::Device<EXEC, Kokkos::HostSpace>,                   \
                               Kokkos::MemoryTraits<Kokkos::Unmanaged>, const MKL_INT>,                                \
-      true, TPL_AVAIL> {                                                                                              \
+      true, ETI_SPEC_AVAIL> {                                                                                         \
     using Matrix = KokkosSparse::CrsMatrix<SCALAR, MKL_INT, Kokkos::Device<EXEC, Kokkos::HostSpace>, void, MKL_INT>;  \
     using ConstMatrix = KokkosSparse::CrsMatrix<const SCALAR, const MKL_INT, Kokkos::Device<EXEC, Kokkos::HostSpace>, \
                                                 Kokkos::MemoryTraits<Kokkos::Unmanaged>, const MKL_INT>;              \
@@ -229,15 +224,11 @@ Matrix spgemm_noreuse_mkl(const MatrixConst &A, const MatrixConst &B) {
     }                                                                                                                 \
   };
 
-#define SPGEMM_NOREUSE_DECL_MKL_SE(SCALAR, EXEC) \
-  SPGEMM_NOREUSE_DECL_MKL(SCALAR, EXEC, true)    \
-  SPGEMM_NOREUSE_DECL_MKL(SCALAR, EXEC, false)
-
-#define SPGEMM_NOREUSE_DECL_MKL_E(EXEC)                    \
-  SPGEMM_NOREUSE_DECL_MKL_SE(float, EXEC)                  \
-  SPGEMM_NOREUSE_DECL_MKL_SE(double, EXEC)                 \
-  SPGEMM_NOREUSE_DECL_MKL_SE(Kokkos::complex<float>, EXEC) \
-  SPGEMM_NOREUSE_DECL_MKL_SE(Kokkos::complex<double>, EXEC)
+#define SPGEMM_NOREUSE_DECL_MKL_E(EXEC)                 \
+  SPGEMM_NOREUSE_DECL_MKL(float, EXEC)                  \
+  SPGEMM_NOREUSE_DECL_MKL(double, EXEC)                 \
+  SPGEMM_NOREUSE_DECL_MKL(Kokkos::complex<float>, EXEC) \
+  SPGEMM_NOREUSE_DECL_MKL(Kokkos::complex<double>, EXEC)
 
 #ifdef KOKKOS_ENABLE_SERIAL
 SPGEMM_NOREUSE_DECL_MKL_E(Kokkos::Serial)

--- a/sparse/tpls/KokkosSparse_spgemm_numeric_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spgemm_numeric_tpl_spec_decl.hpp
@@ -128,8 +128,8 @@ void spgemm_numeric_cusparse(KernelHandle *handle, lno_t /*m*/, lno_t /*n*/, lno
 }
 #endif
 
-#define SPGEMM_NUMERIC_DECL_CUSPARSE(SCALAR, MEMSPACE, TPL_AVAIL)                                                      \
-  template <>                                                                                                          \
+#define SPGEMM_NUMERIC_DECL_CUSPARSE(SCALAR, MEMSPACE)                                                                 \
+  template <bool ETI_SPEC_AVAIL>                                                                                       \
   struct SPGEMM_NUMERIC<KokkosKernels::Experimental::KokkosKernelsHandle<const int, const int, const SCALAR,           \
                                                                          Kokkos::Cuda, MEMSPACE, MEMSPACE>,            \
                         Kokkos::View<const int *, KokkosKernels::default_layout,                                       \
@@ -150,7 +150,7 @@ void spgemm_numeric_cusparse(KernelHandle *handle, lno_t /*m*/, lno_t /*n*/, lno
                                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                         \
                         Kokkos::View<SCALAR *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,  \
                                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                         \
-                        true, TPL_AVAIL> {                                                                             \
+                        true, ETI_SPEC_AVAIL> {                                                                        \
     using KernelHandle = KokkosKernels::Experimental::KokkosKernelsHandle<const int, const int, const SCALAR,          \
                                                                           Kokkos::Cuda, MEMSPACE, MEMSPACE>;           \
     using c_int_view_t =                                                                                               \
@@ -178,19 +178,14 @@ void spgemm_numeric_cusparse(KernelHandle *handle, lno_t /*m*/, lno_t /*n*/, lno
     }                                                                                                                  \
   };
 
-#define SPGEMM_NUMERIC_DECL_CUSPARSE_S(SCALAR, TPL_AVAIL)            \
-  SPGEMM_NUMERIC_DECL_CUSPARSE(SCALAR, Kokkos::CudaSpace, TPL_AVAIL) \
-  SPGEMM_NUMERIC_DECL_CUSPARSE(SCALAR, Kokkos::CudaUVMSpace, TPL_AVAIL)
+#define SPGEMM_NUMERIC_DECL_CUSPARSE_S(SCALAR)            \
+  SPGEMM_NUMERIC_DECL_CUSPARSE(SCALAR, Kokkos::CudaSpace) \
+  SPGEMM_NUMERIC_DECL_CUSPARSE(SCALAR, Kokkos::CudaUVMSpace)
 
-SPGEMM_NUMERIC_DECL_CUSPARSE_S(float, true)
-SPGEMM_NUMERIC_DECL_CUSPARSE_S(double, true)
-SPGEMM_NUMERIC_DECL_CUSPARSE_S(Kokkos::complex<float>, true)
-SPGEMM_NUMERIC_DECL_CUSPARSE_S(Kokkos::complex<double>, true)
-
-SPGEMM_NUMERIC_DECL_CUSPARSE_S(float, false)
-SPGEMM_NUMERIC_DECL_CUSPARSE_S(double, false)
-SPGEMM_NUMERIC_DECL_CUSPARSE_S(Kokkos::complex<float>, false)
-SPGEMM_NUMERIC_DECL_CUSPARSE_S(Kokkos::complex<double>, false)
+SPGEMM_NUMERIC_DECL_CUSPARSE_S(float)
+SPGEMM_NUMERIC_DECL_CUSPARSE_S(double)
+SPGEMM_NUMERIC_DECL_CUSPARSE_S(Kokkos::complex<float>)
+SPGEMM_NUMERIC_DECL_CUSPARSE_S(Kokkos::complex<double>)
 #endif
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_ROCSPARSE
@@ -265,8 +260,8 @@ void spgemm_numeric_rocsparse(KernelHandle *handle, typename KernelHandle::nnz_l
   handle->set_call_numeric();
 }
 
-#define SPGEMM_NUMERIC_DECL_ROCSPARSE(SCALAR, TPL_AVAIL)                                                              \
-  template <>                                                                                                         \
+#define SPGEMM_NUMERIC_DECL_ROCSPARSE(SCALAR)                                                                         \
+  template <bool ETI_SPEC_AVAIL>                                                                                      \
   struct SPGEMM_NUMERIC<                                                                                              \
       KokkosKernels::Experimental::KokkosKernelsHandle<const int, const int, const SCALAR, Kokkos::HIP,               \
                                                        Kokkos::HIPSpace, Kokkos::HIPSpace>,                           \
@@ -288,7 +283,7 @@ void spgemm_numeric_rocsparse(KernelHandle *handle, typename KernelHandle::nnz_l
                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                          \
       Kokkos::View<SCALAR *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,            \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                          \
-      true, TPL_AVAIL> {                                                                                              \
+      true, ETI_SPEC_AVAIL> {                                                                                         \
     using KernelHandle =                                                                                              \
         KokkosKernels::Experimental::KokkosKernelsHandle<const int, const int, const SCALAR, Kokkos::HIP,             \
                                                          Kokkos::HIPSpace, Kokkos::HIPSpace>;                         \
@@ -318,15 +313,10 @@ void spgemm_numeric_rocsparse(KernelHandle *handle, typename KernelHandle::nnz_l
     }                                                                                                                 \
   };
 
-SPGEMM_NUMERIC_DECL_ROCSPARSE(float, true)
-SPGEMM_NUMERIC_DECL_ROCSPARSE(double, true)
-SPGEMM_NUMERIC_DECL_ROCSPARSE(Kokkos::complex<float>, true)
-SPGEMM_NUMERIC_DECL_ROCSPARSE(Kokkos::complex<double>, true)
-
-SPGEMM_NUMERIC_DECL_ROCSPARSE(float, false)
-SPGEMM_NUMERIC_DECL_ROCSPARSE(double, false)
-SPGEMM_NUMERIC_DECL_ROCSPARSE(Kokkos::complex<float>, false)
-SPGEMM_NUMERIC_DECL_ROCSPARSE(Kokkos::complex<double>, false)
+SPGEMM_NUMERIC_DECL_ROCSPARSE(float)
+SPGEMM_NUMERIC_DECL_ROCSPARSE(double)
+SPGEMM_NUMERIC_DECL_ROCSPARSE(Kokkos::complex<float>)
+SPGEMM_NUMERIC_DECL_ROCSPARSE(Kokkos::complex<double>)
 #endif
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_MKL
@@ -383,8 +373,8 @@ void spgemm_numeric_mkl(KernelHandle *handle, typename KernelHandle::nnz_lno_t m
   handle->set_computed_entries();
 }
 
-#define SPGEMM_NUMERIC_DECL_MKL(SCALAR, EXEC, TPL_AVAIL)                                                               \
-  template <>                                                                                                          \
+#define SPGEMM_NUMERIC_DECL_MKL(SCALAR, EXEC)                                                                          \
+  template <bool ETI_SPEC_AVAIL>                                                                                       \
   struct SPGEMM_NUMERIC<                                                                                               \
       KokkosKernels::Experimental::KokkosKernelsHandle<const MKL_INT, const MKL_INT, const SCALAR, EXEC,               \
                                                        Kokkos::HostSpace, Kokkos::HostSpace>,                          \
@@ -406,7 +396,7 @@ void spgemm_numeric_mkl(KernelHandle *handle, typename KernelHandle::nnz_lno_t m
                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                           \
       Kokkos::View<SCALAR *, KokkosKernels::default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,                   \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                           \
-      true, TPL_AVAIL> {                                                                                               \
+      true, ETI_SPEC_AVAIL> {                                                                                          \
     using KernelHandle = KokkosKernels::Experimental::KokkosKernelsHandle<const MKL_INT, const MKL_INT, const SCALAR,  \
                                                                           EXEC, Kokkos::HostSpace, Kokkos::HostSpace>; \
     using c_int_view_t =                                                                                               \
@@ -433,15 +423,11 @@ void spgemm_numeric_mkl(KernelHandle *handle, typename KernelHandle::nnz_lno_t m
     }                                                                                                                  \
   };
 
-#define SPGEMM_NUMERIC_DECL_MKL_SE(SCALAR, EXEC) \
-  SPGEMM_NUMERIC_DECL_MKL(SCALAR, EXEC, true)    \
-  SPGEMM_NUMERIC_DECL_MKL(SCALAR, EXEC, false)
-
-#define SPGEMM_NUMERIC_DECL_MKL_E(EXEC)                    \
-  SPGEMM_NUMERIC_DECL_MKL_SE(float, EXEC)                  \
-  SPGEMM_NUMERIC_DECL_MKL_SE(double, EXEC)                 \
-  SPGEMM_NUMERIC_DECL_MKL_SE(Kokkos::complex<float>, EXEC) \
-  SPGEMM_NUMERIC_DECL_MKL_SE(Kokkos::complex<double>, EXEC)
+#define SPGEMM_NUMERIC_DECL_MKL_E(EXEC)                 \
+  SPGEMM_NUMERIC_DECL_MKL(float, EXEC)                  \
+  SPGEMM_NUMERIC_DECL_MKL(double, EXEC)                 \
+  SPGEMM_NUMERIC_DECL_MKL(Kokkos::complex<float>, EXEC) \
+  SPGEMM_NUMERIC_DECL_MKL(Kokkos::complex<double>, EXEC)
 
 #ifdef KOKKOS_ENABLE_SERIAL
 SPGEMM_NUMERIC_DECL_MKL_E(Kokkos::Serial)

--- a/sparse/tpls/KokkosSparse_spgemm_symbolic_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spgemm_symbolic_tpl_spec_decl.hpp
@@ -281,8 +281,8 @@ void spgemm_symbolic_cusparse(KernelHandle *handle, lno_t m, lno_t n, lno_t k, c
 }
 #endif
 
-#define SPGEMM_SYMBOLIC_DECL_CUSPARSE(SCALAR, MEMSPACE, TPL_AVAIL)                                                     \
-  template <>                                                                                                          \
+#define SPGEMM_SYMBOLIC_DECL_CUSPARSE(SCALAR, MEMSPACE)                                                                \
+  template <bool ETI_SPEC_AVAIL>                                                                                       \
   struct SPGEMM_SYMBOLIC<                                                                                              \
       KokkosKernels::Experimental::KokkosKernelsHandle<const int, const int, const SCALAR, Kokkos::Cuda, MEMSPACE,     \
                                                        MEMSPACE>,                                                      \
@@ -296,7 +296,7 @@ void spgemm_symbolic_cusparse(KernelHandle *handle, lno_t m, lno_t n, lno_t k, c
                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                           \
       Kokkos::View<int *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,                       \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                           \
-      true, TPL_AVAIL> {                                                                                               \
+      true, ETI_SPEC_AVAIL> {                                                                                          \
     using KernelHandle = KokkosKernels::Experimental::KokkosKernelsHandle<const int, const int, const SCALAR,          \
                                                                           Kokkos::Cuda, MEMSPACE, MEMSPACE>;           \
     using c_int_view_t =                                                                                               \
@@ -317,19 +317,14 @@ void spgemm_symbolic_cusparse(KernelHandle *handle, lno_t m, lno_t n, lno_t k, c
     }                                                                                                                  \
   };
 
-#define SPGEMM_SYMBOLIC_DECL_CUSPARSE_S(SCALAR, TPL_AVAIL)            \
-  SPGEMM_SYMBOLIC_DECL_CUSPARSE(SCALAR, Kokkos::CudaSpace, TPL_AVAIL) \
-  SPGEMM_SYMBOLIC_DECL_CUSPARSE(SCALAR, Kokkos::CudaUVMSpace, TPL_AVAIL)
+#define SPGEMM_SYMBOLIC_DECL_CUSPARSE_S(SCALAR)            \
+  SPGEMM_SYMBOLIC_DECL_CUSPARSE(SCALAR, Kokkos::CudaSpace) \
+  SPGEMM_SYMBOLIC_DECL_CUSPARSE(SCALAR, Kokkos::CudaUVMSpace)
 
-SPGEMM_SYMBOLIC_DECL_CUSPARSE_S(float, true)
-SPGEMM_SYMBOLIC_DECL_CUSPARSE_S(double, true)
-SPGEMM_SYMBOLIC_DECL_CUSPARSE_S(Kokkos::complex<float>, true)
-SPGEMM_SYMBOLIC_DECL_CUSPARSE_S(Kokkos::complex<double>, true)
-
-SPGEMM_SYMBOLIC_DECL_CUSPARSE_S(float, false)
-SPGEMM_SYMBOLIC_DECL_CUSPARSE_S(double, false)
-SPGEMM_SYMBOLIC_DECL_CUSPARSE_S(Kokkos::complex<float>, false)
-SPGEMM_SYMBOLIC_DECL_CUSPARSE_S(Kokkos::complex<double>, false)
+SPGEMM_SYMBOLIC_DECL_CUSPARSE_S(float)
+SPGEMM_SYMBOLIC_DECL_CUSPARSE_S(double)
+SPGEMM_SYMBOLIC_DECL_CUSPARSE_S(Kokkos::complex<float>)
+SPGEMM_SYMBOLIC_DECL_CUSPARSE_S(Kokkos::complex<double>)
 
 #endif
 
@@ -411,8 +406,8 @@ void spgemm_symbolic_rocsparse(KernelHandle *handle, typename KernelHandle::nnz_
   handle->set_computed_rowptrs();
 }
 
-#define SPGEMM_SYMBOLIC_DECL_ROCSPARSE(SCALAR, TPL_AVAIL)                                                       \
-  template <>                                                                                                   \
+#define SPGEMM_SYMBOLIC_DECL_ROCSPARSE(SCALAR)                                                                  \
+  template <bool ETI_SPEC_AVAIL>                                                                                \
   struct SPGEMM_SYMBOLIC<                                                                                       \
       KokkosKernels::Experimental::KokkosKernelsHandle<const int, const int, const SCALAR, Kokkos::HIP,         \
                                                        Kokkos::HIPSpace, Kokkos::HIPSpace>,                     \
@@ -426,7 +421,7 @@ void spgemm_symbolic_rocsparse(KernelHandle *handle, typename KernelHandle::nnz_
                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                    \
       Kokkos::View<int *, KokkosKernels::default_layout, Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>,         \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                    \
-      true, TPL_AVAIL> {                                                                                        \
+      true, ETI_SPEC_AVAIL> {                                                                                   \
     using KernelHandle =                                                                                        \
         KokkosKernels::Experimental::KokkosKernelsHandle<const int, const int, const SCALAR, Kokkos::HIP,       \
                                                          Kokkos::HIPSpace, Kokkos::HIPSpace>;                   \
@@ -449,15 +444,10 @@ void spgemm_symbolic_rocsparse(KernelHandle *handle, typename KernelHandle::nnz_
     }                                                                                                           \
   };
 
-SPGEMM_SYMBOLIC_DECL_ROCSPARSE(float, false)
-SPGEMM_SYMBOLIC_DECL_ROCSPARSE(double, false)
-SPGEMM_SYMBOLIC_DECL_ROCSPARSE(Kokkos::complex<float>, false)
-SPGEMM_SYMBOLIC_DECL_ROCSPARSE(Kokkos::complex<double>, false)
-
-SPGEMM_SYMBOLIC_DECL_ROCSPARSE(float, true)
-SPGEMM_SYMBOLIC_DECL_ROCSPARSE(double, true)
-SPGEMM_SYMBOLIC_DECL_ROCSPARSE(Kokkos::complex<float>, true)
-SPGEMM_SYMBOLIC_DECL_ROCSPARSE(Kokkos::complex<double>, true)
+SPGEMM_SYMBOLIC_DECL_ROCSPARSE(float)
+SPGEMM_SYMBOLIC_DECL_ROCSPARSE(double)
+SPGEMM_SYMBOLIC_DECL_ROCSPARSE(Kokkos::complex<float>)
+SPGEMM_SYMBOLIC_DECL_ROCSPARSE(Kokkos::complex<double>)
 #endif
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_MKL
@@ -504,8 +494,8 @@ void spgemm_symbolic_mkl(KernelHandle *handle, typename KernelHandle::nnz_lno_t 
   handle->set_c_nnz(rowptrC(m));
 }
 
-#define SPGEMM_SYMBOLIC_DECL_MKL(SCALAR, EXEC, TPL_AVAIL)                                                              \
-  template <>                                                                                                          \
+#define SPGEMM_SYMBOLIC_DECL_MKL(SCALAR, EXEC)                                                                         \
+  template <bool ETI_SPEC_AVAIL>                                                                                       \
   struct SPGEMM_SYMBOLIC<                                                                                              \
       KokkosKernels::Experimental::KokkosKernelsHandle<const MKL_INT, const MKL_INT, const SCALAR, EXEC,               \
                                                        Kokkos::HostSpace, Kokkos::HostSpace>,                          \
@@ -519,7 +509,7 @@ void spgemm_symbolic_mkl(KernelHandle *handle, typename KernelHandle::nnz_lno_t 
                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                           \
       Kokkos::View<MKL_INT *, KokkosKernels::default_layout, Kokkos::Device<EXEC, Kokkos::HostSpace>,                  \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                           \
-      true, TPL_AVAIL> {                                                                                               \
+      true, ETI_SPEC_AVAIL> {                                                                                          \
     using KernelHandle = KokkosKernels::Experimental::KokkosKernelsHandle<const MKL_INT, const MKL_INT, const SCALAR,  \
                                                                           EXEC, Kokkos::HostSpace, Kokkos::HostSpace>; \
     using c_int_view_t =                                                                                               \
@@ -538,15 +528,11 @@ void spgemm_symbolic_mkl(KernelHandle *handle, typename KernelHandle::nnz_lno_t 
     }                                                                                                                  \
   };
 
-#define SPGEMM_SYMBOLIC_DECL_MKL_SE(SCALAR, EXEC) \
-  SPGEMM_SYMBOLIC_DECL_MKL(SCALAR, EXEC, true)    \
-  SPGEMM_SYMBOLIC_DECL_MKL(SCALAR, EXEC, false)
-
-#define SPGEMM_SYMBOLIC_DECL_MKL_E(EXEC)                    \
-  SPGEMM_SYMBOLIC_DECL_MKL_SE(float, EXEC)                  \
-  SPGEMM_SYMBOLIC_DECL_MKL_SE(double, EXEC)                 \
-  SPGEMM_SYMBOLIC_DECL_MKL_SE(Kokkos::complex<float>, EXEC) \
-  SPGEMM_SYMBOLIC_DECL_MKL_SE(Kokkos::complex<double>, EXEC)
+#define SPGEMM_SYMBOLIC_DECL_MKL_E(EXEC)                 \
+  SPGEMM_SYMBOLIC_DECL_MKL(float, EXEC)                  \
+  SPGEMM_SYMBOLIC_DECL_MKL(double, EXEC)                 \
+  SPGEMM_SYMBOLIC_DECL_MKL(Kokkos::complex<float>, EXEC) \
+  SPGEMM_SYMBOLIC_DECL_MKL(Kokkos::complex<double>, EXEC)
 
 #ifdef KOKKOS_ENABLE_SERIAL
 SPGEMM_SYMBOLIC_DECL_MKL_E(Kokkos::Serial)

--- a/sparse/tpls/KokkosSparse_spmv_bsrmatrix_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spmv_bsrmatrix_tpl_spec_decl.hpp
@@ -142,7 +142,7 @@ inline void spmv_mv_bsr_mkl(Handle* handle, sparse_operation_t op, Scalar alpha,
 }
 
 #define KOKKOSSPARSE_SPMV_MKL(SCALAR, EXECSPACE)                                                                         \
-  template <>                                                                                                            \
+  template <bool ETI_SPEC_AVAIL>                                                                                         \
   struct SPMV_BSRMATRIX<EXECSPACE,                                                                                       \
                         KokkosSparse::Impl::SPMVHandleImpl<EXECSPACE, Kokkos::HostSpace, SCALAR, MKL_INT, MKL_INT>,      \
                         ::KokkosSparse::Experimental::BsrMatrix<                                                         \
@@ -152,7 +152,7 @@ inline void spmv_mv_bsr_mkl(Handle* handle, sparse_operation_t op, Scalar alpha,
                                      Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>,                    \
                         Kokkos::View<SCALAR*, Kokkos::LayoutLeft, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,          \
                                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                           \
-                        true> {                                                                                          \
+                        true, ETI_SPEC_AVAIL> {                                                                          \
     using device_type = Kokkos::Device<EXECSPACE, Kokkos::HostSpace>;                                                    \
     using Handle      = KokkosSparse::Impl::SPMVHandleImpl<EXECSPACE, Kokkos::HostSpace, SCALAR, MKL_INT, MKL_INT>;      \
     using AMatrix     = ::KokkosSparse::Experimental::BsrMatrix<SCALAR const, MKL_INT const, device_type,                \
@@ -189,7 +189,7 @@ KOKKOSSPARSE_SPMV_MKL(Kokkos::complex<double>, Kokkos::OpenMP)
 #undef KOKKOSSPARSE_SPMV_MKL
 
 #define KOKKOSSPARSE_SPMV_MV_MKL(SCALAR, EXECSPACE)                                                                      \
-  template <>                                                                                                            \
+  template <bool ETI_SPEC_AVAIL>                                                                                         \
   struct SPMV_MV_BSRMATRIX<                                                                                              \
       EXECSPACE, KokkosSparse::Impl::SPMVHandleImpl<EXECSPACE, Kokkos::HostSpace, SCALAR, MKL_INT, MKL_INT>,             \
       ::KokkosSparse::Experimental::BsrMatrix<SCALAR const, MKL_INT const,                                               \
@@ -199,7 +199,7 @@ KOKKOSSPARSE_SPMV_MKL(Kokkos::complex<double>, Kokkos::OpenMP)
                    Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>,                                      \
       Kokkos::View<SCALAR**, Kokkos::LayoutLeft, Kokkos::Device<EXECSPACE, Kokkos::HostSpace>,                           \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                             \
-      true, true> {                                                                                                      \
+      true, ETI_SPEC_AVAIL> {                                                                                            \
     using device_type = Kokkos::Device<EXECSPACE, Kokkos::HostSpace>;                                                    \
     using Handle      = KokkosSparse::Impl::SPMVHandleImpl<EXECSPACE, Kokkos::HostSpace, SCALAR, MKL_INT, MKL_INT>;      \
     using AMatrix     = ::KokkosSparse::Experimental::BsrMatrix<SCALAR const, MKL_INT const, device_type,                \
@@ -552,7 +552,7 @@ void spmv_mv_bsr_cusparse(const Kokkos::Cuda& exec, Handle* handle, const char m
 }
 
 #define KOKKOSSPARSE_SPMV_CUSPARSE(SCALAR, ORDINAL, OFFSET, LAYOUT, SPACE)                                         \
-  template <>                                                                                                      \
+  template <bool ETI_SPEC_AVAIL>                                                                                   \
   struct SPMV_BSRMATRIX<                                                                                           \
       Kokkos::Cuda, KokkosSparse::Impl::SPMVHandleImpl<Kokkos::Cuda, SPACE, SCALAR, OFFSET, ORDINAL>,              \
       ::KokkosSparse::Experimental::BsrMatrix<SCALAR const, ORDINAL const, Kokkos::Device<Kokkos::Cuda, SPACE>,    \
@@ -560,7 +560,7 @@ void spmv_mv_bsr_cusparse(const Kokkos::Cuda& exec, Handle* handle, const char m
       Kokkos::View<SCALAR const*, LAYOUT, Kokkos::Device<Kokkos::Cuda, SPACE>,                                     \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>,                                \
       Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<Kokkos::Cuda, SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
-      true> {                                                                                                      \
+      true, ETI_SPEC_AVAIL> {                                                                                      \
     using device_type       = Kokkos::Device<Kokkos::Cuda, SPACE>;                                                 \
     using memory_trait_type = Kokkos::MemoryTraits<Kokkos::Unmanaged>;                                             \
     using Handle            = KokkosSparse::Impl::SPMVHandleImpl<Kokkos::Cuda, SPACE, SCALAR, OFFSET, ORDINAL>;    \
@@ -604,8 +604,8 @@ KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<float>, int, int, Kokkos::LayoutRight
 
 // cuSparse TPL does not support LayoutRight for this operation
 // only specialize for LayoutLeft
-#define KOKKOSSPARSE_SPMV_MV_CUSPARSE(SCALAR, ORDINAL, OFFSET, SPACE, ETI_AVAIL)                                \
-  template <>                                                                                                   \
+#define KOKKOSSPARSE_SPMV_MV_CUSPARSE(SCALAR, ORDINAL, OFFSET, SPACE)                                           \
+  template <bool ETI_SPEC_AVAIL>                                                                                \
   struct SPMV_MV_BSRMATRIX<                                                                                     \
       Kokkos::Cuda, KokkosSparse::Impl::SPMVHandleImpl<Kokkos::Cuda, SPACE, SCALAR, OFFSET, ORDINAL>,           \
       ::KokkosSparse::Experimental::BsrMatrix<SCALAR const, ORDINAL const, Kokkos::Device<Kokkos::Cuda, SPACE>, \
@@ -614,7 +614,7 @@ KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<float>, int, int, Kokkos::LayoutRight
                    Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>,                             \
       Kokkos::View<SCALAR**, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::Cuda, SPACE>,                           \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged>>,                                                    \
-      false, true, ETI_AVAIL> {                                                                                 \
+      false, true, ETI_SPEC_AVAIL> {                                                                            \
     using device_type       = Kokkos::Device<Kokkos::Cuda, SPACE>;                                              \
     using memory_trait_type = Kokkos::MemoryTraits<Kokkos::Unmanaged>;                                          \
     using Handle            = KokkosSparse::Impl::SPMVHandleImpl<Kokkos::Cuda, SPACE, SCALAR, OFFSET, ORDINAL>; \
@@ -637,22 +637,14 @@ KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<float>, int, int, Kokkos::LayoutRight
     }                                                                                                           \
   };
 
-KOKKOSSPARSE_SPMV_MV_CUSPARSE(double, int, int, Kokkos::CudaSpace, true)
-KOKKOSSPARSE_SPMV_MV_CUSPARSE(double, int, int, Kokkos::CudaSpace, false)
-KOKKOSSPARSE_SPMV_MV_CUSPARSE(float, int, int, Kokkos::CudaSpace, true)
-KOKKOSSPARSE_SPMV_MV_CUSPARSE(float, int, int, Kokkos::CudaSpace, false)
-KOKKOSSPARSE_SPMV_MV_CUSPARSE(Kokkos::complex<double>, int, int, Kokkos::CudaSpace, true)
-KOKKOSSPARSE_SPMV_MV_CUSPARSE(Kokkos::complex<double>, int, int, Kokkos::CudaSpace, false)
-KOKKOSSPARSE_SPMV_MV_CUSPARSE(Kokkos::complex<float>, int, int, Kokkos::CudaSpace, true)
-KOKKOSSPARSE_SPMV_MV_CUSPARSE(Kokkos::complex<float>, int, int, Kokkos::CudaSpace, false)
-KOKKOSSPARSE_SPMV_MV_CUSPARSE(double, int, int, Kokkos::CudaUVMSpace, true)
-KOKKOSSPARSE_SPMV_MV_CUSPARSE(double, int, int, Kokkos::CudaUVMSpace, false)
-KOKKOSSPARSE_SPMV_MV_CUSPARSE(float, int, int, Kokkos::CudaUVMSpace, true)
-KOKKOSSPARSE_SPMV_MV_CUSPARSE(float, int, int, Kokkos::CudaUVMSpace, false)
-KOKKOSSPARSE_SPMV_MV_CUSPARSE(Kokkos::complex<double>, int, int, Kokkos::CudaUVMSpace, true)
-KOKKOSSPARSE_SPMV_MV_CUSPARSE(Kokkos::complex<double>, int, int, Kokkos::CudaUVMSpace, false)
-KOKKOSSPARSE_SPMV_MV_CUSPARSE(Kokkos::complex<float>, int, int, Kokkos::CudaUVMSpace, true)
-KOKKOSSPARSE_SPMV_MV_CUSPARSE(Kokkos::complex<float>, int, int, Kokkos::CudaUVMSpace, false)
+KOKKOSSPARSE_SPMV_MV_CUSPARSE(double, int, int, Kokkos::CudaSpace)
+KOKKOSSPARSE_SPMV_MV_CUSPARSE(float, int, int, Kokkos::CudaSpace)
+KOKKOSSPARSE_SPMV_MV_CUSPARSE(Kokkos::complex<double>, int, int, Kokkos::CudaSpace)
+KOKKOSSPARSE_SPMV_MV_CUSPARSE(Kokkos::complex<float>, int, int, Kokkos::CudaSpace)
+KOKKOSSPARSE_SPMV_MV_CUSPARSE(double, int, int, Kokkos::CudaUVMSpace)
+KOKKOSSPARSE_SPMV_MV_CUSPARSE(float, int, int, Kokkos::CudaUVMSpace)
+KOKKOSSPARSE_SPMV_MV_CUSPARSE(Kokkos::complex<double>, int, int, Kokkos::CudaUVMSpace)
+KOKKOSSPARSE_SPMV_MV_CUSPARSE(Kokkos::complex<float>, int, int, Kokkos::CudaUVMSpace)
 
 #undef KOKKOSSPARSE_SPMV_MV_CUSPARSE
 
@@ -877,7 +869,7 @@ void spmv_bsr_rocsparse(const Kokkos::HIP& exec, Handle* handle, const char mode
 }  // spmv_bsr_rocsparse
 
 #define KOKKOSSPARSE_SPMV_ROCSPARSE(SCALAR, ORDINAL, OFFSET, LAYOUT, SPACE)                                       \
-  template <>                                                                                                     \
+  template <bool ETI_SPEC_AVAIL>                                                                                  \
   struct SPMV_BSRMATRIX<                                                                                          \
       Kokkos::HIP, KokkosSparse::Impl::SPMVHandleImpl<Kokkos::HIP, SPACE, SCALAR, OFFSET, ORDINAL>,               \
       ::KokkosSparse::Experimental::BsrMatrix<SCALAR const, ORDINAL const, Kokkos::Device<Kokkos::HIP, SPACE>,    \
@@ -885,7 +877,7 @@ void spmv_bsr_rocsparse(const Kokkos::HIP& exec, Handle* handle, const char mode
       Kokkos::View<SCALAR const*, LAYOUT, Kokkos::Device<Kokkos::HIP, SPACE>,                                     \
                    Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>>,                               \
       Kokkos::View<SCALAR*, LAYOUT, Kokkos::Device<Kokkos::HIP, SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>>, \
-      true> {                                                                                                     \
+      true, ETI_SPEC_AVAIL> {                                                                                     \
     using device_type       = Kokkos::Device<Kokkos::HIP, SPACE>;                                                 \
     using memory_trait_type = Kokkos::MemoryTraits<Kokkos::Unmanaged>;                                            \
     using Handle            = KokkosSparse::Impl::SPMVHandleImpl<Kokkos::HIP, SPACE, SCALAR, OFFSET, ORDINAL>;    \


### PR DESCRIPTION
Make all TPL specializations partial by templating them on ``bool ETI_SPEC_AVAIL``.

This accomplishes two things:
- Make TPL wrappers instantiate lazily, instead of eagerly in every translation unit where they're included. This speeds up the build, especially for wrappers than contain fallback kernels.
- Avoids the need to call DECL macros twice (with "true" and "false" plugged in for eti_spec_avail), but also without using the tedious eti_spec_avail expression with all kernel template arguments.

This would essentially resolve #2041 in a simpler way, IMO.

I tested a large configuration (serial+openmp+cuda, with TPLs) before and after to see the impact on build times and library sizes.
Before/develop:
- ``make -j8`` took 31:53
- libkokkoskernels.a was 230.5 MB
- The overall build directory was 1.75 GB

After:
- ``make -j8`` took 30:13
- libkokkoskernels.a was 170.8 MB (26% smaller)
- The build directory was 1.36 GB (22% smaller)

This is not the only solution to the issues identified in #2041. The other I can see would be moving the TPL specializations out of the headers and into their own .cpp files. This would then require more work:
- separate DECL/INST macros
- some more CMake logic
- using the long expressions to get the correct ``blah_eti_spec_avail<...>::value`` to plug into the specializations

I'm not sure all this is worth it, since the majority of the possible build time reduction is already achieved here with many fewer lines changed.

While working on this, it was also shown that our ETI system does work as intended. Object files that will be linked with ``libkokkoskernels`` (perf tests, for example) do contain ETI'd kernels as undefined symbols, which means they didn't re-compile them unnecessarily. If these object files did recompile kernels, they'd show up as weak symbols.