### PR TITLE
Add batched syrk

### DIFF
--- a/batched/dense/impl/KokkosBatched_Syrk_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_Syrk_Impl.hpp
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#ifndef KOKKOSBATCHED_SYRK_IMPL_HPP_
+#define KOKKOSBATCHED_SYRK_IMPL_HPP_
+
+#include <KokkosBlas_util.hpp>
+#include <KokkosBatched_Util.hpp>
+#include "KokkosBatched_Syrk_Internal.hpp"
+
+namespace KokkosBatched {
+namespace Impl {
+template <bool is_trans, typename AViewType, typename CViewType>
+KOKKOS_INLINE_FUNCTION static int checkSyrkInput([[maybe_unused]] const AViewType &A,
+                                                 [[maybe_unused]] const CViewType &C) {
+  static_assert(Kokkos::is_view_v<AViewType>, "KokkosBatched::syrk: AViewType is not a Kokkos::View.");
+  static_assert(Kokkos::is_view_v<CViewType>, "KokkosBatched::syrk: CViewType is not a Kokkos::View.");
+  static_assert(AViewType::rank == 2, "KokkosBatched::syrk: AViewType must have rank 2.");
+  static_assert(CViewType::rank == 2, "KokkosBatched::syrk: CViewType must have rank 2.");
+#ifndef NDEBUG
+  const int ldc = C.extent_int(0), n = C.extent_int(1);
+  const int lda   = A.extent_int(0);
+  const int k     = is_trans ? A.extent_int(0) : A.extent_int(1);
+  const int nrowa = is_trans ? k : n;
+
+  if (lda < Kokkos::max(1, nrowa)) {
+    Kokkos::printf(
+        "KokkosBatched::syrk: leading dimension of A must not be smaller than "
+        "max(1, nrowa): "
+        "lda = %d, nrowa = %d\n",
+        lda, nrowa);
+    return 1;
+  }
+
+  if (ldc < Kokkos::max(1, n)) {
+    Kokkos::printf(
+        "KokkosBatched::syrk: leading dimension of C must not be smaller than "
+        "max(1, n): "
+        "ldc = %d, n = %d\n",
+        ldc, n);
+    return 1;
+  }
+#endif
+  return 0;
+}
+}  // namespace Impl
+
+/// Serial Batched Syrk:
+/// {s,d,c,z}syrk and {c,z}herk interface
+/// Performs one of the symmetric rank k operation
+///   C := alpha*A*A**T + beta*C
+///   C := alpha*A*A**H + beta*C
+///   C := alpha*A**T*A + beta*C
+///   C := alpha*A**H*A + beta*C
+template <typename ArgUplo, typename ArgTrans>
+template <typename ScalarType, typename AViewType, typename CViewType>
+KOKKOS_INLINE_FUNCTION int SerialSyrk<ArgUplo, ArgTrans>::invoke(const ScalarType alpha, const AViewType &A,
+                                                                 const ScalarType beta, const CViewType &C) {
+  // Quick return if possible
+  constexpr bool is_trans = std::same_as<ArgTrans, Trans::Transpose> || std::same_as<ArgTrans, Trans::ConjTranspose>;
+  const int n             = C.extent_int(1);
+  const int k             = is_trans ? A.extent_int(0) : A.extent_int(1);
+  if (n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
+
+  auto info = Impl::checkSyrkInput<is_trans>(A, C);
+  if (info) return info;
+
+  using op = std::conditional_t<(std::same_as<ArgTrans, Trans::ConjNoTranspose> ||
+                                 std::same_as<ArgTrans, Trans::ConjTranspose>),
+                                KokkosBlas::Impl::OpConj, KokkosBlas::Impl::OpID>;
+
+  using sym_op = std::conditional_t<(std::same_as<ArgTrans, Trans::ConjNoTranspose> ||
+                                     std::same_as<ArgTrans, Trans::ConjTranspose>),
+                                    KokkosBlas::Impl::OpReal, KokkosBlas::Impl::OpID>;
+
+  using value_type = typename CViewType::non_const_value_type;
+  using mag_type   = typename KokkosKernels::ArithTraits<value_type>::mag_type;
+  using ReduceType = std::conditional_t<(std::same_as<ArgTrans, Trans::ConjNoTranspose> ||
+                                         std::same_as<ArgTrans, Trans::ConjTranspose>),
+                                        mag_type, value_type>;
+
+  if constexpr (std::same_as<ArgUplo, Uplo::Lower>) {
+    return Impl::SerialSyrkInternalLower::invoke<is_trans, ReduceType>(
+        op(), sym_op(), n, k, alpha, A.data(), A.stride(0), A.stride(1), beta, C.data(), C.stride(0), C.stride(1));
+  } else {
+    return Impl::SerialSyrkInternalUpper::invoke<is_trans, ReduceType>(
+        op(), sym_op(), n, k, alpha, A.data(), A.stride(0), A.stride(1), beta, C.data(), C.stride(0), C.stride(1));
+  }
+}
+
+/// Team Batched Syrk:
+/// {s,d,c,z}syrk and {c,z}herk interface
+/// Performs one of the symmetric rank k operation
+///   C := alpha*A*A**T + beta*C
+///   C := alpha*A*A**H + beta*C
+///   C := alpha*A**T*A + beta*C
+///   C := alpha*A**H*A + beta*C
+template <typename MemberType, typename ArgUplo, typename ArgTrans>
+template <typename ScalarType, typename AViewType, typename CViewType>
+KOKKOS_INLINE_FUNCTION int TeamSyrk<MemberType, ArgUplo, ArgTrans>::invoke(const MemberType &member,
+                                                                           const ScalarType alpha, const AViewType &A,
+                                                                           const ScalarType beta, const CViewType &C) {
+  // Quick return if possible
+  constexpr bool is_trans = std::same_as<ArgTrans, Trans::Transpose> || std::same_as<ArgTrans, Trans::ConjTranspose>;
+  const int n             = C.extent_int(1);
+  const int k             = is_trans ? A.extent_int(0) : A.extent_int(1);
+  if (n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
+
+  auto info = Impl::checkSyrkInput<is_trans>(A, C);
+  if (info) return info;
+
+  using op = std::conditional_t<(std::same_as<ArgTrans, Trans::ConjNoTranspose> ||
+                                 std::same_as<ArgTrans, Trans::ConjTranspose>),
+                                KokkosBlas::Impl::OpConj, KokkosBlas::Impl::OpID>;
+
+  using sym_op = std::conditional_t<(std::same_as<ArgTrans, Trans::ConjNoTranspose> ||
+                                     std::same_as<ArgTrans, Trans::ConjTranspose>),
+                                    KokkosBlas::Impl::OpReal, KokkosBlas::Impl::OpID>;
+
+  using value_type = typename CViewType::non_const_value_type;
+  using mag_type   = typename KokkosKernels::ArithTraits<value_type>::mag_type;
+  using ReduceType = std::conditional_t<(std::same_as<ArgTrans, Trans::ConjNoTranspose> ||
+                                         std::same_as<ArgTrans, Trans::ConjTranspose>),
+                                        mag_type, value_type>;
+
+  if constexpr (std::same_as<ArgUplo, Uplo::Lower>) {
+    return Impl::TeamSyrkInternalLower::invoke<is_trans, ReduceType>(member, op(), sym_op(), n, k, alpha, A.data(),
+                                                                     A.stride(0), A.stride(1), beta, C.data(),
+                                                                     C.stride(0), C.stride(1));
+  } else {
+    return Impl::TeamSyrkInternalUpper::invoke<is_trans, ReduceType>(member, op(), sym_op(), n, k, alpha, A.data(),
+                                                                     A.stride(0), A.stride(1), beta, C.data(),
+                                                                     C.stride(0), C.stride(1));
+  }
+}
+
+/// TeamVector Batched Syrk:
+/// {s,d,c,z}syrk and {c,z}herk interface
+/// Performs one of the symmetric rank k operation
+///   C := alpha*A*A**T + beta*C
+///   C := alpha*A*A**H + beta*C
+///   C := alpha*A**T*A + beta*C
+///   C := alpha*A**H*A + beta*C
+template <typename MemberType, typename ArgUplo, typename ArgTrans>
+template <typename ScalarType, typename AViewType, typename CViewType>
+KOKKOS_INLINE_FUNCTION int TeamVectorSyrk<MemberType, ArgUplo, ArgTrans>::invoke(
+    const MemberType &member, const ScalarType alpha, const AViewType &A, const ScalarType beta, const CViewType &C) {
+  // Quick return if possible
+  constexpr bool is_trans = std::same_as<ArgTrans, Trans::Transpose> || std::same_as<ArgTrans, Trans::ConjTranspose>;
+  const int n             = C.extent_int(1);
+  const int k             = is_trans ? A.extent_int(0) : A.extent_int(1);
+  if (n == 0 || ((alpha == ScalarType(0) || k == 0) && beta == ScalarType(1))) return 0;
+
+  auto info = Impl::checkSyrkInput<is_trans>(A, C);
+  if (info) return info;
+
+  using op = std::conditional_t<(std::same_as<ArgTrans, Trans::ConjNoTranspose> ||
+                                 std::same_as<ArgTrans, Trans::ConjTranspose>),
+                                KokkosBlas::Impl::OpConj, KokkosBlas::Impl::OpID>;
+
+  using sym_op = std::conditional_t<(std::same_as<ArgTrans, Trans::ConjNoTranspose> ||
+                                     std::same_as<ArgTrans, Trans::ConjTranspose>),
+                                    KokkosBlas::Impl::OpReal, KokkosBlas::Impl::OpID>;
+
+  using value_type = typename CViewType::non_const_value_type;
+  using mag_type   = typename KokkosKernels::ArithTraits<value_type>::mag_type;
+  using ReduceType = std::conditional_t<(std::same_as<ArgTrans, Trans::ConjNoTranspose> ||
+                                         std::same_as<ArgTrans, Trans::ConjTranspose>),
+                                        mag_type, value_type>;
+
+  if constexpr (std::same_as<ArgUplo, Uplo::Lower>) {
+    return Impl::TeamVectorSyrkInternalLower::invoke<is_trans, ReduceType>(member, op(), sym_op(), n, k, alpha,
+                                                                           A.data(), A.stride(0), A.stride(1), beta,
+                                                                           C.data(), C.stride(0), C.stride(1));
+  } else {
+    return Impl::TeamVectorSyrkInternalUpper::invoke<is_trans, ReduceType>(member, op(), sym_op(), n, k, alpha,
+                                                                           A.data(), A.stride(0), A.stride(1), beta,
+                                                                           C.data(), C.stride(0), C.stride(1));
+  }
+}
+
+}  // namespace KokkosBatched
+
+#endif  // KOKKOSBATCHED_SYRK_IMPL_HPP_

--- a/batched/dense/impl/KokkosBatched_Syrk_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Syrk_Internal.hpp
@@ -1,0 +1,422 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#ifndef KOKKOSBATCHED_SYRK_INTERNAL_HPP_
+#define KOKKOSBATCHED_SYRK_INTERNAL_HPP_
+
+#include <KokkosBatched_Util.hpp>
+
+namespace KokkosBatched {
+namespace Impl {
+
+///
+/// Serial Internal Impl
+/// ====================
+
+/// Lower
+
+struct SerialSyrkInternalLower {
+  template <bool is_trans, typename ReduceType, typename Op, typename SymOp, typename ScalarType, typename ValueType>
+  KOKKOS_INLINE_FUNCTION static int invoke(Op op, SymOp sym_op, const int n, const int k, const ScalarType alpha,
+                                           const ValueType *KOKKOS_RESTRICT a, const int as0, const int as1,
+                                           const ScalarType beta, ValueType *KOKKOS_RESTRICT c, const int cs0,
+                                           const int cs1);
+};
+
+template <bool is_trans, typename ReduceType, typename Op, typename SymOp, typename ScalarType, typename ValueType>
+KOKKOS_INLINE_FUNCTION int SerialSyrkInternalLower::invoke(Op op, SymOp sym_op, const int n, const int k,
+                                                           const ScalarType alpha, const ValueType *KOKKOS_RESTRICT a,
+                                                           const int as0, const int as1, const ScalarType beta,
+                                                           ValueType *KOKKOS_RESTRICT c, const int cs0, const int cs1) {
+  if (beta == ScalarType(0)) {
+    for (int j = 0; j < n; j++) {
+      for (int i = j; i < n; i++) {
+        c[i * cs0 + j * cs1] = ValueType(0);
+      }
+    }
+  } else {
+    for (int j = 0; j < n; j++) {
+      c[j * cs0 + j * cs1] = beta * sym_op(c[j * cs0 + j * cs1]);
+      for (int i = j + 1; i < n; i++) {
+        c[i * cs0 + j * cs1] *= beta;
+      }
+    }
+  }
+
+  if (alpha != ScalarType(0)) {
+    // C: = alpha * A * A**T + beta * C or C: = alpha * A * A**H + beta * C
+    if constexpr (!is_trans) {
+      for (int j = 0; j < n; j++) {
+        for (int l = 0; l < k; l++) {
+          if (a[j * as0 + l * as1] != ValueType(0)) {
+            auto temp            = alpha * op(a[j * as0 + l * as1]);
+            c[j * cs0 + j * cs1] = sym_op(c[j * cs0 + j * cs1] + temp * a[j * as0 + l * as1]);
+            for (int i = j + 1; i < n; i++) {
+              c[i * cs0 + j * cs1] += temp * a[i * as0 + l * as1];
+            }
+          }
+        }
+      }
+    } else {
+      // C: = alpha * A**T * A + beta * C or C: = alpha * A**H * A + beta * C
+      for (int j = 0; j < n; j++) {
+        ReduceType rtemp(0);
+        for (int l = 0; l < k; l++) {
+          rtemp += sym_op(op(a[l * as0 + j * as1]) * a[l * as0 + j * as1]);
+        }
+        c[j * cs0 + j * cs1] += alpha * rtemp;
+        for (int i = j + 1; i < n; i++) {
+          ValueType temp(0);
+          for (int l = 0; l < k; l++) {
+            temp += op(a[l * as0 + i * as1]) * a[l * as0 + j * as1];
+          }
+          c[i * cs0 + j * cs1] += alpha * temp;
+        }
+      }
+    }
+  }
+
+  return 0;
+}
+
+/// Upper
+
+struct SerialSyrkInternalUpper {
+  template <bool is_trans, typename ReduceType, typename Op, typename SymOp, typename ScalarType, typename ValueType>
+  KOKKOS_INLINE_FUNCTION static int invoke(Op op, SymOp sym_op, const int n, const int k, const ScalarType alpha,
+                                           const ValueType *KOKKOS_RESTRICT a, const int as0, const int as1,
+                                           const ScalarType beta, ValueType *KOKKOS_RESTRICT c, const int cs0,
+                                           const int cs1);
+};
+
+template <bool is_trans, typename ReduceType, typename Op, typename SymOp, typename ScalarType, typename ValueType>
+KOKKOS_INLINE_FUNCTION int SerialSyrkInternalUpper::invoke(Op op, SymOp sym_op, const int n, const int k,
+                                                           const ScalarType alpha, const ValueType *KOKKOS_RESTRICT a,
+                                                           const int as0, const int as1, const ScalarType beta,
+                                                           ValueType *KOKKOS_RESTRICT c, const int cs0, const int cs1) {
+  if (beta == ScalarType(0)) {
+    for (int j = 0; j < n; j++) {
+      for (int i = 0; i < j + 1; i++) {
+        c[i * cs0 + j * cs1] = ValueType(0);
+      }
+    }
+  } else {
+    for (int j = 0; j < n; j++) {
+      for (int i = 0; i < j; i++) {
+        c[i * cs0 + j * cs1] *= beta;
+      }
+      c[j * cs0 + j * cs1] = beta * sym_op(c[j * cs0 + j * cs1]);
+    }
+  }
+
+  if (alpha != ScalarType(0)) {
+    // C: = alpha * A * A**T + beta * C or C: = alpha * A * A**H + beta * C
+    if constexpr (!is_trans) {
+      for (int j = 0; j < n; j++) {
+        for (int l = 0; l < k; l++) {
+          if (a[j * as0 + l * as1] != ValueType(0)) {
+            auto temp = alpha * op(a[j * as0 + l * as1]);
+            for (int i = 0; i < j; i++) {
+              c[i * cs0 + j * cs1] += temp * a[i * as0 + l * as1];
+            }
+            c[j * cs0 + j * cs1] += sym_op(temp * a[j * as0 + l * as1]);
+          }
+        }
+      }
+    } else {
+      // C: = alpha * A**T * A + beta * C or C: = alpha * A**H * A + beta * C
+      for (int j = 0; j < n; j++) {
+        for (int i = 0; i < j; i++) {
+          ValueType temp(0);
+          for (int l = 0; l < k; l++) {
+            temp += op(a[l * as0 + i * as1]) * a[l * as0 + j * as1];
+          }
+          c[i * cs0 + j * cs1] += alpha * temp;
+        }
+        ReduceType rtemp(0);
+        for (int l = 0; l < k; l++) {
+          rtemp += sym_op(op(a[l * as0 + j * as1]) * a[l * as0 + j * as1]);
+        }
+        c[j * cs0 + j * cs1] += alpha * rtemp;
+      }
+    }
+  }
+
+  return 0;
+}
+
+///
+/// Team Internal Impl
+/// ====================
+
+/// Lower
+
+struct TeamSyrkInternalLower {
+  template <bool is_trans, typename ReduceType, typename MemberType, typename Op, typename SymOp, typename ScalarType,
+            typename ValueType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, Op op, SymOp sym_op, const int n, const int k,
+                                           const ScalarType alpha, const ValueType *KOKKOS_RESTRICT a, const int as0,
+                                           const int as1, const ScalarType beta, ValueType *KOKKOS_RESTRICT c,
+                                           const int cs0, const int cs1);
+};
+
+template <bool is_trans, typename ReduceType, typename MemberType, typename Op, typename SymOp, typename ScalarType,
+          typename ValueType>
+KOKKOS_INLINE_FUNCTION int TeamSyrkInternalLower::invoke(const MemberType &member, Op op, SymOp sym_op, const int n,
+                                                         const int k, const ScalarType alpha,
+                                                         const ValueType *KOKKOS_RESTRICT a, const int as0,
+                                                         const int as1, const ScalarType beta,
+                                                         ValueType *KOKKOS_RESTRICT c, const int cs0, const int cs1) {
+  if (beta == ScalarType(0)) {
+    Kokkos::parallel_for(Kokkos::TeamThreadRange(member, n), [&](const int j) {
+      Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, (n - j)),
+                           [&](const int ii) { c[(ii + j) * cs0 + j * cs1] = ValueType(0); });
+    });
+  } else {
+    Kokkos::parallel_for(Kokkos::TeamThreadRange(member, n), [&](const int j) {
+      c[j * cs0 + j * cs1] = beta * sym_op(c[j * cs0 + j * cs1]);
+      Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, (n - j - 1)),
+                           [&](const int ii) { c[(ii + j + 1) * cs0 + j * cs1] *= beta; });
+    });
+  }
+
+  if (alpha != ScalarType(0)) {
+    if constexpr (!is_trans) {
+      // C: = alpha * A * A**T + beta * C or C: = alpha * A * A**H + beta * C
+      Kokkos::parallel_for(Kokkos::TeamThreadRange(member, n), [&](const int j) {
+        Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, (n - j)), [&](const int ii) {
+          ValueType temp(0);
+          for (int l = 0; l < k; l++) {
+            temp += op(a[j * as0 + l * as1]) * a[(ii + j) * as0 + l * as1];
+          }
+          c[(ii + j) * cs0 + j * cs1] += alpha * temp;
+        });
+        c[j * cs0 + j * cs1] = sym_op(c[j * cs0 + j * cs1]);
+      });
+    } else {
+      // C: = alpha * A**T * A + beta * C or C: = alpha * A**H * A + beta * C
+      Kokkos::parallel_for(Kokkos::TeamThreadRange(member, n), [&](const int j) {
+        Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, (n - j)), [&](const int ii) {
+          ValueType temp(0);
+          for (int l = 0; l < k; l++) {
+            temp += op(a[l * as0 + (ii + j) * as1]) * a[l * as0 + j * as1];
+          }
+          c[(ii + j) * cs0 + j * cs1] += alpha * temp;
+        });
+        c[j * cs0 + j * cs1] = sym_op(c[j * cs0 + j * cs1]);
+      });
+    }
+  }
+
+  return 0;
+}
+
+/// Upper
+
+struct TeamSyrkInternalUpper {
+  template <bool is_trans, typename ReduceType, typename MemberType, typename Op, typename SymOp, typename ScalarType,
+            typename ValueType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, Op op, SymOp sym_op, const int n, const int k,
+                                           const ScalarType alpha, const ValueType *KOKKOS_RESTRICT a, const int as0,
+                                           const int as1, const ScalarType beta, ValueType *KOKKOS_RESTRICT c,
+                                           const int cs0, const int cs1);
+};
+
+template <bool is_trans, typename ReduceType, typename MemberType, typename Op, typename SymOp, typename ScalarType,
+          typename ValueType>
+KOKKOS_INLINE_FUNCTION int TeamSyrkInternalUpper::invoke(const MemberType &member, Op op, SymOp sym_op, const int n,
+                                                         const int k, const ScalarType alpha,
+                                                         const ValueType *KOKKOS_RESTRICT a, const int as0,
+                                                         const int as1, const ScalarType beta,
+                                                         ValueType *KOKKOS_RESTRICT c, const int cs0, const int cs1) {
+  if (beta == ScalarType(0)) {
+    Kokkos::parallel_for(Kokkos::TeamThreadRange(member, n), [&](const int j) {
+      Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, j + 1),
+                           [&](const int i) { c[i * cs0 + j * cs1] = ValueType(0); });
+    });
+  } else {
+    Kokkos::parallel_for(Kokkos::TeamThreadRange(member, n), [&](const int j) {
+      Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, j), [&](const int i) { c[i * cs0 + j * cs1] *= beta; });
+      c[j * cs0 + j * cs1] = beta * sym_op(c[j * cs0 + j * cs1]);
+    });
+  }
+
+  if (alpha != ScalarType(0)) {
+    // C: = alpha * A * A**T + beta * C or C: = alpha * A * A**H + beta * C
+    if constexpr (!is_trans) {
+      Kokkos::parallel_for(Kokkos::TeamThreadRange(member, n), [&](const int j) {
+        Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, j + 1), [&](const int i) {
+          ValueType temp(0);
+          for (int l = 0; l < k; l++) {
+            temp += op(a[j * as0 + l * as1]) * a[i * as0 + l * as1];
+          }
+          c[i * cs0 + j * cs1] += alpha * temp;
+        });
+        c[j * cs0 + j * cs1] = sym_op(c[j * cs0 + j * cs1]);
+      });
+    } else {
+      // C: = alpha * A**T * A + beta * C or C: = alpha * A**H * A + beta * C
+      Kokkos::parallel_for(Kokkos::TeamThreadRange(member, n), [&](const int j) {
+        Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, j + 1), [&](const int i) {
+          ValueType temp(0);
+          for (int l = 0; l < k; l++) {
+            temp += op(a[l * as0 + i * as1]) * a[l * as0 + j * as1];
+          }
+          c[i * cs0 + j * cs1] += alpha * temp;
+        });
+        c[j * cs0 + j * cs1] = sym_op(c[j * cs0 + j * cs1]);
+      });
+    }
+  }
+
+  return 0;
+}
+
+///
+/// TeamVector Internal Impl
+/// ====================
+
+/// Lower
+
+struct TeamVectorSyrkInternalLower {
+  template <bool is_trans, typename ReduceType, typename MemberType, typename Op, typename SymOp, typename ScalarType,
+            typename ValueType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, Op op, SymOp sym_op, const int n, const int k,
+                                           const ScalarType alpha, const ValueType *KOKKOS_RESTRICT a, const int as0,
+                                           const int as1, const ScalarType beta, ValueType *KOKKOS_RESTRICT c,
+                                           const int cs0, const int cs1);
+};
+
+template <bool is_trans, typename ReduceType, typename MemberType, typename Op, typename SymOp, typename ScalarType,
+          typename ValueType>
+KOKKOS_INLINE_FUNCTION int TeamVectorSyrkInternalLower::invoke(const MemberType &member, Op op, SymOp sym_op,
+                                                               const int n, const int k, const ScalarType alpha,
+                                                               const ValueType *KOKKOS_RESTRICT a, const int as0,
+                                                               const int as1, const ScalarType beta,
+                                                               ValueType *KOKKOS_RESTRICT c, const int cs0,
+                                                               const int cs1) {
+  if (beta == ScalarType(0)) {
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(member, n), [&](const int j) {
+      for (int i = j; i < n; i++) {
+        c[i * cs0 + j * cs1] = ValueType(0);
+      }
+    });
+  } else {
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(member, n), [&](const int j) {
+      c[j * cs0 + j * cs1] = beta * sym_op(c[j * cs0 + j * cs1]);
+      for (int i = j + 1; i < n; i++) {
+        c[i * cs0 + j * cs1] *= beta;
+      }
+    });
+  }
+
+  if (alpha != ScalarType(0)) {
+    if constexpr (!is_trans) {
+      // C: = alpha * A * A**T + beta * C or C: = alpha * A * A**H + beta * C
+      Kokkos::parallel_for(Kokkos::TeamVectorRange(member, n), [&](const int j) {
+        for (int l = 0; l < k; l++) {
+          if (a[j * as0 + l * as1] != ValueType(0)) {
+            auto temp            = alpha * op(a[j * as0 + l * as1]);
+            c[j * cs0 + j * cs1] = sym_op(c[j * cs0 + j * cs1] + temp * a[j * as0 + l * as1]);
+            for (int i = j + 1; i < n; i++) {
+              c[i * cs0 + j * cs1] += temp * a[i * as0 + l * as1];
+            }
+          }
+        }
+      });
+    } else {
+      // C: = alpha * A**T * A + beta * C or C: = alpha * A**H * A + beta * C
+      Kokkos::parallel_for(Kokkos::TeamVectorRange(member, n), [&](const int j) {
+        ReduceType rtemp(0);
+        for (int l = 0; l < k; l++) {
+          rtemp += sym_op(op(a[l * as0 + j * as1]) * a[l * as0 + j * as1]);
+        }
+        c[j * cs0 + j * cs1] += alpha * rtemp;
+        for (int i = j + 1; i < n; i++) {
+          ValueType temp(0);
+          for (int l = 0; l < k; l++) {
+            temp += op(a[l * as0 + i * as1]) * a[l * as0 + j * as1];
+          }
+          c[i * cs0 + j * cs1] += alpha * temp;
+        }
+      });
+    }
+  }
+
+  return 0;
+}
+
+/// Upper
+
+struct TeamVectorSyrkInternalUpper {
+  template <bool is_trans, typename ReduceType, typename MemberType, typename Op, typename SymOp, typename ScalarType,
+            typename ValueType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, Op op, SymOp sym_op, const int n, const int k,
+                                           const ScalarType alpha, const ValueType *KOKKOS_RESTRICT a, const int as0,
+                                           const int as1, const ScalarType beta, ValueType *KOKKOS_RESTRICT c,
+                                           const int cs0, const int cs1);
+};
+
+template <bool is_trans, typename ReduceType, typename MemberType, typename Op, typename SymOp, typename ScalarType,
+          typename ValueType>
+KOKKOS_INLINE_FUNCTION int TeamVectorSyrkInternalUpper::invoke(const MemberType &member, Op op, SymOp sym_op,
+                                                               const int n, const int k, const ScalarType alpha,
+                                                               const ValueType *KOKKOS_RESTRICT a, const int as0,
+                                                               const int as1, const ScalarType beta,
+                                                               ValueType *KOKKOS_RESTRICT c, const int cs0,
+                                                               const int cs1) {
+  if (beta == ScalarType(0)) {
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(member, n), [&](const int j) {
+      for (int i = 0; i < j + 1; i++) {
+        c[i * cs0 + j * cs1] = ValueType(0);
+      }
+    });
+  } else {
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(member, n), [&](const int j) {
+      for (int i = 0; i < j; i++) {
+        c[i * cs0 + j * cs1] *= beta;
+      }
+      c[j * cs0 + j * cs1] = beta * sym_op(c[j * cs0 + j * cs1]);
+    });
+  }
+
+  if (alpha != ScalarType(0)) {
+    // C: = alpha * A * A**T + beta * C or C: = alpha * A * A**H + beta * C
+    if constexpr (!is_trans) {
+      Kokkos::parallel_for(Kokkos::TeamVectorRange(member, n), [&](const int j) {
+        for (int l = 0; l < k; l++) {
+          if (a[j * as0 + l * as1] != ValueType(0)) {
+            auto temp = alpha * op(a[j * as0 + l * as1]);
+            for (int i = 0; i < j; i++) {
+              c[i * cs0 + j * cs1] += temp * a[i * as0 + l * as1];
+            }
+            c[j * cs0 + j * cs1] += sym_op(temp * a[j * as0 + l * as1]);
+          }
+        }
+      });
+    } else {
+      // C: = alpha * A**T * A + beta * C or C: = alpha * A**H * A + beta * C
+      Kokkos::parallel_for(Kokkos::TeamVectorRange(member, n), [&](const int j) {
+        for (int i = 0; i < j; i++) {
+          ValueType temp(0);
+          for (int l = 0; l < k; l++) {
+            temp += op(a[l * as0 + i * as1]) * a[l * as0 + j * as1];
+          }
+          c[i * cs0 + j * cs1] += alpha * temp;
+        }
+        ReduceType rtemp(0);
+        for (int l = 0; l < k; l++) {
+          rtemp += sym_op(op(a[l * as0 + j * as1]) * a[l * as0 + j * as1]);
+        }
+        c[j * cs0 + j * cs1] += alpha * rtemp;
+      });
+    }
+  }
+
+  return 0;
+}
+
+}  // namespace Impl
+}  // namespace KokkosBatched
+
+#endif  // KOKKOSBATCHED_SYRK_INTERNAL_HPP_

