### PR TITLE
EXPECT*KK macro rework

### DIFF
--- a/batched/dense/unit_test/Test_Batched_Nrm.hpp
+++ b/batched/dense/unit_test/Test_Batched_Nrm.hpp
@@ -137,8 +137,8 @@ void impl_test_batched_nrm_analytical(const std::size_t Nb) {
   auto h_norm_s = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, norm_s);
 
   for (std::size_t ib = 0; ib < Nb; ib++) {
-    KK_EXPECT_NEAR(h_norm(ib), h_norm_ref(ib), eps);
-    KK_EXPECT_NEAR(h_norm_s(ib), h_norm_ref(ib), eps);
+    EXPECT_NEAR_KK(h_norm(ib), h_norm_ref(ib), eps);
+    EXPECT_NEAR_KK(h_norm_s(ib), h_norm_ref(ib), eps);
   }
 }
 
@@ -219,8 +219,8 @@ void impl_test_batched_nrm_overflow(const std::size_t Nb) {
   auto h_norm_s = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, norm_s);
 
   for (std::size_t ib = 0; ib < Nb; ib++) {
-    KK_EXPECT_NEAR(h_norm(ib), h_norm_ref(ib), eps);
-    KK_EXPECT_NEAR(h_norm_s(ib), h_norm_ref(ib), eps);
+    EXPECT_NEAR_KK(h_norm(ib), h_norm_ref(ib), eps);
+    EXPECT_NEAR_KK(h_norm_s(ib), h_norm_ref(ib), eps);
   }
 }
 
@@ -316,8 +316,8 @@ void impl_test_batched_nrm(const std::size_t Nb, const std::size_t N) {
 
   // Check if norm is correct
   for (std::size_t ib = 0; ib < Nb; ib++) {
-    KK_EXPECT_NEAR(h_norm(ib), h_norm_ref(ib), eps);
-    KK_EXPECT_NEAR(h_norm_s(ib), h_norm_ref(ib), eps);
+    EXPECT_NEAR_KK(h_norm(ib), h_norm_ref(ib), eps);
+    EXPECT_NEAR_KK(h_norm_s(ib), h_norm_ref(ib), eps);
   }
 }
 

