### PR TITLE
Export enabled TPLs in KokkosKernelsConfig.cmake

### DIFF
--- a/cmake/KokkosKernelsConfig.cmake.in
+++ b/cmake/KokkosKernelsConfig.cmake.in
@@ -7,6 +7,11 @@ include(CMakeFindDependencyMacro)
 
 @KOKKOSKERNELS_TPL_EXPORTS@
 
+set(KokkosKernels_TPLS @KOKKOSKERNELS_TPL_LIST@)
+foreach(TPL ${KokkosKernels_TPLS})
+  set(KokkosKernels_TPL_ENABLE_${TPL} ON)
+endforeach()
+
 if(NOT Kokkos_FOUND)
   find_dependency(Kokkos HINTS @Kokkos_DIR@)
 endif()


### PR DESCRIPTION
As discussed in https://kokkosteam.slack.com/archives/CMZDYKZ96/p1786654759582509, this pull reques exports the enabled TPLs in the CMake configuration so that downstream users can use those values in their `CMake` setup.