--- a/batched/dense/src/KokkosBatched_Syrk.hpp
+++ b/batched/dense/src/KokkosBatched_Syrk.hpp
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+#ifndef KOKKOSBATCHED_SYRK_HPP_
+#define KOKKOSBATCHED_SYRK_HPP_
+
+#include <KokkosBatched_Util.hpp>
+
+/// \author Yuuichi Asahi (yuuichi.asahi@cea.fr)
+
+namespace KokkosBatched {
+
+/// \brief Serial Batched Syrk:
+/// Performs one of the symmetric rank k operation
+///   C := alpha*A*A**T + beta*C
+///   C := alpha*A*A**H + beta*C
+///   C := alpha*A**T*A + beta*C
+///   C := alpha*A**H*A + beta*C
+///    where alpha and beta are real scalars, C is an n by n symmetric or hermitian matrix and
+///    A is an n by k matrix in the first case and a k by n matrix in the second case.
+///
+/// \tparam ArgUplo: Type indicating whether the upper (Uplo::Upper) or lower (Uplo::Lower) triangular part of A is
+/// modified
+/// \tparam ArgTrans: Type indicating whether the A (Trans::NoTranspose), or A**T (Trans::Transpose), or A**H
+/// (Trans::ConjTranspose), or AH (Trans::ConjNoTranspose) is used.
+///
+/// \tparam ScalarType: Input type for the scalar alpha
+/// \tparam AViewType: Input type for the matrix A, needs to be a 2D view
+/// \tparam CViewType: Input/output type for the matrix C, needs to be a 2D view
+///
+/// \param[in] alpha: alpha is a scalar
+/// \param[in] A: A is a n by k matrix, a rank 2 view
+/// \param[in,out] C: C is a n by n matrix, a rank 2 view
+///
+/// No nested parallel_for is used inside of the function.
+///
+template <typename ArgUplo, typename ArgTrans>
+struct SerialSyrk {
+  static_assert(
+      std::is_same_v<ArgUplo, Uplo::Upper> || std::is_same_v<ArgUplo, Uplo::Lower>,
+      "KokkosBatched::syrk: Use Uplo::Upper for upper triangular matrix or Uplo::Lower for lower triangular matrix");
+  static_assert(KokkosBlas::is_trans_v<ArgTrans>,
+                "KokkosBatched::syrk: Use Trans::NoTranspose/Trans::Transpose for {s,d,c,z}syrk or "
+                "Trans::ConjNoTranspose/Trans::ConjTranspose for {c,z}herk");
+
+  template <typename ScalarType, typename AViewType, typename CViewType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const ScalarType alpha, const AViewType &A, const ScalarType beta,
+                                           const CViewType &C);
+};
+
+/// \brief Team Batched Syrk:
+/// Performs one of the symmetric rank k operation
+///   C := alpha*A*A**T + beta*C
+///   C := alpha*A*A**H + beta*C
+///   C := alpha*A**T*A + beta*C
+///   C := alpha*A**H*A + beta*C
+///    where alpha and beta are real scalars, C is an n by n hermitian matrix and
+///    A is an n by k matrix in the first case and a k by n matrix in the second case.
+///
+/// \tparam MemberType: Member type of the Kokkos team policy
+/// \tparam ArgUplo: Type indicating whether the upper (Uplo::Upper) or lower (Uplo::Lower) triangular part of A is
+/// modified
+/// \tparam ArgTrans: Type indicating whether the A (Trans::NoTranspose), or A**T (Trans::Transpose), or A**H
+/// (Trans::ConjTranspose), or AH (Trans::ConjNoTranspose) is used.
+///
+/// \tparam ScalarType: Input type for the scalar alpha
+/// \tparam AViewType: Input type for the matrix A, needs to be a 2D view
+/// \tparam CViewType: Input/output type for the matrix C, needs to be a 2D view
+///
+/// \param[in] alpha: alpha is a scalar
+/// \param[in] A: A is a n by k matrix, a rank 2 view
+/// \param[in,out] C: C is a n by n matrix, a rank 2 view
+///
+template <typename MemberType, typename ArgUplo, typename ArgTrans>
+struct TeamSyrk {
+  static_assert(
+      std::is_same_v<ArgUplo, Uplo::Upper> || std::is_same_v<ArgUplo, Uplo::Lower>,
+      "KokkosBatched::syrk: Use Uplo::Upper for upper triangular matrix or Uplo::Lower for lower triangular matrix");
+  static_assert(KokkosBlas::is_trans_v<ArgTrans>,
+                "KokkosBatched::syrk: Use Trans::NoTranspose/Trans::Transpose for {s,d,c,z}syrk or "
+                "Trans::ConjNoTranspose/Trans::ConjTranspose for {c,z}herk");
+  template <typename ScalarType, typename AViewType, typename CViewType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
+                                           const ScalarType beta, const CViewType &C);
+};
+
+/// \brief TeamVector Batched Syrk:
+/// Performs one of the symmetric rank k operation
+///   C := alpha*A*A**T + beta*C
+///   C := alpha*A*A**H + beta*C
+///   C := alpha*A**T*A + beta*C
+///   C := alpha*A**H*A + beta*C
+///    where alpha and beta are real scalars, C is an n by n hermitian matrix and
+///    A is an n by k matrix in the first case and a k by n matrix in the second case.
+///
+/// \tparam MemberType: Member type of the Kokkos team policy
+/// \tparam ArgUplo: Type indicating whether the upper (Uplo::Upper) or lower (Uplo::Lower) triangular part of A is
+/// modified
+/// \tparam ArgTrans: Type indicating whether the A (Trans::NoTranspose), or A**T (Trans::Transpose), or A**H
+/// (Trans::ConjTranspose), or AH (Trans::ConjNoTranspose) is used.
+///
+/// \tparam ScalarType: Input type for the scalar alpha
+/// \tparam AViewType: Input type for the matrix A, needs to be a 2D view
+/// \tparam CViewType: Input/output type for the matrix C, needs to be a 2D view
+///
+/// \param[in] alpha: alpha is a scalar
+/// \param[in] A: A is a n by k matrix, a rank 2 view
+/// \param[in,out] C: C is a n by n matrix, a rank 2 view
+///
+template <typename MemberType, typename ArgUplo, typename ArgTrans>
+struct TeamVectorSyrk {
+  static_assert(
+      std::is_same_v<ArgUplo, Uplo::Upper> || std::is_same_v<ArgUplo, Uplo::Lower>,
+      "KokkosBatched::syrk: Use Uplo::Upper for upper triangular matrix or Uplo::Lower for lower triangular matrix");
+  static_assert(KokkosBlas::is_trans_v<ArgTrans>,
+                "KokkosBatched::syrk: Use Trans::NoTranspose/Trans::Transpose for {s,d,c,z}syrk or "
+                "Trans::ConjNoTranspose/Trans::ConjTranspose for {c,z}herk");
+  template <typename ScalarType, typename AViewType, typename CViewType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const MemberType &member, const ScalarType alpha, const AViewType &A,
+                                           const ScalarType beta, const CViewType &C);
+};
+
+}  // namespace KokkosBatched
+
+#include "KokkosBatched_Syrk_Impl.hpp"
+
+#endif  // KOKKOSBATCHED_SYRK_HPP_

