### PR TITLE
Fix typo KokkosKernels_TPL_ENABLE -> KokkosKernels_ENABLE_TPL

### DIFF
--- a/cmake/KokkosKernelsConfig.cmake.in
+++ b/cmake/KokkosKernelsConfig.cmake.in
@@ -9,7 +9,7 @@ include(CMakeFindDependencyMacro)
 
 set(KokkosKernels_TPLS @KOKKOSKERNELS_TPL_LIST@)
 foreach(TPL ${KokkosKernels_TPLS})
-  set(KokkosKernels_TPL_ENABLE_${TPL} ON)
+  set(KokkosKernels_ENABLE_TPL_${TPL} ON)
 endforeach()
 
 if(NOT Kokkos_FOUND)


### PR DESCRIPTION
Follow-up to #3248. The idea was to use the same CMake variable name as would be available when configuring `KokkosKernels` in place but I accidentally swapped `TPL` and `ENABLE`.