### PR TITLE
Adjustments to allow DKokkosKernels_ENABLE_TPL_MKL to compile on Aurora

### DIFF
--- a/blas/tpls/KokkosBlas2_gemv_tpl_spec_decl.hpp
+++ b/blas/tpls/KokkosBlas2_gemv_tpl_spec_decl.hpp
@@ -485,39 +485,18 @@ KOKKOSBLAS2_CGEMV_ROCBLAS(Kokkos::LayoutRight, false)
 namespace KokkosBlas {
 namespace Impl {
 
-inline oneapi::mkl::transpose mode_kk_to_onemkl(char mode_kk) {
-  switch (toupper(mode_kk)) {
-    case 'N': return oneapi::mkl::transpose::nontrans;
-    case 'T': return oneapi::mkl::transpose::trans;
-    case 'C': return oneapi::mkl::transpose::conjtrans;
-    default:;
-  }
-  throw std::invalid_argument("Invalid mode for oneMKL (should be one of N, T, C)");
-}
-
-template <typename T, bool is_complex = false>
-struct kokkos_to_std_type_map {
-  using type = T;
-};
-
-// e.g., map Kokkos::complex<float> to std::complex<float>
-template <typename T>
-struct kokkos_to_std_type_map<T, true> {
-  using type = std::complex<typename KokkosKernels::ArithTraits<T>::mag_type>;
-};
-
 #define KOKKOSBLAS2_GEMV_ONEMKL(SCALAR, LAYOUT, ETI_SPEC_AVAIL)                                                         \
   template <>                                                                                                           \
   struct GEMV<                                                                                                          \
-      EXEC_SPACE, Kokkos::View<const SCALAR**, LAYOUT, Kokkos::SYCL, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,         \
+      Kokkos::SYCL, Kokkos::View<const SCALAR**, LAYOUT, Kokkos::SYCL, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,       \
       Kokkos::View<const SCALAR*, LAYOUT, Kokkos::SYCL, Kokkos::MemoryTraits<Kokkos::Unmanaged> >,                      \
       Kokkos::View<SCALAR*, LAYOUT, Kokkos::SYCL, Kokkos::MemoryTraits<Kokkos::Unmanaged> >, true, ETI_SPEC_AVAIL> {    \
     using mem_traits = Kokkos::MemoryTraits<Kokkos::Unmanaged>;                                                         \
-    using AViewType  = Kokkos::View<const SCALAR**, LAYOUT, EXEC_SPACE, mem_traits>;                                    \
-    using XViewType  = Kokkos::View<const SCALAR*, LAYOUT, EXEC_SPACE, mem_traits>;                                     \
-    using YViewType  = Kokkos::View<SCALAR*, LAYOUT, EXEC_SPACE, mem_traits>;                                           \
+    using AViewType  = Kokkos::View<const SCALAR**, LAYOUT, Kokkos::SYCL, mem_traits>;                                  \
+    using XViewType  = Kokkos::View<const SCALAR*, LAYOUT, Kokkos::SYCL, mem_traits>;                                   \
+    using YViewType  = Kokkos::View<SCALAR*, LAYOUT, Kokkos::SYCL, mem_traits>;                                         \
                                                                                                                         \
-    static void gemv(const EXEC_SPACE& exec, const char kk_trans[], typename AViewType::const_value_type& alpha,        \
+    static void gemv(const Kokkos::SYCL& exec, const char kk_trans[], typename AViewType::const_value_type& alpha,      \
                      const AViewType& A, const XViewType& X, typename YViewType::const_value_type& beta,                \
                      const YViewType& Y) {                                                                              \
       if (beta == KokkosKernels::ArithTraits<SCALAR>::zero()) {                                                         \


### PR DESCRIPTION
A previous commit 5ce4df1cf2d6ed0a57c74312cf84a99e8b9428cb broke the `DKokkosKernels_ENABLE_TPL_MKL` build that we use on Aurora. In particular, it had two issues:

1) In `blas/tpls/KokkosBlas2_gemv_tpl_spec_decl.hpp`, there was a definition of ` oneapi::mkl::transpose mode_kk_to_onemkl` which was not needed since it's defined in `blas/tpls/KokkosBlas_tpl_spec.hpp` which is included. This led to the compile error
```
kokkos-kernels/blas/tpls/KokkosBlas2_gemv_tpl_spec_decl.hpp:505:8: error: 
      redefinition of 'kokkos_to_std_type_map<T, true>'
  505 | struct kokkos_to_std_type_map<T, true> {
      |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
kokkos-kernels/blas/tpls/KokkosBlas_tpl_spec.hpp:243:8: note: 
      previous definition is here
  243 | struct kokkos_to_std_type_map<T, true> {
      |        ^
```

2) `EXEC_SPACE` was used, but it's never defined. This lead to the error
```
kokkos-kernels/kokkos-kernels/blas/tpls/KokkosBlas2_gemv_tpl_spec_decl.hpp:548:1: error: 
      use of undeclared identifier 'EXEC_SPACE'
  548 | KOKKOSBLAS2_GEMV_ONEMKL(float, Kokkos::LayoutLeft, true)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

To fix 1), this PR removes the new definition since it's in the header file. 

To fix 2), this PR swaps in `Kokkos::SYCL` for EXEC_SPACE, as we know we will be using SYCL since it's guarded by `defined(KOKKOS_ENABLE_SYCL)`.