--- a/batched/dense/unit_test/Test_Batched_Dense.hpp
+++ b/batched/dense/unit_test/Test_Batched_Dense.hpp
@@ -14,6 +14,7 @@
 #include "Test_Batched_Rotm.hpp"
 #include "Test_Batched_Rotmg.hpp"
 #include "Test_Batched_Swap.hpp"
+#include "Test_Batched_Syrk.hpp"
 #include "Test_Batched_SerialEigendecomposition.hpp"
 #include "Test_Batched_SerialEigendecomposition_Real.hpp"
 #include "Test_Batched_SerialGesv.hpp"

--- a/batched/dense/unit_test/Test_Batched_Syrk.hpp
+++ b/batched/dense/unit_test/Test_Batched_Syrk.hpp
@@ -1,0 +1,921 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+/// \author Yuuichi Asahi (yuuichi.asahi@cea.fr)
+#include <gtest/gtest.h>
+#include <Kokkos_Core.hpp>
+#include <Kokkos_Random.hpp>
+#include <KokkosBatched_Util.hpp>
+#include <KokkosBatched_Syrk.hpp>
+#include "Test_Batched_DenseUtils.hpp"
+
+namespace Test {
+namespace Syrk {
+
+template <typename U, typename T, typename M>
+struct ParamTag {
+  using uplo  = U;
+  using trans = T;
+  using mode  = M;
+};
+
+template <typename DeviceType, typename ParamTagType, typename ScalarType, typename AViewType, typename CViewType>
+struct Functor_BatchedSyrk {
+  using execution_space = typename DeviceType::execution_space;
+  using member_type     = typename Kokkos::TeamPolicy<execution_space>::member_type;
+  using ArgMode         = typename ParamTagType::mode;
+  using ArgUplo         = typename ParamTagType::uplo;
+  using ArgTrans        = typename ParamTagType::trans;
+  AViewType m_A;
+  CViewType m_C;
+  ScalarType m_alpha, m_beta;
+
+  Functor_BatchedSyrk(const ScalarType alpha, const AViewType &A, const ScalarType beta, const CViewType &C)
+      : m_alpha(alpha), m_A(A), m_beta(beta), m_C(C) {}
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const member_type &member, int &info) const {
+    const int k = member.league_rank();
+    auto sub_C  = Kokkos::subview(m_C, k, Kokkos::ALL(), Kokkos::ALL());
+    auto sub_A  = Kokkos::subview(m_A, k, Kokkos::ALL(), Kokkos::ALL());
+    if constexpr (std::is_same_v<ArgMode, KokkosBatched::Mode::Serial>) {
+      Kokkos::single(Kokkos::PerTeam(member), [&]() {
+        info += KokkosBatched::SerialSyrk<ArgUplo, ArgTrans>::invoke(m_alpha, sub_A, m_beta, sub_C);
+      });
+    } else if constexpr (std::is_same_v<ArgMode, KokkosBatched::Mode::Team>) {
+      info += KokkosBatched::TeamSyrk<member_type, ArgUplo, ArgTrans>::invoke(member, m_alpha, sub_A, m_beta, sub_C);
+    } else if constexpr (std::is_same_v<ArgMode, KokkosBatched::Mode::TeamVector>) {
+      info +=
+          KokkosBatched::TeamVectorSyrk<member_type, ArgUplo, ArgTrans>::invoke(member, m_alpha, sub_A, m_beta, sub_C);
+    }
+  }
+
+  inline int run() {
+    using value_type        = typename AViewType::non_const_value_type;
+    std::string name_region = std::same_as<ArgMode, KokkosBatched::Mode::Serial> ? "KokkosBatched::Test::SerialSyrk"
+                              : std::same_as<ArgMode, KokkosBatched::Mode::Team>
+                                  ? "KokkosBatched::Test::TeamSyrk"
+                                  : "KokkosBatched::Test::TeamVectorSyrk";
+    const std::string name_value_type = Test::value_type_name<value_type>();
+    std::string name                  = name_region + name_value_type;
+    int info_sum                      = 0;
+    Kokkos::Profiling::pushRegion(name.c_str());
+    const int league_size = m_A.extent_int(0);
+
+    Kokkos::TeamPolicy<execution_space> policy(league_size, Kokkos::AUTO);
+    Kokkos::parallel_reduce(name.c_str(), policy, *this, info_sum);
+    Kokkos::Profiling::popRegion();
+    return info_sum;
+  }
+};
+
+/// \brief Implementation details of batched syrk analytical test
+///        to confirm C:= A*A**T + C or C:= A**T*A + C is computed correctly
+///        A and C are deliberately chosen to have non symmetric values to confirm both cases.
+///        alpha = 1.5, beta = 1.2
+///        4x4 matrix (upper)
+///        A: [[1,  -3, -2,  0],
+///            [3,  3, -1, -2],
+///            [2,  1,  9, 5],
+///            [0,  2, -5, 27]]
+///        C = A
+///        ArgTrans == NoTranspose/ConjNoTranspose
+///        C: = alpha * U * U**T + beta * C
+///        Ref: [[22.2, -9.6, -30.9,   6.0],
+///              [3,    38.1, -16.2, -66.9],
+///              [2,       1, 177.3, 144.0],
+///              [0,       2,   -5, 1169.4]]
+///
+///        C: = alpha * L**T * L + beta * C
+///        Ref: [[ 22.2,    -3,    -2,      0],
+///              [ -2.4,  38.1,    -1,     -2],
+///              [-26.1, -13.8, 177.3,      5],
+///              [  6.0, -62.1, 132.0, 1169.4]]
+///
+///        ArgTrans == Transpose/ConjTranspose
+///        C: = alpha * U**T * U + beta * C
+///        Ref: [[22.2,  8.4,  17.1,    6.0],
+///              [3,    38.1,   1.8,   77.1],
+///              [2,       1, 177.3, -126.0],
+///              [0,       2,    -5, 1169.4]]
+///
+///        C: = alpha * L**T * L + beta * C
+///        Ref: [[ 22.2,    -3,     -2,      0],
+///              [ 15.6,  38.1,     -1,     -2],
+///              [ 21.9,   4.2,  177.3,    5.0],
+///              [  6.0,  81.9, -138.0, 1169.4]]
+/// \param[in] Nb Batch size of matrices
+template <typename DeviceType, typename ScalarType, typename LayoutType, typename ParamTagType>
+void impl_test_batched_syrk_analytical(const std::size_t Nb) {
+  using ats               = typename KokkosKernels::ArithTraits<ScalarType>;
+  using RealType          = typename ats::mag_type;
+  using View3DType        = Kokkos::View<ScalarType ***, LayoutType, DeviceType>;
+  using StridedView3DType = Kokkos::View<ScalarType ***, Kokkos::LayoutStride, DeviceType>;
+  using ArgUplo           = typename ParamTagType::uplo;
+  using ArgTrans          = typename ParamTagType::trans;
+  using ArgMode           = typename ParamTagType::mode;
+
+  const std::size_t BlkSize = 4;
+  View3DType A("A", Nb, BlkSize, BlkSize);
+  View3DType C("C", Nb, BlkSize, BlkSize), C_ref("C_ref", Nb, BlkSize, BlkSize);
+
+  const std::size_t incx = 2;
+  // Testing incx argument with strided views
+  Kokkos::LayoutStride layout{Nb, incx, BlkSize, Nb * incx, BlkSize, Nb * incx * BlkSize};
+  StridedView3DType A_s("A_s", layout), C_s("C_s", layout);
+
+  // Only filling a
+  auto h_A     = Kokkos::create_mirror_view(A);
+  auto h_C_ref = Kokkos::create_mirror_view(C_ref);
+
+  for (std::size_t ib = 0; ib < Nb; ib++) {
+    h_A(ib, 0, 0) = 1;
+    h_A(ib, 0, 1) = -3;
+    h_A(ib, 0, 2) = -2;
+    h_A(ib, 0, 3) = 0;
+    h_A(ib, 1, 0) = 3;
+    h_A(ib, 1, 1) = 3;
+    h_A(ib, 1, 2) = -1;
+    h_A(ib, 1, 3) = -2;
+    h_A(ib, 2, 0) = 2;
+    h_A(ib, 2, 1) = 1;
+    h_A(ib, 2, 2) = 9;
+    h_A(ib, 2, 3) = 5;
+    h_A(ib, 3, 0) = 0;
+    h_A(ib, 3, 1) = 2;
+    h_A(ib, 3, 2) = -5;
+    h_A(ib, 3, 3) = 27;
+
+    if (std::same_as<ArgTrans, KokkosBatched::Trans::NoTranspose> ||
+        std::same_as<ArgTrans, KokkosBatched::Trans::ConjNoTranspose>) {
+      if (std::same_as<ArgUplo, KokkosBatched::Uplo::Upper>) {
+        h_C_ref(ib, 0, 0) = 22.2;
+        h_C_ref(ib, 0, 1) = -9.6;
+        h_C_ref(ib, 0, 2) = -30.9;
+        h_C_ref(ib, 0, 3) = 6;
+        h_C_ref(ib, 1, 0) = 3;
+        h_C_ref(ib, 1, 1) = 38.1;
+        h_C_ref(ib, 1, 2) = -16.2;
+        h_C_ref(ib, 1, 3) = -66.9;
+        h_C_ref(ib, 2, 0) = 2;
+        h_C_ref(ib, 2, 1) = 1;
+        h_C_ref(ib, 2, 2) = 177.3;
+        h_C_ref(ib, 2, 3) = 144;
+        h_C_ref(ib, 3, 0) = 0;
+        h_C_ref(ib, 3, 1) = 2;
+        h_C_ref(ib, 3, 2) = -5;
+        h_C_ref(ib, 3, 3) = 1169.4;
+      } else {
+        h_C_ref(ib, 0, 0) = 22.2;
+        h_C_ref(ib, 0, 1) = -3;
+        h_C_ref(ib, 0, 2) = -2;
+        h_C_ref(ib, 0, 3) = 0;
+        h_C_ref(ib, 1, 0) = -2.4;
+        h_C_ref(ib, 1, 1) = 38.1;
+        h_C_ref(ib, 1, 2) = -1;
+        h_C_ref(ib, 1, 3) = -2;
+        h_C_ref(ib, 2, 0) = -26.1;
+        h_C_ref(ib, 2, 1) = -13.8;
+        h_C_ref(ib, 2, 2) = 177.3;
+        h_C_ref(ib, 2, 3) = 5;
+        h_C_ref(ib, 3, 0) = 6;
+        h_C_ref(ib, 3, 1) = -62.1;
+        h_C_ref(ib, 3, 2) = 132;
+        h_C_ref(ib, 3, 3) = 1169.4;
+      }
+    } else {
+      if (std::same_as<ArgUplo, KokkosBatched::Uplo::Upper>) {
+        h_C_ref(ib, 0, 0) = 22.2;
+        h_C_ref(ib, 0, 1) = 8.4;
+        h_C_ref(ib, 0, 2) = 17.1;
+        h_C_ref(ib, 0, 3) = 6;
+        h_C_ref(ib, 1, 0) = 3;
+        h_C_ref(ib, 1, 1) = 38.1;
+        h_C_ref(ib, 1, 2) = 1.8;
+        h_C_ref(ib, 1, 3) = 77.1;
+        h_C_ref(ib, 2, 0) = 2;
+        h_C_ref(ib, 2, 1) = 1;
+        h_C_ref(ib, 2, 2) = 177.3;
+        h_C_ref(ib, 2, 3) = -126;
+        h_C_ref(ib, 3, 0) = 0;
+        h_C_ref(ib, 3, 1) = 2;
+        h_C_ref(ib, 3, 2) = -5;
+        h_C_ref(ib, 3, 3) = 1169.4;
+      } else {
+        h_C_ref(ib, 0, 0) = 22.2;
+        h_C_ref(ib, 0, 1) = -3;
+        h_C_ref(ib, 0, 2) = -2;
+        h_C_ref(ib, 0, 3) = 0;
+        h_C_ref(ib, 1, 0) = 15.6;
+        h_C_ref(ib, 1, 1) = 38.1;
+        h_C_ref(ib, 1, 2) = -1;
+        h_C_ref(ib, 1, 3) = -2;
+        h_C_ref(ib, 2, 0) = 21.9;
+        h_C_ref(ib, 2, 1) = 4.2;
+        h_C_ref(ib, 2, 2) = 177.3;
+        h_C_ref(ib, 2, 3) = 5;
+        h_C_ref(ib, 3, 0) = 6;
+        h_C_ref(ib, 3, 1) = 81.9;
+        h_C_ref(ib, 3, 2) = -138;
+        h_C_ref(ib, 3, 3) = 1169.4;
+      }
+    }
+  }
+
+  Kokkos::deep_copy(A, h_A);
+  Kokkos::deep_copy(C, A);
+  Kokkos::deep_copy(A_s, A);
+  Kokkos::deep_copy(C_s, A);
+
+  const ScalarType alpha = 1.5, beta = 1.2;
+
+  auto info =
+      Functor_BatchedSyrk<DeviceType, ParamTagType, ScalarType, View3DType, View3DType>(alpha, A, beta, C).run();
+
+  Kokkos::fence();
+  EXPECT_EQ(info, 0);
+
+  // With strided views
+  info = Functor_BatchedSyrk<DeviceType, ParamTagType, ScalarType, StridedView3DType, StridedView3DType>(alpha, A_s,
+                                                                                                         beta, C_s)
+             .run();
+
+  Kokkos::fence();
+  EXPECT_EQ(info, 0);
+
+  RealType eps = 1.0e1 * ats::epsilon();
+  auto h_C     = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, C);
+
+  // Check if C:= alpha * A * A**T + C or C:= alpha * A**T * A + C is computed correctly
+  for (std::size_t ib = 0; ib < Nb; ib++) {
+    for (std::size_t i = 0; i < BlkSize; i++) {
+      for (std::size_t j = 0; j < BlkSize; j++) {
+        KK_EXPECT_NEAR(h_C(ib, i, j), h_C_ref(ib, i, j), eps);
+      }
+    }
+  }
+
+  // Testing for strided views, reusing C
+  Kokkos::deep_copy(C, C_s);
+  Kokkos::deep_copy(h_C, C);
+
+  // Check if C:= alpha * A * A**T + C or C:= alpha * A**T * A + C is computed correctly
+  for (std::size_t ib = 0; ib < Nb; ib++) {
+    for (std::size_t i = 0; i < BlkSize; i++) {
+      for (std::size_t j = 0; j < BlkSize; j++) {
+        KK_EXPECT_NEAR(h_C(ib, i, j), h_C_ref(ib, i, j), eps);
+      }
+    }
+  }
+}
+
+/// \brief Implementation details of batched syrk test
+///
+/// \param[in] Nb Batch size of matrices
+/// \param[in] M Number of rows of matrices
+/// \param[in] N Number of columns of matrices
+template <typename DeviceType, typename ScalarType, typename LayoutType, typename ParamTagType>
+void impl_test_batched_syrk(const std::size_t Nb, const std::size_t M, const std::size_t N) {
+  using ats        = typename KokkosKernels::ArithTraits<ScalarType>;
+  using RealType   = typename ats::mag_type;
+  using View3DType = Kokkos::View<ScalarType ***, LayoutType, DeviceType>;
+  using ArgUplo    = typename ParamTagType::uplo;
+  using ArgTrans   = typename ParamTagType::trans;
+
+  const bool is_trans = std::same_as<typename ParamTagType::trans, KokkosBatched::Trans::Transpose> ||
+                        std::same_as<typename ParamTagType::trans, KokkosBatched::Trans::ConjTranspose>;
+
+  // For NoTrans, A is N*M, C is NxN
+  // For Trans, A is M*N, C is MxM
+  const std::size_t n = is_trans ? M : N;
+  const std::size_t k = is_trans ? N : M;
+
+  View3DType A("A", Nb, n, k), C("C", Nb, N, N), C_alpha0("C_alpha0", Nb, N, N), C_beta0("C_beta0", Nb, N, N),
+      C_ref("C_ref", Nb, N, N), C_alpha0_ref("C_alpha0_ref", Nb, N, N), C_beta0_ref("C_beta0_ref", Nb, N, N);
+
+  // Create a random matrix A and x
+  using execution_space = typename DeviceType::execution_space;
+  Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(13718);
+  ScalarType randStart, randEnd;
+
+  KokkosKernels::Impl::getRandomBounds(1.0, randStart, randEnd);
+  Kokkos::fill_random(A, rand_pool, randStart, randEnd);
+  Kokkos::fill_random(C, rand_pool, randStart, randEnd);
+
+  Kokkos::deep_copy(C_ref, C);
+  Kokkos::deep_copy(C_alpha0, C);
+  Kokkos::deep_copy(C_beta0, C);
+  Kokkos::deep_copy(C_alpha0_ref, C_alpha0);
+  Kokkos::deep_copy(C_beta0_ref, C_beta0);
+
+  // When beta is zero
+  const RealType alpha = 1.5, beta = 1.2, zero = KokkosKernels::ArithTraits<RealType>::zero();
+  const ScalarType czero = KokkosKernels::ArithTraits<ScalarType>::zero();
+  auto info0 =
+      Functor_BatchedSyrk<DeviceType, ParamTagType, ScalarType, View3DType, View3DType>(alpha, A, beta, C).run();
+  auto info1 =
+      Functor_BatchedSyrk<DeviceType, ParamTagType, ScalarType, View3DType, View3DType>(zero, A, beta, C_alpha0).run();
+  auto info2 =
+      Functor_BatchedSyrk<DeviceType, ParamTagType, ScalarType, View3DType, View3DType>(alpha, A, zero, C_beta0).run();
+
+  Kokkos::fence();
+
+  if (is_trans) {
+    if (M == 0 && N > 0) {
+// Quick return case: M=0, N>0, this is not allowed in blas
+#ifndef NDEBUG
+      EXPECT_GT(info0, 0);
+      EXPECT_GT(info1, 0);
+      EXPECT_GT(info2, 0);
+#else
+      EXPECT_EQ(info0, 0);
+      EXPECT_EQ(info1, 0);
+      EXPECT_EQ(info2, 0);
+#endif
+      return;
+    }
+  }
+
+  EXPECT_EQ(info0, 0);
+  EXPECT_EQ(info1, 0);
+  EXPECT_EQ(info2, 0);
+
+  // Make a reference at host
+  auto h_A            = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, A);
+  auto h_C_ref        = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, C_ref);
+  auto h_C_alpha0_ref = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, C_alpha0_ref);
+  auto h_C_beta0_ref  = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, C_beta0_ref);
+
+  // Note: ConjTranspose/ConjNoTranspose corresponds to {c,z}herk for Hermitian matrix
+  constexpr bool is_conj = std::same_as<typename ParamTagType::trans, Trans::ConjTranspose> ||
+                           std::same_as<typename ParamTagType::trans, Trans::ConjNoTranspose>;
+  using Op     = std::conditional_t<is_conj, KokkosBlas::Impl::OpConj, KokkosBlas::Impl::OpID>;
+  using Sym_Op = std::conditional_t<is_conj, KokkosBlas::Impl::OpReal, KokkosBlas::Impl::OpID>;
+
+  Op op;
+  Sym_Op sym_op;
+
+  for (std::size_t ib = 0; ib < Nb; ib++) {
+    if (std::same_as<ArgUplo, Uplo::Upper>) {
+      for (std::size_t j = 0; j < N; j++) {
+        for (std::size_t i = 0; i < j + 1; i++) {
+          h_C_alpha0_ref(ib, i, j) = beta * h_C_alpha0_ref(ib, i, j);
+        }
+        h_C_alpha0_ref(ib, j, j) = sym_op(h_C_alpha0_ref(ib, j, j));
+      }
+    } else {
+      for (std::size_t j = 0; j < N; j++) {
+        for (std::size_t i = j; i < N; i++) {
+          h_C_alpha0_ref(ib, i, j) = beta * h_C_alpha0_ref(ib, i, j);
+        }
+        h_C_alpha0_ref(ib, j, j) = sym_op(h_C_alpha0_ref(ib, j, j));
+      }
+    }
+
+    if (!is_trans) {
+      if (std::same_as<ArgUplo, Uplo::Upper>) {
+        for (std::size_t j = 0; j < N; j++) {
+          for (std::size_t i = 0; i < j + 1; i++) {
+            h_C_beta0_ref(ib, i, j) = zero;
+            h_C_ref(ib, i, j)       = beta * h_C_ref(ib, i, j);
+          }
+          for (std::size_t l = 0; l < M; l++) {
+            if (h_A(ib, j, l) != czero) {
+              auto temp = alpha * op(h_A(ib, j, l));
+              for (std::size_t i = 0; i < j + 1; i++) {
+                h_C_ref(ib, i, j) += temp * h_A(ib, i, l);
+                h_C_beta0_ref(ib, i, j) += temp * h_A(ib, i, l);
+              }
+            }
+          }
+          h_C_ref(ib, j, j)       = sym_op(h_C_ref(ib, j, j));
+          h_C_beta0_ref(ib, j, j) = sym_op(h_C_beta0_ref(ib, j, j));
+        }
+      } else {
+        for (std::size_t j = 0; j < N; j++) {
+          for (std::size_t i = j; i < N; i++) {
+            h_C_beta0_ref(ib, i, j) = zero;
+            h_C_ref(ib, i, j)       = beta * h_C_ref(ib, i, j);
+          }
+          for (std::size_t l = 0; l < M; l++) {
+            if (h_A(ib, j, l) != czero) {
+              auto temp = alpha * op(h_A(ib, j, l));
+              for (std::size_t i = j; i < N; i++) {
+                h_C_ref(ib, i, j) += temp * h_A(ib, i, l);
+                h_C_beta0_ref(ib, i, j) += temp * h_A(ib, i, l);
+              }
+            }
+          }
+          h_C_ref(ib, j, j)       = sym_op(h_C_ref(ib, j, j));
+          h_C_beta0_ref(ib, j, j) = sym_op(h_C_beta0_ref(ib, j, j));
+        }
+      }
+    } else {
+      if (std::same_as<ArgUplo, Uplo::Upper>) {
+        for (std::size_t j = 0; j < N; j++) {
+          for (std::size_t i = 0; i < j + 1; i++) {
+            auto temp = czero;
+            for (std::size_t l = 0; l < M; l++) {
+              temp += op(h_A(ib, l, i)) * h_A(ib, l, j);
+            }
+            h_C_beta0_ref(ib, i, j) = alpha * temp;
+            h_C_ref(ib, i, j)       = alpha * temp + beta * h_C_ref(ib, i, j);
+          }
+          h_C_ref(ib, j, j)       = sym_op(h_C_ref(ib, j, j));
+          h_C_beta0_ref(ib, j, j) = sym_op(h_C_beta0_ref(ib, j, j));
+        }
+      } else {
+        for (std::size_t j = 0; j < N; j++) {
+          for (std::size_t i = j; i < N; i++) {
+            auto temp = czero;
+            for (std::size_t l = 0; l < M; l++) {
+              temp += op(h_A(ib, l, i)) * h_A(ib, l, j);
+            }
+            h_C_beta0_ref(ib, i, j) = alpha * temp;
+            h_C_ref(ib, i, j)       = alpha * temp + beta * h_C_ref(ib, i, j);
+          }
+          h_C_ref(ib, j, j)       = sym_op(h_C_ref(ib, j, j));
+          h_C_beta0_ref(ib, j, j) = sym_op(h_C_beta0_ref(ib, j, j));
+        }
+      }
+    }
+  }
+
+  RealType eps = 1.0e1 * ats::epsilon();
+
+  auto h_C        = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, C);
+  auto h_C_alpha0 = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, C_alpha0);
+  auto h_C_beta0  = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, C_beta0);
+
+  // Check if A:= alpha * x * y**T + A or A:= alpha * x * y**H + A
+  // std::cout << "Nb: " << Nb << ", M: " << M << ", N: " << N << std::endl;
+
+  for (std::size_t ib = 0; ib < Nb; ib++) {
+    // std::cout << "ib: " << ib << std::endl;
+    // std::cout << "h_A ( " << h_A.extent(0) << ", " << h_A.extent(1) << ", " << h_A.extent(2) << " ): " << std::endl;
+    // for (std::size_t i = 0; i < h_A.extent(1); i++) {
+    //   for (std::size_t j = 0; j < h_A.extent(2); j++) {
+    //     std::cout << h_A(ib, i, j) << " ";
+    //   }
+    //   std::cout << std::endl;
+    // }
+    for (std::size_t i = 0; i < N; i++) {
+      for (std::size_t j = 0; j < N; j++) {
+        // if (std::abs(h_C(ib, i, j) - h_C_ref(ib, i, j)) > eps || std::abs(h_C_alpha0(ib, i, j) - h_C_alpha0_ref(ib,
+        // i, j)) > eps ||
+        //     std::abs(h_C_beta0(ib, i, j) - h_C_beta0_ref(ib, i, j)) > eps) {
+        //   std::cout << "i: " << i << ", j: " << j << ", h_C: " << h_C(ib, i, j)
+        //             << ", h_C_ref: " << h_C_ref(ib, i, j) << ", h_C_alpha0: " << h_C_alpha0(ib, i, j) << ",
+        //             h_C_alpha0_ref: " << h_C_alpha0_ref(ib, i, j)
+        //             << ", h_C_beta0: " << h_C_beta0(ib, i, j) << ", h_C_beta0_ref: " << h_C_beta0_ref(ib, i, j) <<
+        //             std::endl;
+        // }
+        KK_EXPECT_NEAR(h_C(ib, i, j), h_C_ref(ib, i, j), eps);
+        KK_EXPECT_NEAR(h_C_alpha0(ib, i, j), h_C_alpha0_ref(ib, i, j), eps);
+        KK_EXPECT_NEAR(h_C_beta0(ib, i, j), h_C_beta0_ref(ib, i, j), eps);
+      }
+    }
+  }
+}
+
+}  // namespace Syrk
+}  // namespace Test
+
+template <typename DeviceType, typename ScalarType, typename ParamTagType>
+int test_batched_syrk() {
+#if defined(KOKKOSKERNELS_INST_LAYOUTLEFT)
+  {
+    using LayoutType = Kokkos::LayoutLeft;
+    Test::Syrk::impl_test_batched_syrk_analytical<DeviceType, ScalarType, LayoutType, ParamTagType>(1);
+    Test::Syrk::impl_test_batched_syrk_analytical<DeviceType, ScalarType, LayoutType, ParamTagType>(2);
+    for (int i = 0; i < 5; i++) {
+      for (int j = 0; j < 5; j++) {
+        Test::Syrk::impl_test_batched_syrk<DeviceType, ScalarType, LayoutType, ParamTagType>(1, i, j);
+        Test::Syrk::impl_test_batched_syrk<DeviceType, ScalarType, LayoutType, ParamTagType>(2, i, j);
+      }
+    }
+  }
+#endif
+#if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT)
+  {
+    using LayoutType = Kokkos::LayoutRight;
+    Test::Syrk::impl_test_batched_syrk_analytical<DeviceType, ScalarType, LayoutType, ParamTagType>(1);
+    Test::Syrk::impl_test_batched_syrk_analytical<DeviceType, ScalarType, LayoutType, ParamTagType>(2);
+    for (int i = 0; i < 5; i++) {
+      for (int j = 0; j < 5; j++) {
+        Test::Syrk::impl_test_batched_syrk<DeviceType, ScalarType, LayoutType, ParamTagType>(1, i, j);
+        Test::Syrk::impl_test_batched_syrk<DeviceType, ScalarType, LayoutType, ParamTagType>(2, i, j);
+      }
+    }
+  }
+#endif
+
+  return 0;
+}
+
+#if defined(KOKKOSKERNELS_INST_FLOAT)
+// Serial
+TEST_F(TestCategory, test_batched_serial_syrk_l_nt_float) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Lower, Trans::NoTranspose, KokkosBatched::Mode::Serial>;
+  test_batched_syrk<TestDevice, float, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_serial_syrk_l_t_float) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Lower, Trans::Transpose, KokkosBatched::Mode::Serial>;
+  test_batched_syrk<TestDevice, float, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_serial_syrk_l_nc_float) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Lower, Trans::ConjNoTranspose, KokkosBatched::Mode::Serial>;
+  test_batched_syrk<TestDevice, float, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_serial_syrk_l_c_float) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Lower, Trans::ConjTranspose, KokkosBatched::Mode::Serial>;
+  test_batched_syrk<TestDevice, float, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_serial_syrk_u_nt_float) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Upper, Trans::NoTranspose, KokkosBatched::Mode::Serial>;
+  test_batched_syrk<TestDevice, float, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_serial_syrk_u_t_float) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Upper, Trans::Transpose, KokkosBatched::Mode::Serial>;
+  test_batched_syrk<TestDevice, float, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_serial_syrk_u_nc_float) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Upper, Trans::ConjNoTranspose, KokkosBatched::Mode::Serial>;
+  test_batched_syrk<TestDevice, float, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_serial_syrk_u_c_float) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Upper, Trans::ConjTranspose, KokkosBatched::Mode::Serial>;
+  test_batched_syrk<TestDevice, float, param_tag_type>();
+}
+// Team
+TEST_F(TestCategory, test_batched_team_syrk_l_nt_float) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Lower, Trans::NoTranspose, KokkosBatched::Mode::Team>;
+  test_batched_syrk<TestDevice, float, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_syrk_l_t_float) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Lower, Trans::Transpose, KokkosBatched::Mode::Team>;
+  test_batched_syrk<TestDevice, float, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_syrk_l_nc_float) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Lower, Trans::ConjNoTranspose, KokkosBatched::Mode::Team>;
+  test_batched_syrk<TestDevice, float, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_syrk_l_c_float) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Lower, Trans::ConjTranspose, KokkosBatched::Mode::Team>;
+  test_batched_syrk<TestDevice, float, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_syrk_u_nt_float) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Upper, Trans::NoTranspose, KokkosBatched::Mode::Team>;
+  test_batched_syrk<TestDevice, float, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_syrk_u_t_float) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Upper, Trans::Transpose, KokkosBatched::Mode::Team>;
+  test_batched_syrk<TestDevice, float, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_syrk_u_nc_float) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Upper, Trans::ConjNoTranspose, KokkosBatched::Mode::Team>;
+  test_batched_syrk<TestDevice, float, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_syrk_u_c_float) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Upper, Trans::ConjTranspose, KokkosBatched::Mode::Team>;
+  test_batched_syrk<TestDevice, float, param_tag_type>();
+}
+// TeamVector
+TEST_F(TestCategory, test_batched_team_vector_syrk_l_nt_float) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Lower, Trans::NoTranspose, KokkosBatched::Mode::TeamVector>;
+  test_batched_syrk<TestDevice, float, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_vector_syrk_l_t_float) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Lower, Trans::Transpose, KokkosBatched::Mode::TeamVector>;
+  test_batched_syrk<TestDevice, float, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_vector_syrk_l_nc_float) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Lower, Trans::ConjNoTranspose, KokkosBatched::Mode::TeamVector>;
+  test_batched_syrk<TestDevice, float, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_vector_syrk_l_c_float) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Lower, Trans::ConjTranspose, KokkosBatched::Mode::TeamVector>;
+  test_batched_syrk<TestDevice, float, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_vector_syrk_u_nt_float) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Upper, Trans::NoTranspose, KokkosBatched::Mode::TeamVector>;
+  test_batched_syrk<TestDevice, float, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_vector_syrk_u_t_float) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Upper, Trans::Transpose, KokkosBatched::Mode::TeamVector>;
+  test_batched_syrk<TestDevice, float, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_vector_syrk_u_nc_float) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Upper, Trans::ConjNoTranspose, KokkosBatched::Mode::TeamVector>;
+  test_batched_syrk<TestDevice, float, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_vector_syrk_u_c_float) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Upper, Trans::ConjTranspose, KokkosBatched::Mode::TeamVector>;
+  test_batched_syrk<TestDevice, float, param_tag_type>();
+}
+#endif
+
+#if defined(KOKKOSKERNELS_INST_DOUBLE)
+// Serial
+TEST_F(TestCategory, test_batched_serial_syrk_l_nt_double) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Lower, Trans::NoTranspose, KokkosBatched::Mode::Serial>;
+  test_batched_syrk<TestDevice, double, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_serial_syrk_l_t_double) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Lower, Trans::Transpose, KokkosBatched::Mode::Serial>;
+  test_batched_syrk<TestDevice, double, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_serial_syrk_l_nc_double) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Lower, Trans::ConjNoTranspose, KokkosBatched::Mode::Serial>;
+  test_batched_syrk<TestDevice, double, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_serial_syrk_l_c_double) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Lower, Trans::ConjTranspose, KokkosBatched::Mode::Serial>;
+  test_batched_syrk<TestDevice, double, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_serial_syrk_u_nt_double) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Upper, Trans::NoTranspose, KokkosBatched::Mode::Serial>;
+  test_batched_syrk<TestDevice, double, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_serial_syrk_u_t_double) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Upper, Trans::Transpose, KokkosBatched::Mode::Serial>;
+  test_batched_syrk<TestDevice, double, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_serial_syrk_u_nc_double) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Upper, Trans::ConjNoTranspose, KokkosBatched::Mode::Serial>;
+  test_batched_syrk<TestDevice, double, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_serial_syrk_u_c_double) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Upper, Trans::ConjTranspose, KokkosBatched::Mode::Serial>;
+  test_batched_syrk<TestDevice, double, param_tag_type>();
+}
+// Team
+TEST_F(TestCategory, test_batched_team_syrk_l_nt_double) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Lower, Trans::NoTranspose, KokkosBatched::Mode::Team>;
+  test_batched_syrk<TestDevice, double, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_syrk_l_t_double) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Lower, Trans::Transpose, KokkosBatched::Mode::Team>;
+  test_batched_syrk<TestDevice, double, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_syrk_l_nc_double) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Lower, Trans::ConjNoTranspose, KokkosBatched::Mode::Team>;
+  test_batched_syrk<TestDevice, double, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_syrk_l_c_double) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Lower, Trans::ConjTranspose, KokkosBatched::Mode::Team>;
+  test_batched_syrk<TestDevice, double, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_syrk_u_nt_double) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Upper, Trans::NoTranspose, KokkosBatched::Mode::Team>;
+  test_batched_syrk<TestDevice, double, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_syrk_u_t_double) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Upper, Trans::Transpose, KokkosBatched::Mode::Team>;
+  test_batched_syrk<TestDevice, double, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_syrk_u_nc_double) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Upper, Trans::ConjNoTranspose, KokkosBatched::Mode::Team>;
+  test_batched_syrk<TestDevice, double, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_syrk_u_c_double) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Upper, Trans::ConjTranspose, KokkosBatched::Mode::Team>;
+  test_batched_syrk<TestDevice, double, param_tag_type>();
+}
+// TeamVector
+TEST_F(TestCategory, test_batched_team_vector_syrk_l_nt_double) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Lower, Trans::NoTranspose, KokkosBatched::Mode::TeamVector>;
+  test_batched_syrk<TestDevice, double, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_vector_syrk_l_t_double) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Lower, Trans::Transpose, KokkosBatched::Mode::TeamVector>;
+  test_batched_syrk<TestDevice, double, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_vector_syrk_l_nc_double) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Lower, Trans::ConjNoTranspose, KokkosBatched::Mode::TeamVector>;
+  test_batched_syrk<TestDevice, double, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_vector_syrk_l_c_double) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Lower, Trans::ConjTranspose, KokkosBatched::Mode::TeamVector>;
+  test_batched_syrk<TestDevice, double, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_vector_syrk_u_nt_double) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Upper, Trans::NoTranspose, KokkosBatched::Mode::TeamVector>;
+  test_batched_syrk<TestDevice, double, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_vector_syrk_u_t_double) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Upper, Trans::Transpose, KokkosBatched::Mode::TeamVector>;
+  test_batched_syrk<TestDevice, double, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_vector_syrk_u_nc_double) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Upper, Trans::ConjNoTranspose, KokkosBatched::Mode::TeamVector>;
+  test_batched_syrk<TestDevice, double, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_vector_syrk_u_c_double) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Upper, Trans::ConjTranspose, KokkosBatched::Mode::TeamVector>;
+  test_batched_syrk<TestDevice, double, param_tag_type>();
+}
+#endif
+
+#if defined(KOKKOSKERNELS_INST_COMPLEX_FLOAT)
+// Serial
+TEST_F(TestCategory, test_batched_serial_syrk_l_nt_fcomplex) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Lower, Trans::NoTranspose, KokkosBatched::Mode::Serial>;
+  test_batched_syrk<TestDevice, Kokkos::complex<float>, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_serial_syrk_l_t_fcomplex) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Lower, Trans::Transpose, KokkosBatched::Mode::Serial>;
+  test_batched_syrk<TestDevice, Kokkos::complex<float>, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_serial_syrk_l_nc_fcomplex) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Lower, Trans::ConjNoTranspose, KokkosBatched::Mode::Serial>;
+  test_batched_syrk<TestDevice, Kokkos::complex<float>, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_serial_syrk_l_c_fcomplex) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Lower, Trans::ConjTranspose, KokkosBatched::Mode::Serial>;
+  test_batched_syrk<TestDevice, Kokkos::complex<float>, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_serial_syrk_u_nt_fcomplex) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Upper, Trans::NoTranspose, KokkosBatched::Mode::Serial>;
+  test_batched_syrk<TestDevice, Kokkos::complex<float>, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_serial_syrk_u_t_fcomplex) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Upper, Trans::Transpose, KokkosBatched::Mode::Serial>;
+  test_batched_syrk<TestDevice, Kokkos::complex<float>, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_serial_syrk_u_nc_fcomplex) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Upper, Trans::ConjNoTranspose, KokkosBatched::Mode::Serial>;
+  test_batched_syrk<TestDevice, Kokkos::complex<float>, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_serial_syrk_u_c_fcomplex) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Upper, Trans::ConjTranspose, KokkosBatched::Mode::Serial>;
+  test_batched_syrk<TestDevice, Kokkos::complex<float>, param_tag_type>();
+}
+// Team
+TEST_F(TestCategory, test_batched_team_syrk_l_nt_fcomplex) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Lower, Trans::NoTranspose, KokkosBatched::Mode::Team>;
+  test_batched_syrk<TestDevice, Kokkos::complex<float>, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_syrk_l_t_fcomplex) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Lower, Trans::Transpose, KokkosBatched::Mode::Team>;
+  test_batched_syrk<TestDevice, Kokkos::complex<float>, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_syrk_l_nc_fcomplex) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Lower, Trans::ConjNoTranspose, KokkosBatched::Mode::Team>;
+  test_batched_syrk<TestDevice, Kokkos::complex<float>, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_syrk_l_c_fcomplex) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Lower, Trans::ConjTranspose, KokkosBatched::Mode::Team>;
+  test_batched_syrk<TestDevice, Kokkos::complex<float>, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_syrk_u_nt_fcomplex) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Upper, Trans::NoTranspose, KokkosBatched::Mode::Team>;
+  test_batched_syrk<TestDevice, Kokkos::complex<float>, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_syrk_u_t_fcomplex) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Upper, Trans::Transpose, KokkosBatched::Mode::Team>;
+  test_batched_syrk<TestDevice, Kokkos::complex<float>, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_syrk_u_nc_fcomplex) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Upper, Trans::ConjNoTranspose, KokkosBatched::Mode::Team>;
+  test_batched_syrk<TestDevice, Kokkos::complex<float>, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_syrk_u_c_fcomplex) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Upper, Trans::ConjTranspose, KokkosBatched::Mode::Team>;
+  test_batched_syrk<TestDevice, Kokkos::complex<float>, param_tag_type>();
+}
+// TeamVector
+TEST_F(TestCategory, test_batched_team_vector_syrk_l_nt_fcomplex) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Lower, Trans::NoTranspose, KokkosBatched::Mode::TeamVector>;
+  test_batched_syrk<TestDevice, Kokkos::complex<float>, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_vector_syrk_l_t_fcomplex) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Lower, Trans::Transpose, KokkosBatched::Mode::TeamVector>;
+  test_batched_syrk<TestDevice, Kokkos::complex<float>, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_vector_syrk_l_nc_fcomplex) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Lower, Trans::ConjNoTranspose, KokkosBatched::Mode::TeamVector>;
+  test_batched_syrk<TestDevice, Kokkos::complex<float>, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_vector_syrk_l_c_fcomplex) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Lower, Trans::ConjTranspose, KokkosBatched::Mode::TeamVector>;
+  test_batched_syrk<TestDevice, Kokkos::complex<float>, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_vector_syrk_u_nt_fcomplex) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Upper, Trans::NoTranspose, KokkosBatched::Mode::TeamVector>;
+  test_batched_syrk<TestDevice, Kokkos::complex<float>, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_vector_syrk_u_t_fcomplex) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Upper, Trans::Transpose, KokkosBatched::Mode::TeamVector>;
+  test_batched_syrk<TestDevice, Kokkos::complex<float>, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_vector_syrk_u_nc_fcomplex) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Upper, Trans::ConjNoTranspose, KokkosBatched::Mode::TeamVector>;
+  test_batched_syrk<TestDevice, Kokkos::complex<float>, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_vector_syrk_u_c_fcomplex) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Upper, Trans::ConjTranspose, KokkosBatched::Mode::TeamVector>;
+  test_batched_syrk<TestDevice, Kokkos::complex<float>, param_tag_type>();
+}
+#endif
+
+#if defined(KOKKOSKERNELS_INST_COMPLEX_DOUBLE)
+// Serial
+TEST_F(TestCategory, test_batched_serial_syrk_l_nt_dcomplex) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Lower, Trans::NoTranspose, KokkosBatched::Mode::Serial>;
+  test_batched_syrk<TestDevice, Kokkos::complex<double>, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_serial_syrk_l_t_dcomplex) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Lower, Trans::Transpose, KokkosBatched::Mode::Serial>;
+  test_batched_syrk<TestDevice, Kokkos::complex<double>, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_serial_syrk_l_nc_dcomplex) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Lower, Trans::ConjNoTranspose, KokkosBatched::Mode::Serial>;
+  test_batched_syrk<TestDevice, Kokkos::complex<double>, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_serial_syrk_l_c_dcomplex) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Lower, Trans::ConjTranspose, KokkosBatched::Mode::Serial>;
+  test_batched_syrk<TestDevice, Kokkos::complex<double>, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_serial_syrk_u_nt_dcomplex) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Upper, Trans::NoTranspose, KokkosBatched::Mode::Serial>;
+  test_batched_syrk<TestDevice, Kokkos::complex<double>, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_serial_syrk_u_t_dcomplex) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Upper, Trans::Transpose, KokkosBatched::Mode::Serial>;
+  test_batched_syrk<TestDevice, Kokkos::complex<double>, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_serial_syrk_u_nc_dcomplex) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Upper, Trans::ConjNoTranspose, KokkosBatched::Mode::Serial>;
+  test_batched_syrk<TestDevice, Kokkos::complex<double>, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_serial_syrk_u_c_dcomplex) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Upper, Trans::ConjTranspose, KokkosBatched::Mode::Serial>;
+  test_batched_syrk<TestDevice, Kokkos::complex<double>, param_tag_type>();
+}
+// Team
+TEST_F(TestCategory, test_batched_team_syrk_l_nt_dcomplex) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Lower, Trans::NoTranspose, KokkosBatched::Mode::Team>;
+  test_batched_syrk<TestDevice, Kokkos::complex<double>, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_syrk_l_t_dcomplex) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Lower, Trans::Transpose, KokkosBatched::Mode::Team>;
+  test_batched_syrk<TestDevice, Kokkos::complex<double>, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_syrk_l_nc_dcomplex) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Lower, Trans::ConjNoTranspose, KokkosBatched::Mode::Team>;
+  test_batched_syrk<TestDevice, Kokkos::complex<double>, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_syrk_l_c_dcomplex) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Lower, Trans::ConjTranspose, KokkosBatched::Mode::Team>;
+  test_batched_syrk<TestDevice, Kokkos::complex<double>, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_syrk_u_nt_dcomplex) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Upper, Trans::NoTranspose, KokkosBatched::Mode::Team>;
+  test_batched_syrk<TestDevice, Kokkos::complex<double>, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_syrk_u_t_dcomplex) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Upper, Trans::Transpose, KokkosBatched::Mode::Team>;
+  test_batched_syrk<TestDevice, Kokkos::complex<double>, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_syrk_u_nc_dcomplex) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Upper, Trans::ConjNoTranspose, KokkosBatched::Mode::Team>;
+  test_batched_syrk<TestDevice, Kokkos::complex<double>, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_syrk_u_c_dcomplex) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Upper, Trans::ConjTranspose, KokkosBatched::Mode::Team>;
+  test_batched_syrk<TestDevice, Kokkos::complex<double>, param_tag_type>();
+}
+// TeamVector
+TEST_F(TestCategory, test_batched_team_vector_syrk_l_nt_dcomplex) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Lower, Trans::NoTranspose, KokkosBatched::Mode::TeamVector>;
+  test_batched_syrk<TestDevice, Kokkos::complex<double>, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_vector_syrk_l_t_dcomplex) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Lower, Trans::Transpose, KokkosBatched::Mode::TeamVector>;
+  test_batched_syrk<TestDevice, Kokkos::complex<double>, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_vector_syrk_l_nc_dcomplex) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Lower, Trans::ConjNoTranspose, KokkosBatched::Mode::TeamVector>;
+  test_batched_syrk<TestDevice, Kokkos::complex<double>, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_vector_syrk_l_c_dcomplex) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Lower, Trans::ConjTranspose, KokkosBatched::Mode::TeamVector>;
+  test_batched_syrk<TestDevice, Kokkos::complex<double>, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_vector_syrk_u_nt_dcomplex) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Upper, Trans::NoTranspose, KokkosBatched::Mode::TeamVector>;
+  test_batched_syrk<TestDevice, Kokkos::complex<double>, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_vector_syrk_u_t_dcomplex) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Upper, Trans::Transpose, KokkosBatched::Mode::TeamVector>;
+  test_batched_syrk<TestDevice, Kokkos::complex<double>, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_vector_syrk_u_nc_dcomplex) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Upper, Trans::ConjNoTranspose, KokkosBatched::Mode::TeamVector>;
+  test_batched_syrk<TestDevice, Kokkos::complex<double>, param_tag_type>();
+}
+TEST_F(TestCategory, test_batched_team_vector_syrk_u_c_dcomplex) {
+  using param_tag_type = ::Test::Syrk::ParamTag<Uplo::Upper, Trans::ConjTranspose, KokkosBatched::Mode::TeamVector>;
+  test_batched_syrk<TestDevice, Kokkos::complex<double>, param_tag_type>();
+}
+#endif