--- a/batched/dense/unit_test/Test_Batched_Swap.hpp
+++ b/batched/dense/unit_test/Test_Batched_Swap.hpp
@@ -193,13 +193,13 @@ void impl_test_batched_swap_analytical(const std::size_t Nb) {
 
   for (std::size_t ib = 0; ib < Nb; ib++) {
     for (std::size_t i = 0; i < N; i++) {
-      KK_EXPECT_NEAR(h_x0(ib, i), h_x0_ref(ib, i), eps);
-      KK_EXPECT_NEAR(h_y0(ib, i), h_y0_ref(ib, i), eps);
+      EXPECT_NEAR_KK(h_x0(ib, i), h_x0_ref(ib, i), eps);
+      EXPECT_NEAR_KK(h_y0(ib, i), h_y0_ref(ib, i), eps);
     }
     for (std::size_t i = 0; i < M; i++) {
       for (std::size_t j = 0; j < N; j++) {
-        KK_EXPECT_NEAR(h_x1(ib, i, j), h_x1_ref(ib, i, j), eps);
-        KK_EXPECT_NEAR(h_y1(ib, i, j), h_y1_ref(ib, i, j), eps);
+        EXPECT_NEAR_KK(h_x1(ib, i, j), h_x1_ref(ib, i, j), eps);
+        EXPECT_NEAR_KK(h_y1(ib, i, j), h_y1_ref(ib, i, j), eps);
       }
     }
   }
@@ -215,13 +215,13 @@ void impl_test_batched_swap_analytical(const std::size_t Nb) {
   Kokkos::deep_copy(h_y1, y1);
   for (std::size_t ib = 0; ib < Nb; ib++) {
     for (std::size_t i = 0; i < N; i++) {
-      KK_EXPECT_NEAR(h_x0(ib, i), h_x0_ref(ib, i), eps);
-      KK_EXPECT_NEAR(h_y0(ib, i), h_y0_ref(ib, i), eps);
+      EXPECT_NEAR_KK(h_x0(ib, i), h_x0_ref(ib, i), eps);
+      EXPECT_NEAR_KK(h_y0(ib, i), h_y0_ref(ib, i), eps);
     }
     for (std::size_t i = 0; i < M; i++) {
       for (std::size_t j = 0; j < N; j++) {
-        KK_EXPECT_NEAR(h_x1(ib, i, j), h_x1_ref(ib, i, j), eps);
-        KK_EXPECT_NEAR(h_y1(ib, i, j), h_y1_ref(ib, i, j), eps);
+        EXPECT_NEAR_KK(h_x1(ib, i, j), h_x1_ref(ib, i, j), eps);
+        EXPECT_NEAR_KK(h_y1(ib, i, j), h_y1_ref(ib, i, j), eps);
       }
     }
   }
@@ -308,13 +308,13 @@ void impl_test_batched_swap(const std::size_t Nb, const std::size_t M, const std
   // Check if swap is correct
   for (std::size_t ib = 0; ib < Nb; ib++) {
     for (std::size_t i = 0; i < N; i++) {
-      KK_EXPECT_NEAR(h_x0(ib, i), h_x0_ref(ib, i), eps);
-      KK_EXPECT_NEAR(h_y0(ib, i), h_y0_ref(ib, i), eps);
+      EXPECT_NEAR_KK(h_x0(ib, i), h_x0_ref(ib, i), eps);
+      EXPECT_NEAR_KK(h_y0(ib, i), h_y0_ref(ib, i), eps);
     }
     for (std::size_t i = 0; i < M; i++) {
       for (std::size_t j = 0; j < N; j++) {
-        KK_EXPECT_NEAR(h_x1(ib, i, j), h_x1_ref(ib, i, j), eps);
-        KK_EXPECT_NEAR(h_y1(ib, i, j), h_y1_ref(ib, i, j), eps);
+        EXPECT_NEAR_KK(h_x1(ib, i, j), h_x1_ref(ib, i, j), eps);
+        EXPECT_NEAR_KK(h_y1(ib, i, j), h_y1_ref(ib, i, j), eps);
       }
     }
   }
@@ -330,13 +330,13 @@ void impl_test_batched_swap(const std::size_t Nb, const std::size_t M, const std
   Kokkos::deep_copy(h_y1, y1);
   for (std::size_t ib = 0; ib < Nb; ib++) {
     for (std::size_t i = 0; i < N; i++) {
-      KK_EXPECT_NEAR(h_x0(ib, i), h_x0_ref(ib, i), eps);
-      KK_EXPECT_NEAR(h_y0(ib, i), h_y0_ref(ib, i), eps);
+      EXPECT_NEAR_KK(h_x0(ib, i), h_x0_ref(ib, i), eps);
+      EXPECT_NEAR_KK(h_y0(ib, i), h_y0_ref(ib, i), eps);
     }
     for (std::size_t i = 0; i < M; i++) {
       for (std::size_t j = 0; j < N; j++) {
-        KK_EXPECT_NEAR(h_x1(ib, i, j), h_x1_ref(ib, i, j), eps);
-        KK_EXPECT_NEAR(h_y1(ib, i, j), h_y1_ref(ib, i, j), eps);
+        EXPECT_NEAR_KK(h_x1(ib, i, j), h_x1_ref(ib, i, j), eps);
+        EXPECT_NEAR_KK(h_y1(ib, i, j), h_y1_ref(ib, i, j), eps);
       }
     }
   }

--- a/test_common/KokkosKernels_TestUtils.hpp
+++ b/test_common/KokkosKernels_TestUtils.hpp
@@ -51,22 +51,24 @@ namespace TestUtils {
 namespace Impl {
 
 // Base case: scalar absolute comparison
-template <class Scalar1, class Scalar2, class Scalar3,
-          std::enable_if_t<!Kokkos::is_view_v<Scalar1> && !KokkosBatched::is_vector<Scalar1>::value, int> = 0>
+template <class Scalar1, class Scalar2, class Scalar3>
+  requires(!Kokkos::is_view_v<Scalar1> && !Kokkos::is_view_v<Scalar2> && !KokkosBatched::is_vector<Scalar1>::value && !KokkosBatched::is_vector<Scalar2>::value)
 testing::AssertionResult expect_near_pred_format_scalar(const char* expr1, const char* expr2, const char* expr_tol,
                                                         Scalar1 val1, Scalar2 val2, Scalar3 tol) {
-  typedef KokkosKernels::ArithTraits<Scalar1> AT1;
-  typedef KokkosKernels::ArithTraits<Scalar3> AT3;
+  using AT1 = KokkosKernels::ArithTraits<Scalar1>;
+  using AT3 = KokkosKernels::ArithTraits<Scalar3>;
 
   double abs_diff = (double)AT1::abs(val1 - val2);
   double abs_tol  = (double)AT3::abs(tol);
 
   if (abs_diff <= abs_tol) return testing::AssertionSuccess();
 
-  return testing::AssertionFailure() << "Expected: " << expr1 << " is near " << expr2 << " (within " << expr_tol
-                                     << ")\n"
-                                     << "  Actual: " << abs_diff << "\n"
-                                     << "Expected: " << abs_tol << "\n";
+return testing::AssertionFailure()
+<< "Expected: " << expr1 << " is near " << expr2 << " (within " << expr_tol << ")\n"
+<< "  " << expr1 << " evaluates to " << testing::PrintToString(val1) << "\n"
+<< "  " << expr2 << " evaluates to " << testing::PrintToString(val2) << "\n"
+<< "  Difference: " << abs_diff << "\n"
+<< "  Tolerance: " << abs_tol << "\n";
 }
 
 // SIMD Vector specialization: element-wise absolute comparison across all lanes
@@ -90,11 +92,12 @@ static constexpr size_t ExpectNearMaxFailures = 10;
 
 // Helper: mirrors two rank-1 Views to host, then applies elem_cmp(h_v1(i), h_v2(i)) for each index,
 // collecting per-element failures into a single AssertionResult (capped at ExpectNearMaxFailures).
-template <class View1, class View2, class ElemCmp,
-          std::enable_if_t<Kokkos::is_view_v<View1> && Kokkos::is_view_v<View2>, int> = 0>
+template <class View1, class View2, class ElemCmp>
+  requires(Kokkos::is_view_v<View1> && Kokkos::is_view_v<View2>)
 testing::AssertionResult expect_near_1dview_impl(const char* expr1, const char* expr2, const View1& v1, const View2& v2,
                                                  ElemCmp elem_cmp) {
-  static_assert(View1::rank == 1, "expect_near_1dview_impl: only rank-1 Views are supported");
+  static_assert(View1::rank == 1, "expect_near_1dview_impl: View1 must have rank 1.");
+  static_assert(View2::rank == 1, "expect_near_1dview_impl: View2 must have rank 1.");
   const size_t v1_size = v1.extent(0);
   if (v1_size != v2.extent(0)) {
     return testing::AssertionFailure() << expr1 << ".extent(0) (" << v1_size << ") != " << expr2 << ".extent(0) ("
@@ -125,8 +128,8 @@ testing::AssertionResult expect_near_1dview_impl(const char* expr1, const char* 
 }
 
 // Kokkos View specialization: element-wise absolute comparison (rank-1 only)
-template <class View1, class View2, class Scalar3,
-          std::enable_if_t<Kokkos::is_view_v<View1> && Kokkos::is_view_v<View2>, int> = 0>
+template <class View1, class View2, class Scalar3>
+  requires(Kokkos::is_view_v<View1> && Kokkos::is_view_v<View2>)
 testing::AssertionResult expect_near_pred_format_scalar(const char* expr1, const char* expr2, const char* expr_tol,
                                                         const View1& v1, const View2& v2, Scalar3 tol) {
   return expect_near_1dview_impl(expr1, expr2, v1, v2, [&](auto e1, auto e2) {
@@ -135,8 +138,8 @@ testing::AssertionResult expect_near_pred_format_scalar(const char* expr1, const
 }
 
 // Base case: scalar relative comparison — delegates to absolute with per-element tolerance
-template <class Scalar1, class Scalar2, class Scalar3,
-          std::enable_if_t<!Kokkos::is_view_v<Scalar1> && !KokkosBatched::is_vector<Scalar1>::value, int> = 0>
+template <class Scalar1, class Scalar2, class Scalar3>
+  requires(!Kokkos::is_view_v<Scalar1> && !Kokkos::is_view_v<Scalar2> && !KokkosBatched::is_vector<Scalar1>::value && !KokkosBatched::is_vector<Scalar2>::value)
 testing::AssertionResult expect_near_pred_format_scalar_rel(const char* expr1, const char* expr2, const char* expr_tol,
                                                             Scalar1 val1, Scalar2 val2, Scalar3 tol) {
   using AT1 = KokkosKernels::ArithTraits<Scalar1>;
@@ -163,8 +166,8 @@ testing::AssertionResult expect_near_pred_format_scalar_rel(
 }
 
 // Kokkos View specialization: element-wise relative comparison (rank-1 only)
-template <class View1, class View2, class Scalar3,
-          std::enable_if_t<Kokkos::is_view_v<View1> && Kokkos::is_view_v<View2>, int> = 0>
+template <class View1, class View2, class Scalar3>
+  requires(Kokkos::is_view_v<View1> && Kokkos::is_view_v<View2>)
 testing::AssertionResult expect_near_pred_format_scalar_rel(const char* expr1, const char* expr2, const char* expr_tol,
                                                             const View1& v1, const View2& v2, Scalar3 tol) {
   return expect_near_1dview_impl(expr1, expr2, v1, v2, [&](auto e1, auto e2) {

--- a/test_common/KokkosKernels_TestUtils.hpp
+++ b/test_common/KokkosKernels_TestUtils.hpp
@@ -84,12 +84,13 @@ testing::AssertionResult expect_near_pred_format_scalar(const char* expr1, const
   return overall;
 }
 
-// Kokkos View specialization: element-wise absolute comparison (rank-1 only)
-template <class View1, class View2, class Scalar3,
+// Helper: mirrors two rank-1 Views to host, then applies element_cmp(i, h_v1, h_v2) for each index,
+// collecting per-element failures into a single AssertionResult.
+template <class View1, class View2, class ElemCmp,
           std::enable_if_t<Kokkos::is_view_v<View1> && Kokkos::is_view_v<View2>, int> = 0>
-testing::AssertionResult expect_near_pred_format_scalar(const char* expr1, const char* expr2, const char* expr_tol, const View1& v1,
-                                          const View2& v2, Scalar3 tol) {
-  static_assert(View1::rank == 1, "expect_near_pred_format_scalar: only rank-1 Views are supported");
+testing::AssertionResult expect_near_1dview_impl(const char* expr1, const char* expr2,
+                                                 const View1& v1, const View2& v2, ElemCmp elem_cmp) {
+  static_assert(View1::rank == 1, "expect_near_1dview_impl: only rank-1 Views are supported");
   const size_t v1_size = v1.extent(0);
   if (v1_size != v2.extent(0)) {
     return testing::AssertionFailure() << expr1 << ".extent(0) (" << v1_size << ") != " << expr2 << ".extent(0) ("
@@ -101,13 +102,23 @@ testing::AssertionResult expect_near_pred_format_scalar(const char* expr1, const
   KokkosKernels::Impl::safe_device_to_host_deep_copy(v1_size, v2, h_v2);
   testing::AssertionResult overall = testing::AssertionSuccess();
   for (size_t i = 0; i < v1_size; ++i) {
-    auto r = expect_near_pred_format_scalar(expr1, expr2, expr_tol, h_v1(i), h_v2(i), tol);
+    auto r = elem_cmp(h_v1(i), h_v2(i));
     if (!r) {
       if (overall) overall = testing::AssertionFailure();
       overall << "[" << i << "] " << r.message();
     }
   }
   return overall;
+}
+
+// Kokkos View specialization: element-wise absolute comparison (rank-1 only)
+template <class View1, class View2, class Scalar3,
+          std::enable_if_t<Kokkos::is_view_v<View1> && Kokkos::is_view_v<View2>, int> = 0>
+testing::AssertionResult expect_near_pred_format_scalar(const char* expr1, const char* expr2, const char* expr_tol, const View1& v1,
+                                          const View2& v2, Scalar3 tol) {
+  return expect_near_1dview_impl(expr1, expr2, v1, v2, [&](auto e1, auto e2) {
+    return expect_near_pred_format_scalar(expr1, expr2, expr_tol, e1, e2, tol);
+  });
 }
 
 // Base case: scalar relative comparison — delegates to absolute with per-element tolerance
@@ -142,25 +153,9 @@ template <class View1, class View2, class Scalar3,
           std::enable_if_t<Kokkos::is_view_v<View1> && Kokkos::is_view_v<View2>, int> = 0>
 testing::AssertionResult expect_near_pred_format_scalar_rel(const char* expr1, const char* expr2, const char* expr_tol,
                                              const View1& v1, const View2& v2, Scalar3 tol) {
-  static_assert(View1::rank == 1, "expect_near_pred_format_scalar_rel: only rank-1 Views are supported");
-  const size_t v1_size = v1.extent(0);
-  if (v1_size != v2.extent(0)) {
-    return testing::AssertionFailure() << expr1 << ".extent(0) (" << v1_size << ") != " << expr2 << ".extent(0) ("
-                                       << v2.extent(0) << ")";
-  }
-  auto h_v1 = Kokkos::create_mirror_view(v1);
-  auto h_v2 = Kokkos::create_mirror_view(v2);
-  KokkosKernels::Impl::safe_device_to_host_deep_copy(v1_size, v1, h_v1);
-  KokkosKernels::Impl::safe_device_to_host_deep_copy(v1_size, v2, h_v2);
-  testing::AssertionResult overall = testing::AssertionSuccess();
-  for (size_t i = 0; i < v1_size; ++i) {
-    auto r = expect_near_pred_format_scalar_rel(expr1, expr2, expr_tol, h_v1(i), h_v2(i), tol);
-    if (!r) {
-      if (overall) overall = testing::AssertionFailure();
-      overall << "[" << i << "] " << r.message();
-    }
-  }
-  return overall;
+  return expect_near_1dview_impl(expr1, expr2, v1, v2, [&](auto e1, auto e2) {
+    return expect_near_pred_format_scalar_rel(expr1, expr2, expr_tol, e1, e2, tol);
+  });
 }
 
 }  // namespace Impl

--- a/test_common/KokkosKernels_TestUtils.hpp
+++ b/test_common/KokkosKernels_TestUtils.hpp
@@ -11,6 +11,7 @@
 // Make this include-able from all subdirectories
 #include "../tpls/gtest/gtest/gtest.h"  //for EXPECT_**
 
+#include <concepts>
 #include <random>
 #include <algorithm>
 #include <type_traits>

--- a/test_common/KokkosKernels_TestUtils.hpp
+++ b/test_common/KokkosKernels_TestUtils.hpp
@@ -174,13 +174,13 @@ testing::AssertionResult expect_near_pred_format_scalar_rel(const char* expr1, c
 // Checks |val1 - val2| <= |tol|. Works for scalars, rank-1 Kokkos Views, and SIMD vectors.
 // Expands to a GTest expression so callers can append a failure message.
 #define EXPECT_NEAR_KK(val1, val2, tol) \
-  EXPECT_TRUE(TestUtils::Impl::expect_near_pred_format_scalar(#val1, #val2, #tol, (val1), (val2), (tol)))
+  EXPECT_PRED_FORMAT3(TestUtils::Impl::expect_near_pred_format_scalar, val1, val2, tol)
 
 // Checks |val1 - val2| <= tol * max(|val1|, |val2|) per element.
 // Works for scalars, rank-1 Kokkos Views, and SIMD vectors.
 // Expands to a GTest expression; supports << for failure messages.
 #define EXPECT_NEAR_KK_REL(val1, val2, tol) \
-  EXPECT_TRUE(TestUtils::Impl::expect_near_pred_format_scalar_rel(#val1, #val2, #tol, (val1), (val2), (tol)))
+  EXPECT_PRED_FORMAT3(TestUtils::Impl::expect_near_pred_format_scalar_rel, val1, val2, tol)
 
 // Element-wise absolute comparison for rank-1 Kokkos Views.
 #define EXPECT_NEAR_KK_1DVIEW(v1, v2, tol) EXPECT_NEAR_KK(v1, v2, tol)

--- a/test_common/KokkosKernels_TestUtils.hpp
+++ b/test_common/KokkosKernels_TestUtils.hpp
@@ -84,8 +84,10 @@ testing::AssertionResult expect_near_pred_format_scalar(const char* expr1, const
   return overall;
 }
 
-// Helper: mirrors two rank-1 Views to host, then applies element_cmp(i, h_v1, h_v2) for each index,
-// collecting per-element failures into a single AssertionResult.
+static constexpr size_t ExpectNearMaxFailures = 10;
+
+// Helper: mirrors two rank-1 Views to host, then applies elem_cmp(h_v1(i), h_v2(i)) for each index,
+// collecting per-element failures into a single AssertionResult (capped at ExpectNearMaxFailures).
 template <class View1, class View2, class ElemCmp,
           std::enable_if_t<Kokkos::is_view_v<View1> && Kokkos::is_view_v<View2>, int> = 0>
 testing::AssertionResult expect_near_1dview_impl(const char* expr1, const char* expr2,
@@ -101,12 +103,21 @@ testing::AssertionResult expect_near_1dview_impl(const char* expr1, const char* 
   KokkosKernels::Impl::safe_device_to_host_deep_copy(v1_size, v1, h_v1);
   KokkosKernels::Impl::safe_device_to_host_deep_copy(v1_size, v2, h_v2);
   testing::AssertionResult overall = testing::AssertionSuccess();
+  size_t num_failures = 0;
   for (size_t i = 0; i < v1_size; ++i) {
     auto r = elem_cmp(h_v1(i), h_v2(i));
     if (!r) {
       if (overall) overall = testing::AssertionFailure();
-      overall << "[" << i << "] " << r.message();
+      if (num_failures < ExpectNearMaxFailures) {
+        overall << "[" << i << "] " << r.message();
+      } else if (num_failures == ExpectNearMaxFailures) {
+        overall << "(further failures suppressed)\n";
+      }
+      ++num_failures;
     }
+  }
+  if (num_failures > 0) {
+    overall << num_failures << " of " << v1_size << " element(s) failed.\n";
   }
   return overall;
 }

--- a/test_common/KokkosKernels_TestUtils.hpp
+++ b/test_common/KokkosKernels_TestUtils.hpp
@@ -46,40 +46,35 @@
 #endif
 
 namespace TestUtils {
+
 namespace Impl {
-
 template <class Scalar1, class Scalar2, class Scalar3>
-::testing::AssertionResult kk_expect_near_pred_format(const char* expr1, const char* expr2, const char* expr3,
-                                                      const Scalar1& val1, const Scalar2& val2, const Scalar3& tol) {
-  using scalar1_type = typename std::remove_cv<typename std::remove_reference<Scalar1>::type>::type;
-  using scalar3_type = typename std::remove_cv<typename std::remove_reference<Scalar3>::type>::type;
-  using AT1          = KokkosKernels::ArithTraits<scalar1_type>;
-  using AT3          = KokkosKernels::ArithTraits<scalar3_type>;
+testing::AssertionResult ExpectNearKKImpl(
+    const char* expr1, const char* expr2, const char* expr_tol,
+    Scalar1 val1, Scalar2 val2, Scalar3 tol)
+{
+    typedef KokkosKernels::ArithTraits<Scalar1> AT1;
+    typedef KokkosKernels::ArithTraits<Scalar3> AT3;
 
-  const double abs_diff = static_cast<double>(AT1::abs(val1 - val2));
-  const double abs_tol  = static_cast<double>(AT3::abs(tol));
+    double abs_diff = (double)AT1::abs(val1 - val2);
+    double abs_tol  = (double)AT3::abs(tol);
 
-  if (abs_diff <= abs_tol) {
-    return ::testing::AssertionSuccess();
-  }
+    if (abs_diff <= abs_tol) {
+        return testing::AssertionSuccess();
+    }
 
-  return ::testing::AssertionFailure() << "The difference between " << expr1 << " and " << expr2 << " is " << abs_diff
-                                       << ", which exceeds " << expr3 << ", where\n"
-                                       << expr1 << " evaluates to " << ::testing::PrintToString(val1) << ",\n"
-                                       << expr2 << " evaluates to " << ::testing::PrintToString(val2) << ", and\n"
-                                       << expr3 << " evaluates to " << ::testing::PrintToString(tol) << ".";
+    // Return a failure result and format the default message cleanly
+    return testing::AssertionFailure()
+        << "Expected: " << expr1 << " is near " << expr2 << " (within " << expr_tol << ")\n"
+        << "  Actual: " << abs_diff << "\n"
+        << "Expected: " << abs_tol << "\n";
 }
-
-}  // namespace Impl
-
-#define KK_EXPECT_NEAR(val1, val2, tol) \
-  EXPECT_PRED_FORMAT3(::TestUtils::Impl::kk_expect_near_pred_format, val1, val2, tol)
+}
 
 // Checks |val1 - val2| <= |tol|.  Expands to a GTest expression so callers
 // can append a failure message: EXPECT_NEAR_KK(a, b, eps) << "context";
 #define EXPECT_NEAR_KK(val1, val2, tol)                                                             \
-  EXPECT_LE((double)KokkosKernels::ArithTraits<std::decay_t<decltype(val1)>>::abs((val1) - (val2)), \
-            (double)KokkosKernels::ArithTraits<std::decay_t<decltype(tol)>>::abs(tol))
+  EXPECT_TRUE(ExpectNearKKImpl(#val1, #val2, #tol, (val1), (val2), (tol)))
 
 // Checks |val1 - val2| <= tol * max(|val1|, |val2|).
 // Expands to a GTest expression; supports << for failure messages.

--- a/test_common/KokkosKernels_TestUtils.hpp
+++ b/test_common/KokkosKernels_TestUtils.hpp
@@ -48,7 +48,11 @@
 namespace TestUtils {
 
 namespace Impl {
-template <class Scalar1, class Scalar2, class Scalar3>
+
+// Base case: scalar absolute comparison
+template <class Scalar1, class Scalar2, class Scalar3,
+          std::enable_if_t<!Kokkos::is_view_v<Scalar1> &&
+                           !KokkosBatched::is_vector<Scalar1>::value, int> = 0>
 testing::AssertionResult ExpectNearKKImpl(
     const char* expr1, const char* expr2, const char* expr_tol,
     Scalar1 val1, Scalar2 val2, Scalar3 tol)
@@ -59,53 +63,143 @@ testing::AssertionResult ExpectNearKKImpl(
     double abs_diff = (double)AT1::abs(val1 - val2);
     double abs_tol  = (double)AT3::abs(tol);
 
-    if (abs_diff <= abs_tol) {
+    if (abs_diff <= abs_tol)
         return testing::AssertionSuccess();
-    }
 
-    // Return a failure result and format the default message cleanly
     return testing::AssertionFailure()
         << "Expected: " << expr1 << " is near " << expr2 << " (within " << expr_tol << ")\n"
         << "  Actual: " << abs_diff << "\n"
         << "Expected: " << abs_tol << "\n";
 }
+
+// SIMD Vector specialization: element-wise absolute comparison across all lanes
+template <class T, int l, class Scalar3>
+testing::AssertionResult ExpectNearKKImpl(
+    const char* expr1, const char* expr2, const char* expr_tol,
+    const KokkosBatched::Vector<KokkosBatched::SIMD<T>, l>& val1,
+    const KokkosBatched::Vector<KokkosBatched::SIMD<T>, l>& val2,
+    Scalar3 tol)
+{
+    testing::AssertionResult overall = testing::AssertionSuccess();
+    for (int i = 0; i < l; ++i) {
+        auto r = ExpectNearKKImpl(expr1, expr2, expr_tol, val1[i], val2[i], tol);
+        if (!r) {
+            if (overall) overall = testing::AssertionFailure();
+            overall << "[lane " << i << "] " << r.message();
+        }
+    }
+    return overall;
 }
 
-// Checks |val1 - val2| <= |tol|.  Expands to a GTest expression so callers
-// can append a failure message: EXPECT_NEAR_KK(a, b, eps) << "context";
-#define EXPECT_NEAR_KK(val1, val2, tol)                                                             \
-  EXPECT_TRUE(ExpectNearKKImpl(#val1, #val2, #tol, (val1), (val2), (tol)))
+// Kokkos View specialization: element-wise absolute comparison (rank-1 only)
+template <class View1, class View2, class Scalar3,
+          std::enable_if_t<Kokkos::is_view_v<View1> && Kokkos::is_view_v<View2>, int> = 0>
+testing::AssertionResult ExpectNearKKImpl(
+    const char* expr1, const char* expr2, const char* expr_tol,
+    const View1& v1, const View2& v2, Scalar3 tol)
+{
+    static_assert(View1::rank == 1, "ExpectNearKKImpl: only rank-1 Views are supported");
+    const size_t v1_size = v1.extent(0);
+    if (v1_size != v2.extent(0)) {
+        return testing::AssertionFailure()
+            << expr1 << ".extent(0) (" << v1_size << ") != "
+            << expr2 << ".extent(0) (" << v2.extent(0) << ")";
+    }
+    auto h_v1 = Kokkos::create_mirror_view(v1);
+    auto h_v2 = Kokkos::create_mirror_view(v2);
+    KokkosKernels::Impl::safe_device_to_host_deep_copy(v1_size, v1, h_v1);
+    KokkosKernels::Impl::safe_device_to_host_deep_copy(v1_size, v2, h_v2);
+    testing::AssertionResult overall = testing::AssertionSuccess();
+    for (size_t i = 0; i < v1_size; ++i) {
+        auto r = ExpectNearKKImpl(expr1, expr2, expr_tol, h_v1(i), h_v2(i), tol);
+        if (!r) {
+            if (overall) overall = testing::AssertionFailure();
+            overall << "[" << i << "] " << r.message();
+        }
+    }
+    return overall;
+}
 
-// Checks |val1 - val2| <= tol * max(|val1|, |val2|).
+// Base case: scalar relative comparison — delegates to absolute with per-element tolerance
+template <class Scalar1, class Scalar2, class Scalar3,
+          std::enable_if_t<!Kokkos::is_view_v<Scalar1> &&
+                           !KokkosBatched::is_vector<Scalar1>::value, int> = 0>
+testing::AssertionResult ExpectNearKKRelImpl(
+    const char* expr1, const char* expr2, const char* expr_tol,
+    Scalar1 val1, Scalar2 val2, Scalar3 tol)
+{
+    using AT1 = KokkosKernels::ArithTraits<Scalar1>;
+    using AT2 = KokkosKernels::ArithTraits<Scalar2>;
+    return ExpectNearKKImpl(expr1, expr2, expr_tol, val1, val2,
+                            tol * Kokkos::max(AT1::abs(val1), AT2::abs(val2)));
+}
+
+// SIMD Vector specialization: element-wise relative comparison across all lanes
+template <class T, int l, class Scalar3>
+testing::AssertionResult ExpectNearKKRelImpl(
+    const char* expr1, const char* expr2, const char* expr_tol,
+    const KokkosBatched::Vector<KokkosBatched::SIMD<T>, l>& val1,
+    const KokkosBatched::Vector<KokkosBatched::SIMD<T>, l>& val2,
+    Scalar3 tol)
+{
+    testing::AssertionResult overall = testing::AssertionSuccess();
+    for (int i = 0; i < l; ++i) {
+        auto r = ExpectNearKKRelImpl(expr1, expr2, expr_tol, val1[i], val2[i], tol);
+        if (!r) {
+            if (overall) overall = testing::AssertionFailure();
+            overall << "[lane " << i << "] " << r.message();
+        }
+    }
+    return overall;
+}
+
+// Kokkos View specialization: element-wise relative comparison (rank-1 only)
+template <class View1, class View2, class Scalar3,
+          std::enable_if_t<Kokkos::is_view_v<View1> && Kokkos::is_view_v<View2>, int> = 0>
+testing::AssertionResult ExpectNearKKRelImpl(
+    const char* expr1, const char* expr2, const char* expr_tol,
+    const View1& v1, const View2& v2, Scalar3 tol)
+{
+    static_assert(View1::rank == 1, "ExpectNearKKRelImpl: only rank-1 Views are supported");
+    const size_t v1_size = v1.extent(0);
+    if (v1_size != v2.extent(0)) {
+        return testing::AssertionFailure()
+            << expr1 << ".extent(0) (" << v1_size << ") != "
+            << expr2 << ".extent(0) (" << v2.extent(0) << ")";
+    }
+    auto h_v1 = Kokkos::create_mirror_view(v1);
+    auto h_v2 = Kokkos::create_mirror_view(v2);
+    KokkosKernels::Impl::safe_device_to_host_deep_copy(v1_size, v1, h_v1);
+    KokkosKernels::Impl::safe_device_to_host_deep_copy(v1_size, v2, h_v2);
+    testing::AssertionResult overall = testing::AssertionSuccess();
+    for (size_t i = 0; i < v1_size; ++i) {
+        auto r = ExpectNearKKRelImpl(expr1, expr2, expr_tol, h_v1(i), h_v2(i), tol);
+        if (!r) {
+            if (overall) overall = testing::AssertionFailure();
+            overall << "[" << i << "] " << r.message();
+        }
+    }
+    return overall;
+}
+
+}  // namespace Impl
+
+// Checks |val1 - val2| <= |tol|. Works for scalars, rank-1 Kokkos Views, and SIMD vectors.
+// Expands to a GTest expression so callers can append a failure message.
+#define EXPECT_NEAR_KK(val1, val2, tol) \
+  EXPECT_TRUE(TestUtils::Impl::ExpectNearKKImpl(#val1, #val2, #tol, (val1), (val2), (tol)))
+
+// Checks |val1 - val2| <= tol * max(|val1|, |val2|) per element.
+// Works for scalars, rank-1 Kokkos Views, and SIMD vectors.
 // Expands to a GTest expression; supports << for failure messages.
-#define EXPECT_NEAR_KK_REL(val1, val2, tol)                                                             \
-  EXPECT_NEAR_KK(val1, val2,                                                                            \
-                 (tol)*Kokkos::max(KokkosKernels::ArithTraits<std::decay_t<decltype(val1)>>::abs(val1), \
-                                   KokkosKernels::ArithTraits<std::decay_t<decltype(val2)>>::abs(val2)))
+#define EXPECT_NEAR_KK_REL(val1, val2, tol) \
+  EXPECT_TRUE(TestUtils::Impl::ExpectNearKKRelImpl(#val1, #val2, #tol, (val1), (val2), (tol)))
 
-// Checks element-wise |v1(i) - v2(i)| <= |tol| for every index i.
-#define EXPECT_NEAR_KK_1DVIEW(v1, v2, tol)                                                                      \
-  do {                                                                                                          \
-    const size_t _kk_v1_size = (v1).extent(0);                                                                  \
-    EXPECT_EQ(_kk_v1_size, (v2).extent(0));                                                                     \
-    auto _kk_h_v1 = Kokkos::create_mirror_view(v1);                                                             \
-    auto _kk_h_v2 = Kokkos::create_mirror_view(v2);                                                             \
-    KokkosKernels::Impl::safe_device_to_host_deep_copy(_kk_v1_size, v1, _kk_h_v1);                              \
-    KokkosKernels::Impl::safe_device_to_host_deep_copy(_kk_v1_size, v2, _kk_h_v2);                              \
-    for (size_t _kk_i = 0; _kk_i < _kk_v1_size; ++_kk_i) EXPECT_NEAR_KK(_kk_h_v1(_kk_i), _kk_h_v2(_kk_i), tol); \
-  } while (false)
+// Element-wise absolute comparison for rank-1 Kokkos Views.
+#define EXPECT_NEAR_KK_1DVIEW(v1, v2, tol) EXPECT_NEAR_KK(v1, v2, tol)
 
-// Checks element-wise relative tolerance for every index i.
-#define EXPECT_NEAR_KK_REL_1DVIEW(v1, v2, tol)                                                                      \
-  do {                                                                                                              \
-    const size_t _kk_v1_size = (v1).extent(0);                                                                      \
-    EXPECT_EQ(_kk_v1_size, (v2).extent(0));                                                                         \
-    auto _kk_h_v1 = Kokkos::create_mirror_view(v1);                                                                 \
-    auto _kk_h_v2 = Kokkos::create_mirror_view(v2);                                                                 \
-    KokkosKernels::Impl::safe_device_to_host_deep_copy(_kk_v1_size, v1, _kk_h_v1);                                  \
-    KokkosKernels::Impl::safe_device_to_host_deep_copy(_kk_v1_size, v2, _kk_h_v2);                                  \
-    for (size_t _kk_i = 0; _kk_i < _kk_v1_size; ++_kk_i) EXPECT_NEAR_KK_REL(_kk_h_v1(_kk_i), _kk_h_v2(_kk_i), tol); \
-  } while (false)
+// Element-wise relative comparison for rank-1 Kokkos Views.
+#define EXPECT_NEAR_KK_REL_1DVIEW(v1, v2, tol) EXPECT_NEAR_KK_REL(v1, v2, tol)
 
 // Utility class for testing kernels with rank-1 and rank-2 views that may be
 // LayoutStride. Simplifies making a LayoutStride view of a given size that is

--- a/test_common/KokkosKernels_TestUtils.hpp
+++ b/test_common/KokkosKernels_TestUtils.hpp
@@ -52,7 +52,8 @@ namespace Impl {
 
 // Base case: scalar absolute comparison
 template <class Scalar1, class Scalar2, class Scalar3>
-  requires(!Kokkos::is_view_v<Scalar1> && !Kokkos::is_view_v<Scalar2> && !KokkosBatched::is_vector<Scalar1>::value && !KokkosBatched::is_vector<Scalar2>::value)
+  requires(!Kokkos::is_view_v<Scalar1> && !Kokkos::is_view_v<Scalar2> && !KokkosBatched::is_vector<Scalar1>::value &&
+           !KokkosBatched::is_vector<Scalar2>::value)
 testing::AssertionResult expect_near_pred_format_scalar(const char* expr1, const char* expr2, const char* expr_tol,
                                                         Scalar1 val1, Scalar2 val2, Scalar3 tol) {
   using AT1 = KokkosKernels::ArithTraits<Scalar1>;
@@ -63,12 +64,12 @@ testing::AssertionResult expect_near_pred_format_scalar(const char* expr1, const
 
   if (abs_diff <= abs_tol) return testing::AssertionSuccess();
 
-return testing::AssertionFailure()
-<< "Expected: " << expr1 << " is near " << expr2 << " (within " << expr_tol << ")\n"
-<< "  " << expr1 << " evaluates to " << testing::PrintToString(val1) << "\n"
-<< "  " << expr2 << " evaluates to " << testing::PrintToString(val2) << "\n"
-<< "  Difference: " << abs_diff << "\n"
-<< "  Tolerance: " << abs_tol << "\n";
+  return testing::AssertionFailure() << "Expected: " << expr1 << " is near " << expr2 << " (within " << expr_tol
+                                     << ")\n"
+                                     << "  " << expr1 << " evaluates to " << testing::PrintToString(val1) << "\n"
+                                     << "  " << expr2 << " evaluates to " << testing::PrintToString(val2) << "\n"
+                                     << "  Difference: " << abs_diff << "\n"
+                                     << "  Tolerance: " << abs_tol << "\n";
 }
 
 // SIMD Vector specialization: element-wise absolute comparison across all lanes
@@ -139,7 +140,8 @@ testing::AssertionResult expect_near_pred_format_scalar(const char* expr1, const
 
 // Base case: scalar relative comparison — delegates to absolute with per-element tolerance
 template <class Scalar1, class Scalar2, class Scalar3>
-  requires(!Kokkos::is_view_v<Scalar1> && !Kokkos::is_view_v<Scalar2> && !KokkosBatched::is_vector<Scalar1>::value && !KokkosBatched::is_vector<Scalar2>::value)
+  requires(!Kokkos::is_view_v<Scalar1> && !Kokkos::is_view_v<Scalar2> && !KokkosBatched::is_vector<Scalar1>::value &&
+           !KokkosBatched::is_vector<Scalar2>::value)
 testing::AssertionResult expect_near_pred_format_scalar_rel(const char* expr1, const char* expr2, const char* expr_tol,
                                                             Scalar1 val1, Scalar2 val2, Scalar3 tol) {
   using AT1 = KokkosKernels::ArithTraits<Scalar1>;

--- a/test_common/KokkosKernels_TestUtils.hpp
+++ b/test_common/KokkosKernels_TestUtils.hpp
@@ -52,8 +52,8 @@ namespace Impl {
 // Base case: scalar absolute comparison
 template <class Scalar1, class Scalar2, class Scalar3,
           std::enable_if_t<!Kokkos::is_view_v<Scalar1> && !KokkosBatched::is_vector<Scalar1>::value, int> = 0>
-testing::AssertionResult expect_near_pred_format_scalar(const char* expr1, const char* expr2, const char* expr_tol, Scalar1 val1,
-                                          Scalar2 val2, Scalar3 tol) {
+testing::AssertionResult expect_near_pred_format_scalar(const char* expr1, const char* expr2, const char* expr_tol,
+                                                        Scalar1 val1, Scalar2 val2, Scalar3 tol) {
   typedef KokkosKernels::ArithTraits<Scalar1> AT1;
   typedef KokkosKernels::ArithTraits<Scalar3> AT3;
 
@@ -71,8 +71,9 @@ testing::AssertionResult expect_near_pred_format_scalar(const char* expr1, const
 // SIMD Vector specialization: element-wise absolute comparison across all lanes
 template <class T, int l, class Scalar3>
 testing::AssertionResult expect_near_pred_format_scalar(const char* expr1, const char* expr2, const char* expr_tol,
-                                          const KokkosBatched::Vector<KokkosBatched::SIMD<T>, l>& val1,
-                                          const KokkosBatched::Vector<KokkosBatched::SIMD<T>, l>& val2, Scalar3 tol) {
+                                                        const KokkosBatched::Vector<KokkosBatched::SIMD<T>, l>& val1,
+                                                        const KokkosBatched::Vector<KokkosBatched::SIMD<T>, l>& val2,
+                                                        Scalar3 tol) {
   testing::AssertionResult overall = testing::AssertionSuccess();
   for (int i = 0; i < l; ++i) {
     auto r = expect_near_pred_format_scalar(expr1, expr2, expr_tol, val1[i], val2[i], tol);
@@ -90,8 +91,8 @@ static constexpr size_t ExpectNearMaxFailures = 10;
 // collecting per-element failures into a single AssertionResult (capped at ExpectNearMaxFailures).
 template <class View1, class View2, class ElemCmp,
           std::enable_if_t<Kokkos::is_view_v<View1> && Kokkos::is_view_v<View2>, int> = 0>
-testing::AssertionResult expect_near_1dview_impl(const char* expr1, const char* expr2,
-                                                 const View1& v1, const View2& v2, ElemCmp elem_cmp) {
+testing::AssertionResult expect_near_1dview_impl(const char* expr1, const char* expr2, const View1& v1, const View2& v2,
+                                                 ElemCmp elem_cmp) {
   static_assert(View1::rank == 1, "expect_near_1dview_impl: only rank-1 Views are supported");
   const size_t v1_size = v1.extent(0);
   if (v1_size != v2.extent(0)) {
@@ -103,7 +104,7 @@ testing::AssertionResult expect_near_1dview_impl(const char* expr1, const char* 
   KokkosKernels::Impl::safe_device_to_host_deep_copy(v1_size, v1, h_v1);
   KokkosKernels::Impl::safe_device_to_host_deep_copy(v1_size, v2, h_v2);
   testing::AssertionResult overall = testing::AssertionSuccess();
-  size_t num_failures = 0;
+  size_t num_failures              = 0;
   for (size_t i = 0; i < v1_size; ++i) {
     auto r = elem_cmp(h_v1(i), h_v2(i));
     if (!r) {
@@ -125,8 +126,8 @@ testing::AssertionResult expect_near_1dview_impl(const char* expr1, const char* 
 // Kokkos View specialization: element-wise absolute comparison (rank-1 only)
 template <class View1, class View2, class Scalar3,
           std::enable_if_t<Kokkos::is_view_v<View1> && Kokkos::is_view_v<View2>, int> = 0>
-testing::AssertionResult expect_near_pred_format_scalar(const char* expr1, const char* expr2, const char* expr_tol, const View1& v1,
-                                          const View2& v2, Scalar3 tol) {
+testing::AssertionResult expect_near_pred_format_scalar(const char* expr1, const char* expr2, const char* expr_tol,
+                                                        const View1& v1, const View2& v2, Scalar3 tol) {
   return expect_near_1dview_impl(expr1, expr2, v1, v2, [&](auto e1, auto e2) {
     return expect_near_pred_format_scalar(expr1, expr2, expr_tol, e1, e2, tol);
   });
@@ -135,19 +136,20 @@ testing::AssertionResult expect_near_pred_format_scalar(const char* expr1, const
 // Base case: scalar relative comparison — delegates to absolute with per-element tolerance
 template <class Scalar1, class Scalar2, class Scalar3,
           std::enable_if_t<!Kokkos::is_view_v<Scalar1> && !KokkosBatched::is_vector<Scalar1>::value, int> = 0>
-testing::AssertionResult expect_near_pred_format_scalar_rel(const char* expr1, const char* expr2, const char* expr_tol, Scalar1 val1,
-                                             Scalar2 val2, Scalar3 tol) {
+testing::AssertionResult expect_near_pred_format_scalar_rel(const char* expr1, const char* expr2, const char* expr_tol,
+                                                            Scalar1 val1, Scalar2 val2, Scalar3 tol) {
   using AT1 = KokkosKernels::ArithTraits<Scalar1>;
   using AT2 = KokkosKernels::ArithTraits<Scalar2>;
-  return expect_near_pred_format_scalar(expr1, expr2, expr_tol, val1, val2, tol * Kokkos::max(AT1::abs(val1), AT2::abs(val2)));
+  return expect_near_pred_format_scalar(expr1, expr2, expr_tol, val1, val2,
+                                        tol * Kokkos::max(AT1::abs(val1), AT2::abs(val2)));
 }
 
 // SIMD Vector specialization: element-wise relative comparison across all lanes
 template <class T, int l, class Scalar3>
-testing::AssertionResult expect_near_pred_format_scalar_rel(const char* expr1, const char* expr2, const char* expr_tol,
-                                             const KokkosBatched::Vector<KokkosBatched::SIMD<T>, l>& val1,
-                                             const KokkosBatched::Vector<KokkosBatched::SIMD<T>, l>& val2,
-                                             Scalar3 tol) {
+testing::AssertionResult expect_near_pred_format_scalar_rel(
+    const char* expr1, const char* expr2, const char* expr_tol,
+    const KokkosBatched::Vector<KokkosBatched::SIMD<T>, l>& val1,
+    const KokkosBatched::Vector<KokkosBatched::SIMD<T>, l>& val2, Scalar3 tol) {
   testing::AssertionResult overall = testing::AssertionSuccess();
   for (int i = 0; i < l; ++i) {
     auto r = expect_near_pred_format_scalar_rel(expr1, expr2, expr_tol, val1[i], val2[i], tol);
@@ -163,7 +165,7 @@ testing::AssertionResult expect_near_pred_format_scalar_rel(const char* expr1, c
 template <class View1, class View2, class Scalar3,
           std::enable_if_t<Kokkos::is_view_v<View1> && Kokkos::is_view_v<View2>, int> = 0>
 testing::AssertionResult expect_near_pred_format_scalar_rel(const char* expr1, const char* expr2, const char* expr_tol,
-                                             const View1& v1, const View2& v2, Scalar3 tol) {
+                                                            const View1& v1, const View2& v2, Scalar3 tol) {
   return expect_near_1dview_impl(expr1, expr2, v1, v2, [&](auto e1, auto e2) {
     return expect_near_pred_format_scalar_rel(expr1, expr2, expr_tol, e1, e2, tol);
   });

--- a/test_common/KokkosKernels_TestUtils.hpp
+++ b/test_common/KokkosKernels_TestUtils.hpp
@@ -52,7 +52,7 @@ namespace Impl {
 // Base case: scalar absolute comparison
 template <class Scalar1, class Scalar2, class Scalar3,
           std::enable_if_t<!Kokkos::is_view_v<Scalar1> && !KokkosBatched::is_vector<Scalar1>::value, int> = 0>
-testing::AssertionResult ExpectNearKKImpl(const char* expr1, const char* expr2, const char* expr_tol, Scalar1 val1,
+testing::AssertionResult expect_near_pred_format_scalar(const char* expr1, const char* expr2, const char* expr_tol, Scalar1 val1,
                                           Scalar2 val2, Scalar3 tol) {
   typedef KokkosKernels::ArithTraits<Scalar1> AT1;
   typedef KokkosKernels::ArithTraits<Scalar3> AT3;
@@ -70,12 +70,12 @@ testing::AssertionResult ExpectNearKKImpl(const char* expr1, const char* expr2, 
 
 // SIMD Vector specialization: element-wise absolute comparison across all lanes
 template <class T, int l, class Scalar3>
-testing::AssertionResult ExpectNearKKImpl(const char* expr1, const char* expr2, const char* expr_tol,
+testing::AssertionResult expect_near_pred_format_scalar(const char* expr1, const char* expr2, const char* expr_tol,
                                           const KokkosBatched::Vector<KokkosBatched::SIMD<T>, l>& val1,
                                           const KokkosBatched::Vector<KokkosBatched::SIMD<T>, l>& val2, Scalar3 tol) {
   testing::AssertionResult overall = testing::AssertionSuccess();
   for (int i = 0; i < l; ++i) {
-    auto r = ExpectNearKKImpl(expr1, expr2, expr_tol, val1[i], val2[i], tol);
+    auto r = expect_near_pred_format_scalar(expr1, expr2, expr_tol, val1[i], val2[i], tol);
     if (!r) {
       if (overall) overall = testing::AssertionFailure();
       overall << "[lane " << i << "] " << r.message();
@@ -87,9 +87,9 @@ testing::AssertionResult ExpectNearKKImpl(const char* expr1, const char* expr2, 
 // Kokkos View specialization: element-wise absolute comparison (rank-1 only)
 template <class View1, class View2, class Scalar3,
           std::enable_if_t<Kokkos::is_view_v<View1> && Kokkos::is_view_v<View2>, int> = 0>
-testing::AssertionResult ExpectNearKKImpl(const char* expr1, const char* expr2, const char* expr_tol, const View1& v1,
+testing::AssertionResult expect_near_pred_format_scalar(const char* expr1, const char* expr2, const char* expr_tol, const View1& v1,
                                           const View2& v2, Scalar3 tol) {
-  static_assert(View1::rank == 1, "ExpectNearKKImpl: only rank-1 Views are supported");
+  static_assert(View1::rank == 1, "expect_near_pred_format_scalar: only rank-1 Views are supported");
   const size_t v1_size = v1.extent(0);
   if (v1_size != v2.extent(0)) {
     return testing::AssertionFailure() << expr1 << ".extent(0) (" << v1_size << ") != " << expr2 << ".extent(0) ("
@@ -101,7 +101,7 @@ testing::AssertionResult ExpectNearKKImpl(const char* expr1, const char* expr2, 
   KokkosKernels::Impl::safe_device_to_host_deep_copy(v1_size, v2, h_v2);
   testing::AssertionResult overall = testing::AssertionSuccess();
   for (size_t i = 0; i < v1_size; ++i) {
-    auto r = ExpectNearKKImpl(expr1, expr2, expr_tol, h_v1(i), h_v2(i), tol);
+    auto r = expect_near_pred_format_scalar(expr1, expr2, expr_tol, h_v1(i), h_v2(i), tol);
     if (!r) {
       if (overall) overall = testing::AssertionFailure();
       overall << "[" << i << "] " << r.message();
@@ -113,22 +113,22 @@ testing::AssertionResult ExpectNearKKImpl(const char* expr1, const char* expr2, 
 // Base case: scalar relative comparison — delegates to absolute with per-element tolerance
 template <class Scalar1, class Scalar2, class Scalar3,
           std::enable_if_t<!Kokkos::is_view_v<Scalar1> && !KokkosBatched::is_vector<Scalar1>::value, int> = 0>
-testing::AssertionResult ExpectNearKKRelImpl(const char* expr1, const char* expr2, const char* expr_tol, Scalar1 val1,
+testing::AssertionResult expect_near_pred_format_scalar_rel(const char* expr1, const char* expr2, const char* expr_tol, Scalar1 val1,
                                              Scalar2 val2, Scalar3 tol) {
   using AT1 = KokkosKernels::ArithTraits<Scalar1>;
   using AT2 = KokkosKernels::ArithTraits<Scalar2>;
-  return ExpectNearKKImpl(expr1, expr2, expr_tol, val1, val2, tol * Kokkos::max(AT1::abs(val1), AT2::abs(val2)));
+  return expect_near_pred_format_scalar(expr1, expr2, expr_tol, val1, val2, tol * Kokkos::max(AT1::abs(val1), AT2::abs(val2)));
 }
 
 // SIMD Vector specialization: element-wise relative comparison across all lanes
 template <class T, int l, class Scalar3>
-testing::AssertionResult ExpectNearKKRelImpl(const char* expr1, const char* expr2, const char* expr_tol,
+testing::AssertionResult expect_near_pred_format_scalar_rel(const char* expr1, const char* expr2, const char* expr_tol,
                                              const KokkosBatched::Vector<KokkosBatched::SIMD<T>, l>& val1,
                                              const KokkosBatched::Vector<KokkosBatched::SIMD<T>, l>& val2,
                                              Scalar3 tol) {
   testing::AssertionResult overall = testing::AssertionSuccess();
   for (int i = 0; i < l; ++i) {
-    auto r = ExpectNearKKRelImpl(expr1, expr2, expr_tol, val1[i], val2[i], tol);
+    auto r = expect_near_pred_format_scalar_rel(expr1, expr2, expr_tol, val1[i], val2[i], tol);
     if (!r) {
       if (overall) overall = testing::AssertionFailure();
       overall << "[lane " << i << "] " << r.message();
@@ -140,9 +140,9 @@ testing::AssertionResult ExpectNearKKRelImpl(const char* expr1, const char* expr
 // Kokkos View specialization: element-wise relative comparison (rank-1 only)
 template <class View1, class View2, class Scalar3,
           std::enable_if_t<Kokkos::is_view_v<View1> && Kokkos::is_view_v<View2>, int> = 0>
-testing::AssertionResult ExpectNearKKRelImpl(const char* expr1, const char* expr2, const char* expr_tol,
+testing::AssertionResult expect_near_pred_format_scalar_rel(const char* expr1, const char* expr2, const char* expr_tol,
                                              const View1& v1, const View2& v2, Scalar3 tol) {
-  static_assert(View1::rank == 1, "ExpectNearKKRelImpl: only rank-1 Views are supported");
+  static_assert(View1::rank == 1, "expect_near_pred_format_scalar_rel: only rank-1 Views are supported");
   const size_t v1_size = v1.extent(0);
   if (v1_size != v2.extent(0)) {
     return testing::AssertionFailure() << expr1 << ".extent(0) (" << v1_size << ") != " << expr2 << ".extent(0) ("
@@ -154,7 +154,7 @@ testing::AssertionResult ExpectNearKKRelImpl(const char* expr1, const char* expr
   KokkosKernels::Impl::safe_device_to_host_deep_copy(v1_size, v2, h_v2);
   testing::AssertionResult overall = testing::AssertionSuccess();
   for (size_t i = 0; i < v1_size; ++i) {
-    auto r = ExpectNearKKRelImpl(expr1, expr2, expr_tol, h_v1(i), h_v2(i), tol);
+    auto r = expect_near_pred_format_scalar_rel(expr1, expr2, expr_tol, h_v1(i), h_v2(i), tol);
     if (!r) {
       if (overall) overall = testing::AssertionFailure();
       overall << "[" << i << "] " << r.message();
@@ -168,13 +168,13 @@ testing::AssertionResult ExpectNearKKRelImpl(const char* expr1, const char* expr
 // Checks |val1 - val2| <= |tol|. Works for scalars, rank-1 Kokkos Views, and SIMD vectors.
 // Expands to a GTest expression so callers can append a failure message.
 #define EXPECT_NEAR_KK(val1, val2, tol) \
-  EXPECT_TRUE(TestUtils::Impl::ExpectNearKKImpl(#val1, #val2, #tol, (val1), (val2), (tol)))
+  EXPECT_TRUE(TestUtils::Impl::expect_near_pred_format_scalar(#val1, #val2, #tol, (val1), (val2), (tol)))
 
 // Checks |val1 - val2| <= tol * max(|val1|, |val2|) per element.
 // Works for scalars, rank-1 Kokkos Views, and SIMD vectors.
 // Expands to a GTest expression; supports << for failure messages.
 #define EXPECT_NEAR_KK_REL(val1, val2, tol) \
-  EXPECT_TRUE(TestUtils::Impl::ExpectNearKKRelImpl(#val1, #val2, #tol, (val1), (val2), (tol)))
+  EXPECT_TRUE(TestUtils::Impl::expect_near_pred_format_scalar_rel(#val1, #val2, #tol, (val1), (val2), (tol)))
 
 // Element-wise absolute comparison for rank-1 Kokkos Views.
 #define EXPECT_NEAR_KK_1DVIEW(v1, v2, tol) EXPECT_NEAR_KK(v1, v2, tol)

--- a/test_common/KokkosKernels_TestUtils.hpp
+++ b/test_common/KokkosKernels_TestUtils.hpp
@@ -51,135 +51,116 @@ namespace Impl {
 
 // Base case: scalar absolute comparison
 template <class Scalar1, class Scalar2, class Scalar3,
-          std::enable_if_t<!Kokkos::is_view_v<Scalar1> &&
-                           !KokkosBatched::is_vector<Scalar1>::value, int> = 0>
-testing::AssertionResult ExpectNearKKImpl(
-    const char* expr1, const char* expr2, const char* expr_tol,
-    Scalar1 val1, Scalar2 val2, Scalar3 tol)
-{
-    typedef KokkosKernels::ArithTraits<Scalar1> AT1;
-    typedef KokkosKernels::ArithTraits<Scalar3> AT3;
+          std::enable_if_t<!Kokkos::is_view_v<Scalar1> && !KokkosBatched::is_vector<Scalar1>::value, int> = 0>
+testing::AssertionResult ExpectNearKKImpl(const char* expr1, const char* expr2, const char* expr_tol, Scalar1 val1,
+                                          Scalar2 val2, Scalar3 tol) {
+  typedef KokkosKernels::ArithTraits<Scalar1> AT1;
+  typedef KokkosKernels::ArithTraits<Scalar3> AT3;
 
-    double abs_diff = (double)AT1::abs(val1 - val2);
-    double abs_tol  = (double)AT3::abs(tol);
+  double abs_diff = (double)AT1::abs(val1 - val2);
+  double abs_tol  = (double)AT3::abs(tol);
 
-    if (abs_diff <= abs_tol)
-        return testing::AssertionSuccess();
+  if (abs_diff <= abs_tol) return testing::AssertionSuccess();
 
-    return testing::AssertionFailure()
-        << "Expected: " << expr1 << " is near " << expr2 << " (within " << expr_tol << ")\n"
-        << "  Actual: " << abs_diff << "\n"
-        << "Expected: " << abs_tol << "\n";
+  return testing::AssertionFailure() << "Expected: " << expr1 << " is near " << expr2 << " (within " << expr_tol
+                                     << ")\n"
+                                     << "  Actual: " << abs_diff << "\n"
+                                     << "Expected: " << abs_tol << "\n";
 }
 
 // SIMD Vector specialization: element-wise absolute comparison across all lanes
 template <class T, int l, class Scalar3>
-testing::AssertionResult ExpectNearKKImpl(
-    const char* expr1, const char* expr2, const char* expr_tol,
-    const KokkosBatched::Vector<KokkosBatched::SIMD<T>, l>& val1,
-    const KokkosBatched::Vector<KokkosBatched::SIMD<T>, l>& val2,
-    Scalar3 tol)
-{
-    testing::AssertionResult overall = testing::AssertionSuccess();
-    for (int i = 0; i < l; ++i) {
-        auto r = ExpectNearKKImpl(expr1, expr2, expr_tol, val1[i], val2[i], tol);
-        if (!r) {
-            if (overall) overall = testing::AssertionFailure();
-            overall << "[lane " << i << "] " << r.message();
-        }
+testing::AssertionResult ExpectNearKKImpl(const char* expr1, const char* expr2, const char* expr_tol,
+                                          const KokkosBatched::Vector<KokkosBatched::SIMD<T>, l>& val1,
+                                          const KokkosBatched::Vector<KokkosBatched::SIMD<T>, l>& val2, Scalar3 tol) {
+  testing::AssertionResult overall = testing::AssertionSuccess();
+  for (int i = 0; i < l; ++i) {
+    auto r = ExpectNearKKImpl(expr1, expr2, expr_tol, val1[i], val2[i], tol);
+    if (!r) {
+      if (overall) overall = testing::AssertionFailure();
+      overall << "[lane " << i << "] " << r.message();
     }
-    return overall;
+  }
+  return overall;
 }
 
 // Kokkos View specialization: element-wise absolute comparison (rank-1 only)
 template <class View1, class View2, class Scalar3,
           std::enable_if_t<Kokkos::is_view_v<View1> && Kokkos::is_view_v<View2>, int> = 0>
-testing::AssertionResult ExpectNearKKImpl(
-    const char* expr1, const char* expr2, const char* expr_tol,
-    const View1& v1, const View2& v2, Scalar3 tol)
-{
-    static_assert(View1::rank == 1, "ExpectNearKKImpl: only rank-1 Views are supported");
-    const size_t v1_size = v1.extent(0);
-    if (v1_size != v2.extent(0)) {
-        return testing::AssertionFailure()
-            << expr1 << ".extent(0) (" << v1_size << ") != "
-            << expr2 << ".extent(0) (" << v2.extent(0) << ")";
+testing::AssertionResult ExpectNearKKImpl(const char* expr1, const char* expr2, const char* expr_tol, const View1& v1,
+                                          const View2& v2, Scalar3 tol) {
+  static_assert(View1::rank == 1, "ExpectNearKKImpl: only rank-1 Views are supported");
+  const size_t v1_size = v1.extent(0);
+  if (v1_size != v2.extent(0)) {
+    return testing::AssertionFailure() << expr1 << ".extent(0) (" << v1_size << ") != " << expr2 << ".extent(0) ("
+                                       << v2.extent(0) << ")";
+  }
+  auto h_v1 = Kokkos::create_mirror_view(v1);
+  auto h_v2 = Kokkos::create_mirror_view(v2);
+  KokkosKernels::Impl::safe_device_to_host_deep_copy(v1_size, v1, h_v1);
+  KokkosKernels::Impl::safe_device_to_host_deep_copy(v1_size, v2, h_v2);
+  testing::AssertionResult overall = testing::AssertionSuccess();
+  for (size_t i = 0; i < v1_size; ++i) {
+    auto r = ExpectNearKKImpl(expr1, expr2, expr_tol, h_v1(i), h_v2(i), tol);
+    if (!r) {
+      if (overall) overall = testing::AssertionFailure();
+      overall << "[" << i << "] " << r.message();
     }
-    auto h_v1 = Kokkos::create_mirror_view(v1);
-    auto h_v2 = Kokkos::create_mirror_view(v2);
-    KokkosKernels::Impl::safe_device_to_host_deep_copy(v1_size, v1, h_v1);
-    KokkosKernels::Impl::safe_device_to_host_deep_copy(v1_size, v2, h_v2);
-    testing::AssertionResult overall = testing::AssertionSuccess();
-    for (size_t i = 0; i < v1_size; ++i) {
-        auto r = ExpectNearKKImpl(expr1, expr2, expr_tol, h_v1(i), h_v2(i), tol);
-        if (!r) {
-            if (overall) overall = testing::AssertionFailure();
-            overall << "[" << i << "] " << r.message();
-        }
-    }
-    return overall;
+  }
+  return overall;
 }
 
 // Base case: scalar relative comparison — delegates to absolute with per-element tolerance
 template <class Scalar1, class Scalar2, class Scalar3,
-          std::enable_if_t<!Kokkos::is_view_v<Scalar1> &&
-                           !KokkosBatched::is_vector<Scalar1>::value, int> = 0>
-testing::AssertionResult ExpectNearKKRelImpl(
-    const char* expr1, const char* expr2, const char* expr_tol,
-    Scalar1 val1, Scalar2 val2, Scalar3 tol)
-{
-    using AT1 = KokkosKernels::ArithTraits<Scalar1>;
-    using AT2 = KokkosKernels::ArithTraits<Scalar2>;
-    return ExpectNearKKImpl(expr1, expr2, expr_tol, val1, val2,
-                            tol * Kokkos::max(AT1::abs(val1), AT2::abs(val2)));
+          std::enable_if_t<!Kokkos::is_view_v<Scalar1> && !KokkosBatched::is_vector<Scalar1>::value, int> = 0>
+testing::AssertionResult ExpectNearKKRelImpl(const char* expr1, const char* expr2, const char* expr_tol, Scalar1 val1,
+                                             Scalar2 val2, Scalar3 tol) {
+  using AT1 = KokkosKernels::ArithTraits<Scalar1>;
+  using AT2 = KokkosKernels::ArithTraits<Scalar2>;
+  return ExpectNearKKImpl(expr1, expr2, expr_tol, val1, val2, tol * Kokkos::max(AT1::abs(val1), AT2::abs(val2)));
 }
 
 // SIMD Vector specialization: element-wise relative comparison across all lanes
 template <class T, int l, class Scalar3>
-testing::AssertionResult ExpectNearKKRelImpl(
-    const char* expr1, const char* expr2, const char* expr_tol,
-    const KokkosBatched::Vector<KokkosBatched::SIMD<T>, l>& val1,
-    const KokkosBatched::Vector<KokkosBatched::SIMD<T>, l>& val2,
-    Scalar3 tol)
-{
-    testing::AssertionResult overall = testing::AssertionSuccess();
-    for (int i = 0; i < l; ++i) {
-        auto r = ExpectNearKKRelImpl(expr1, expr2, expr_tol, val1[i], val2[i], tol);
-        if (!r) {
-            if (overall) overall = testing::AssertionFailure();
-            overall << "[lane " << i << "] " << r.message();
-        }
+testing::AssertionResult ExpectNearKKRelImpl(const char* expr1, const char* expr2, const char* expr_tol,
+                                             const KokkosBatched::Vector<KokkosBatched::SIMD<T>, l>& val1,
+                                             const KokkosBatched::Vector<KokkosBatched::SIMD<T>, l>& val2,
+                                             Scalar3 tol) {
+  testing::AssertionResult overall = testing::AssertionSuccess();
+  for (int i = 0; i < l; ++i) {
+    auto r = ExpectNearKKRelImpl(expr1, expr2, expr_tol, val1[i], val2[i], tol);
+    if (!r) {
+      if (overall) overall = testing::AssertionFailure();
+      overall << "[lane " << i << "] " << r.message();
     }
-    return overall;
+  }
+  return overall;
 }
 
 // Kokkos View specialization: element-wise relative comparison (rank-1 only)
 template <class View1, class View2, class Scalar3,
           std::enable_if_t<Kokkos::is_view_v<View1> && Kokkos::is_view_v<View2>, int> = 0>
-testing::AssertionResult ExpectNearKKRelImpl(
-    const char* expr1, const char* expr2, const char* expr_tol,
-    const View1& v1, const View2& v2, Scalar3 tol)
-{
-    static_assert(View1::rank == 1, "ExpectNearKKRelImpl: only rank-1 Views are supported");
-    const size_t v1_size = v1.extent(0);
-    if (v1_size != v2.extent(0)) {
-        return testing::AssertionFailure()
-            << expr1 << ".extent(0) (" << v1_size << ") != "
-            << expr2 << ".extent(0) (" << v2.extent(0) << ")";
+testing::AssertionResult ExpectNearKKRelImpl(const char* expr1, const char* expr2, const char* expr_tol,
+                                             const View1& v1, const View2& v2, Scalar3 tol) {
+  static_assert(View1::rank == 1, "ExpectNearKKRelImpl: only rank-1 Views are supported");
+  const size_t v1_size = v1.extent(0);
+  if (v1_size != v2.extent(0)) {
+    return testing::AssertionFailure() << expr1 << ".extent(0) (" << v1_size << ") != " << expr2 << ".extent(0) ("
+                                       << v2.extent(0) << ")";
+  }
+  auto h_v1 = Kokkos::create_mirror_view(v1);
+  auto h_v2 = Kokkos::create_mirror_view(v2);
+  KokkosKernels::Impl::safe_device_to_host_deep_copy(v1_size, v1, h_v1);
+  KokkosKernels::Impl::safe_device_to_host_deep_copy(v1_size, v2, h_v2);
+  testing::AssertionResult overall = testing::AssertionSuccess();
+  for (size_t i = 0; i < v1_size; ++i) {
+    auto r = ExpectNearKKRelImpl(expr1, expr2, expr_tol, h_v1(i), h_v2(i), tol);
+    if (!r) {
+      if (overall) overall = testing::AssertionFailure();
+      overall << "[" << i << "] " << r.message();
     }
-    auto h_v1 = Kokkos::create_mirror_view(v1);
-    auto h_v2 = Kokkos::create_mirror_view(v2);
-    KokkosKernels::Impl::safe_device_to_host_deep_copy(v1_size, v1, h_v1);
-    KokkosKernels::Impl::safe_device_to_host_deep_copy(v1_size, v2, h_v2);
-    testing::AssertionResult overall = testing::AssertionSuccess();
-    for (size_t i = 0; i < v1_size; ++i) {
-        auto r = ExpectNearKKRelImpl(expr1, expr2, expr_tol, h_v1(i), h_v2(i), tol);
-        if (!r) {
-            if (overall) overall = testing::AssertionFailure();
-            overall << "[" << i << "] " << r.message();
-        }
-    }
-    return overall;
+  }
+  return overall;
 }
 
 }  // namespace Impl


### PR DESCRIPTION
Change list:
* Move as much code as possible out of macros and into an Impl struct that all the macros can use
* Use templates to be able to support all types (Views, SIMD, etc)
* Remove redundant KK_EXPECT_NEAR macro

Fixes remaining issues involved with #3232 , namely:
`:247:5: error: cannot convert 'val_type' (aka 'Vector<SIMD<float>, 4>') to 'double' without a conversion operator`