--- a/batched/dense/unit_test/Test_Batched_Syrk.hpp
+++ b/batched/dense/unit_test/Test_Batched_Syrk.hpp
@@ -112,7 +112,6 @@ void impl_test_batched_syrk_analytical(const std::size_t Nb) {
   using StridedView3DType = Kokkos::View<ScalarType ***, Kokkos::LayoutStride, DeviceType>;
   using ArgUplo           = typename ParamTagType::uplo;
   using ArgTrans          = typename ParamTagType::trans;
-  using ArgMode           = typename ParamTagType::mode;
 
   const std::size_t BlkSize = 4;
   View3DType A("A", Nb, BlkSize, BlkSize);
@@ -279,7 +278,6 @@ void impl_test_batched_syrk(const std::size_t Nb, const std::size_t M, const std
   using RealType   = typename ats::mag_type;
   using View3DType = Kokkos::View<ScalarType ***, LayoutType, DeviceType>;
   using ArgUplo    = typename ParamTagType::uplo;
-  using ArgTrans   = typename ParamTagType::trans;
 
   const bool is_trans = std::same_as<typename ParamTagType::trans, KokkosBatched::Trans::Transpose> ||
                         std::same_as<typename ParamTagType::trans, KokkosBatched::Trans::ConjTranspose>;

--- a/batched/dense/unit_test/Test_Batched_Syrk.hpp
+++ b/batched/dense/unit_test/Test_Batched_Syrk.hpp
@@ -55,7 +55,7 @@ struct Functor_BatchedSyrk {
                               : std::same_as<ArgMode, KokkosBatched::Mode::Team>
                                   ? "KokkosBatched::Test::TeamSyrk"
                                   : "KokkosBatched::Test::TeamVectorSyrk";
-    const std::string name_value_type = Test::value_type_name<value_type>();
+    const std::string name_value_type = TestUtils::value_type_name<value_type>();
     std::string name                  = name_region + name_value_type;
     int info_sum                      = 0;
     Kokkos::Profiling::pushRegion(name.c_str());

--- a/batched/dense/unit_test/Test_Batched_Syrk.hpp
+++ b/batched/dense/unit_test/Test_Batched_Syrk.hpp
@@ -248,7 +248,7 @@ void impl_test_batched_syrk_analytical(const std::size_t Nb) {
   for (std::size_t ib = 0; ib < Nb; ib++) {
     for (std::size_t i = 0; i < BlkSize; i++) {
       for (std::size_t j = 0; j < BlkSize; j++) {
-        KK_EXPECT_NEAR(h_C(ib, i, j), h_C_ref(ib, i, j), eps);
+        EXPECT_NEAR_KK(h_C(ib, i, j), h_C_ref(ib, i, j), eps);
       }
     }
   }
@@ -261,7 +261,7 @@ void impl_test_batched_syrk_analytical(const std::size_t Nb) {
   for (std::size_t ib = 0; ib < Nb; ib++) {
     for (std::size_t i = 0; i < BlkSize; i++) {
       for (std::size_t j = 0; j < BlkSize; j++) {
-        KK_EXPECT_NEAR(h_C(ib, i, j), h_C_ref(ib, i, j), eps);
+        EXPECT_NEAR_KK(h_C(ib, i, j), h_C_ref(ib, i, j), eps);
       }
     }
   }
@@ -444,32 +444,12 @@ void impl_test_batched_syrk(const std::size_t Nb, const std::size_t M, const std
   auto h_C_alpha0 = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, C_alpha0);
   auto h_C_beta0  = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, C_beta0);
 
-  // Check if A:= alpha * x * y**T + A or A:= alpha * x * y**H + A
-  // std::cout << "Nb: " << Nb << ", M: " << M << ", N: " << N << std::endl;
-
   for (std::size_t ib = 0; ib < Nb; ib++) {
-    // std::cout << "ib: " << ib << std::endl;
-    // std::cout << "h_A ( " << h_A.extent(0) << ", " << h_A.extent(1) << ", " << h_A.extent(2) << " ): " << std::endl;
-    // for (std::size_t i = 0; i < h_A.extent(1); i++) {
-    //   for (std::size_t j = 0; j < h_A.extent(2); j++) {
-    //     std::cout << h_A(ib, i, j) << " ";
-    //   }
-    //   std::cout << std::endl;
-    // }
     for (std::size_t i = 0; i < N; i++) {
       for (std::size_t j = 0; j < N; j++) {
-        // if (std::abs(h_C(ib, i, j) - h_C_ref(ib, i, j)) > eps || std::abs(h_C_alpha0(ib, i, j) - h_C_alpha0_ref(ib,
-        // i, j)) > eps ||
-        //     std::abs(h_C_beta0(ib, i, j) - h_C_beta0_ref(ib, i, j)) > eps) {
-        //   std::cout << "i: " << i << ", j: " << j << ", h_C: " << h_C(ib, i, j)
-        //             << ", h_C_ref: " << h_C_ref(ib, i, j) << ", h_C_alpha0: " << h_C_alpha0(ib, i, j) << ",
-        //             h_C_alpha0_ref: " << h_C_alpha0_ref(ib, i, j)
-        //             << ", h_C_beta0: " << h_C_beta0(ib, i, j) << ", h_C_beta0_ref: " << h_C_beta0_ref(ib, i, j) <<
-        //             std::endl;
-        // }
-        KK_EXPECT_NEAR(h_C(ib, i, j), h_C_ref(ib, i, j), eps);
-        KK_EXPECT_NEAR(h_C_alpha0(ib, i, j), h_C_alpha0_ref(ib, i, j), eps);
-        KK_EXPECT_NEAR(h_C_beta0(ib, i, j), h_C_beta0_ref(ib, i, j), eps);
+        EXPECT_NEAR_KK(h_C(ib, i, j), h_C_ref(ib, i, j), eps);
+        EXPECT_NEAR_KK(h_C_alpha0(ib, i, j), h_C_alpha0_ref(ib, i, j), eps);
+        EXPECT_NEAR_KK(h_C_beta0(ib, i, j), h_C_beta0_ref(ib, i, j), eps);
       }
     }
   }

--- a/batched/dense/unit_test/Test_Batched_Syrk.hpp
+++ b/batched/dense/unit_test/Test_Batched_Syrk.hpp
@@ -30,7 +30,7 @@ struct Functor_BatchedSyrk {
   ScalarType m_alpha, m_beta;
 
   Functor_BatchedSyrk(const ScalarType alpha, const AViewType &A, const ScalarType beta, const CViewType &C)
-      : m_alpha(alpha), m_A(A), m_beta(beta), m_C(C) {}
+      : m_A(A), m_C(C), m_alpha(alpha), m_beta(beta) {}
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const member_type &member, int &info) const {

--- a/blas/impl/KokkosBlas_util.hpp
+++ b/blas/impl/KokkosBlas_util.hpp
@@ -65,6 +65,7 @@ struct Trans {
   struct Transpose {};
   struct NoTranspose {};
   struct ConjTranspose {};
+  struct ConjNoTranspose {};
 };
 
 template <class T>
@@ -78,6 +79,9 @@ struct is_trans<Trans::NoTranspose> : std::true_type {};
 
 template <>
 struct is_trans<Trans::ConjTranspose> : std::true_type {};
+
+template <>
+struct is_trans<Trans::ConjNoTranspose> : std::true_type {};
 
 template <class T>
 static constexpr bool is_trans_v = is_trans<T>::value;


### PR DESCRIPTION
This PR adds batched [syrk](https://www.netlib.org/lapack/explore-html/d4/d6e/group__herk_ga09ec411a6b845c47efb0bc8bd3283b03.html) 

- [x] Serial/Team/TeamVector implementations
- [x] Corresponding unit-tests 
- [x] A new class `ConjNoTranspose` added to support [zherk](https://www.netlib.org/lapack/explore-html/d4/d6e/group__herk_ga5bd7d028f21ee95764845c1197baa09f.html#ga5bd7d028f21ee95764845c1197baa09f).
