### PR TITLE
fix(ode): replace static pivoting with partial in BDF solver

### DIFF
--- a/ode/impl/KokkosODE_BDF_impl.hpp
+++ b/ode/impl/KokkosODE_BDF_impl.hpp
@@ -366,7 +366,8 @@ KOKKOS_FUNCTION void BDFStep(ode_type& ode, scalar_type& t, scalar_type& dt, sca
       update(eqIdx) = y_new(eqIdx) - y_predict(eqIdx);
     }
 
-    if (newton_status == KokkosODE::Experimental::newton_solver_status::MAX_ITER) {
+    if (newton_status == KokkosODE::Experimental::newton_solver_status::MAX_ITER ||
+        newton_status == KokkosODE::Experimental::newton_solver_status::LIN_SOLVE_FAIL) {
       dt = 0.5 * dt;
       update_D(order, 0.5, coeffs, tempD, D);
       num_equal_steps = 0;

--- a/ode/impl/KokkosODE_Newton_impl.hpp
+++ b/ode/impl/KokkosODE_Newton_impl.hpp
@@ -58,8 +58,35 @@ KOKKOS_FUNCTION KokkosODE::Experimental::newton_solver_status NewtonSolve(
     // compute LHS
     sys.jacobian(y0, J);
 
-    // solve linear problem
-    int linSolverStat = KokkosBatched::SerialGesv<KokkosBatched::Gesv::StaticPivoting>::invoke(J, update, rhs, tmp);
+    // Solve the linear problem J*update = rhs using LU with partial
+    // (row) pivoting. The static pivoting implemented in
+    // KokkosBatched::SerialGesv uses a greedy row-to-column assignment
+    // that can fail spuriously on well-conditioned sparse systems
+    // (e.g. chemistry Jacobians with one dense row), so it is only kept
+    // as a fallback for systems larger than the stack pivot buffer.
+    int linSolverStat = 0;
+    constexpr int pivot_buffer_size = 32;
+    if (sys.neqs <= pivot_buffer_size) {
+      int pivot_buffer[pivot_buffer_size];
+      Kokkos::View<int*, Kokkos::LayoutRight, Kokkos::AnonymousSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>> piv(
+          pivot_buffer, sys.neqs);
+      for (int idx = 0; idx < sys.neqs; ++idx) update(idx) = rhs(idx);
+      linSolverStat = KokkosBatched::SerialGetrf<KokkosBatched::Algo::Getrf::Unblocked>::invoke(J, piv);
+      if (linSolverStat == 0) {
+        linSolverStat =
+            KokkosBatched::SerialGetrs<KokkosBatched::Trans::NoTranspose, KokkosBatched::Algo::Getrs::Unblocked>::invoke(
+                J, piv, update);
+      }
+    } else {
+      linSolverStat = KokkosBatched::SerialGesv<KokkosBatched::Gesv::StaticPivoting>::invoke(J, update, rhs, tmp);
+    }
+
+    // Return before touching y0 if the linear solve failed: applying the
+    // (stale or partial) update would corrupt the iterate.
+    if (linSolverStat != 0) {
+      return newton_solver_status::LIN_SOLVE_FAIL;
+    }
+
     KokkosBlas::SerialScale::invoke(-1, update);
 
     // update solution // x = x + alpha*update

--- a/ode/impl/KokkosODE_Newton_impl.hpp
+++ b/ode/impl/KokkosODE_Newton_impl.hpp
@@ -13,6 +13,8 @@
 #include "KokkosBlas1_axpby.hpp"
 #include "KokkosKernels_InnerProductSpaceTraits.hpp"
 
+#include "KokkosBatched_Getrf.hpp"
+#include "KokkosBatched_Getrs.hpp"
 #include "KokkosODE_Types.hpp"
 
 namespace KokkosODE {

--- a/ode/impl/KokkosODE_Newton_impl.hpp
+++ b/ode/impl/KokkosODE_Newton_impl.hpp
@@ -67,12 +67,11 @@ KOKKOS_FUNCTION KokkosODE::Experimental::newton_solver_status NewtonSolve(
     // (e.g. chemistry Jacobians with one dense row), so it is only kept
     // as a fallback for systems larger than the stack pivot buffer.
     int linSolverStat = 0;
-    constexpr int pivot_buffer_size = 32;
-    if (sys.neqs <= pivot_buffer_size) {
-      int pivot_buffer[pivot_buffer_size];
+    using mat_value_type = typename mat_type::non_const_value_type;
+    if (sys.neqs * sizeof(int) <= tmp.size() * sizeof(mat_value_type)) {
       Kokkos::View<int*, Kokkos::LayoutRight, Kokkos::AnonymousSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>> piv(
-          pivot_buffer, sys.neqs);
-      for (int idx = 0; idx < sys.neqs; ++idx) update(idx) = rhs(idx);
+        reinterpret_cast<int *>(tmp.data()), sys.neqs);
+    for (int idx = 0; idx < sys.neqs; ++idx) update(idx) = rhs(idx);
       linSolverStat = KokkosBatched::SerialGetrf<KokkosBatched::Algo::Getrf::Unblocked>::invoke(J, piv);
       if (linSolverStat == 0) {
         linSolverStat =

--- a/ode/unit_test/Test_ODE_BDF.hpp
+++ b/ode/unit_test/Test_ODE_BDF.hpp
@@ -114,6 +114,61 @@ struct StiffChemistry {
   }
 };
 
+// A sparse linear system whose BDF iteration matrix (I - dt*J) breaks
+// the static pivot selection of Gesv::StaticPivoting even though it is
+// non-singular (det(I - dt*J) = (1 + dt)^3) and well conditioned. It has
+// the sparsity structure of a chemistry network with an energy equation:
+// one dense row and otherwise nearly diagonal rows.
+//
+// Equations: y0' = -y0 - 10*y1
+//            y1' = -y1
+//            y2' = -1000*y0 - y2
+//
+// For dt >~ 0.001 the static pivoting proceeds as follows: row 2
+// is processed first (largest row max, 1000*dt) and takes column 0; row
+// 0 is processed next and takes column 1 since its diagonal entry was
+// scaled down by the column 0 maximum 1000*dt; row 1 has a single
+// nonzero entry, in the already taken column 1, so no pivot can be
+// assigned to it and the linear solve reports a failure.
+//
+// Solution: y0 = (y0(0) - 10*t*y1(0))*exp(-t)
+//           y1 = y1(0)*exp(-t)
+//           y2 = (y2(0) - 1000*t*y0(0) + 5000*t*t*y1(0))*exp(-t)
+struct SparseLinearSystem {
+  static constexpr int neqs = 3;
+
+  SparseLinearSystem() {}
+
+  template <class vec_type1, class vec_type2>
+  KOKKOS_FUNCTION void evaluate_function(const double /*t*/, const double /*dt*/, const vec_type1& y,
+                                         const vec_type2& f) const {
+    f(0) = -y(0) - 10.0 * y(1);
+    f(1) = -y(1);
+    f(2) = -1000.0 * y(0) - y(2);
+  }
+
+  template <class vec_type, class mat_type>
+  KOKKOS_FUNCTION void evaluate_jacobian(const double /*t*/, const double /*dt*/, const vec_type& /*y*/,
+                                         const mat_type& jac) const {
+    jac(0, 0) = -1.0;
+    jac(0, 1) = -10.0;
+    jac(0, 2) = 0.0;
+    jac(1, 0) = 0.0;
+    jac(1, 1) = -1.0;
+    jac(1, 2) = 0.0;
+    jac(2, 0) = -1000.0;
+    jac(2, 1) = 0.0;
+    jac(2, 2) = -1.0;
+  }
+
+  template <class vec_type1, class vec_type2>
+  KOKKOS_FUNCTION void solution(const double t, const vec_type1& y0, const vec_type2& y) const {
+    y(0) = (y0(0) - 10.0 * t * y0(1)) * Kokkos::exp(-t);
+    y(1) = y0(1) * Kokkos::exp(-t);
+    y(2) = (y0(2) - 1000.0 * t * y0(0) + 5000.0 * t * t * y0(1)) * Kokkos::exp(-t);
+  }
+};  // SparseLinearSystem
+
 template <class ode_type, KokkosODE::Experimental::BDF_type bdf_type, class vec_type, class mv_type, class mat_type,
           class scalar_type>
 struct BDFSolve_wrapper {
@@ -388,6 +443,81 @@ void test_BDF_StiffChemistry() {
       solve_wrapper(mySys, t_start, t_end, 110000, y0, y_new, rhs, update, scale, y_vecs, kstack, temp, jac);
   Kokkos::parallel_for(myPolicy, solve_wrapper);
 }
+
+// Integrate the SparseLinearSystem, whose iteration matrix I - dt*J is
+// well conditioned but breaks the static pivotint used in
+// Gesv::StaticPivoting (see the comment on the struct above), and
+// compare against the analytical solution. With static pivoting every
+// Newton iteration reports a spurious linear solve failure: the fixed
+// step BDF1 solve never advances past the initial condition and the
+// adaptive BDFSolve accepts unconverged iterates. With partial
+// pivoting (Getrf/Getrs) both integrate the system accurately.
+template <class device_type, class scalar_type>
+void test_BDF_SparseLinearSystem() {
+  using execution_space = typename device_type::execution_space;
+  using vec_type        = Kokkos::View<scalar_type*, execution_space>;
+  using mv_type         = Kokkos::View<scalar_type**, execution_space>;
+  using mat_type        = Kokkos::View<scalar_type**, execution_space>;
+
+  SparseLinearSystem mySys{};
+
+  const scalar_type t_start = 0.0, t_end = 1.0;
+  vec_type y0("initial conditions", mySys.neqs), y_new("solution", mySys.neqs);
+  auto y0_h    = Kokkos::create_mirror_view(y0);
+  auto y_new_h = Kokkos::create_mirror_view(y_new);
+
+  // Reference solution
+  Kokkos::View<scalar_type*, Kokkos::HostSpace> y_ref_h("reference solution", mySys.neqs);
+  Kokkos::deep_copy(y0_h, 1.0);
+  mySys.solution(t_end, y0_h, y_ref_h);
+
+  Kokkos::RangePolicy<execution_space> myPolicy(0, 1);
+
+  // Fixed order, fixed step BDF1 with dt = 0.1, large enough
+  // for the static pivoting to fail.
+  {
+    const int num_steps = 10;
+    vec_type rhs("rhs", mySys.neqs), update("update", mySys.neqs);
+    vec_type scale("scaling factors", mySys.neqs);
+    mat_type jac("jacobian", mySys.neqs, mySys.neqs), temp("temp storage", mySys.neqs, mySys.neqs + 4);
+    mv_type kstack("Startup RK vectors", 6, mySys.neqs);
+    mv_type y_vecs("history vectors", mySys.neqs, 1);
+
+    Kokkos::deep_copy(scale, 1);
+    Kokkos::deep_copy(y0, 1.0);
+
+    BDFSolve_wrapper<SparseLinearSystem, KokkosODE::Experimental::BDF_type::BDF1, vec_type, mv_type, mat_type,
+                     scalar_type>
+        solve_wrapper(mySys, t_start, t_end, num_steps, y0, y_new, rhs, update, scale, y_vecs, kstack, temp, jac);
+    Kokkos::parallel_for(myPolicy, solve_wrapper);
+    Kokkos::fence();
+
+    Kokkos::deep_copy(y_new_h, y_new);
+    for (int eqIdx = 0; eqIdx < mySys.neqs; ++eqIdx) {
+      // BDF1 discretization error at dt=0.1 is ~5%; a failed linear
+      // solve leaves y at its initial condition, off by more than 100%.
+      EXPECT_NEAR_KK_REL(y_new_h(eqIdx), y_ref_h(eqIdx), 0.1);
+    }
+  }
+
+  // Adaptive time step BDFSolve
+  {
+    mat_type temp("buffer1", mySys.neqs, 23 + 2 * mySys.neqs + 4), temp2("buffer2", 6, 7);
+
+    Kokkos::deep_copy(y0, 1.0);
+    Kokkos::deep_copy(y_new, 0.0);
+
+    BDF_Solve_wrapper bdf_wrapper(mySys, t_start, t_end, scalar_type(0.0), (t_end - t_start) / 10, y0, y_new, temp,
+                                  temp2);
+    Kokkos::parallel_for(myPolicy, bdf_wrapper);
+    Kokkos::fence();
+
+    Kokkos::deep_copy(y_new_h, y_new);
+    for (int eqIdx = 0; eqIdx < mySys.neqs; ++eqIdx) {
+      EXPECT_NEAR_KK_REL(y_new_h(eqIdx), y_ref_h(eqIdx), 1.0e-2);
+    }
+  }
+}  // test_BDF_SparseLinearSystem
 
 // template <class ode_type, KokkosODE::Experimental::BDF_type bdf_type,
 //           class vec_type, class mv_type, class mat_type, class scalar_type>
@@ -720,6 +850,7 @@ void test_BDF_adaptive_stiff() {
 TEST_F(TestCategory, BDF_Logistic_serial) { ::Test::test_BDF_Logistic<TestDevice, double>(); }
 TEST_F(TestCategory, BDF_LotkaVolterra_serial) { ::Test::test_BDF_LotkaVolterra<TestDevice, double>(); }
 TEST_F(TestCategory, BDF_StiffChemistry_serial) { ::Test::test_BDF_StiffChemistry<TestDevice, double>(); }
+TEST_F(TestCategory, BDF_SparseLinearSystem_serial) { ::Test::test_BDF_SparseLinearSystem<TestDevice, double>(); }
 // TEST_F(TestCategory, BDF_parallel_serial) {
 //   ::Test::test_BDF_parallel<TestDevice, double>();
 // }

--- a/ode/unit_test/Test_ODE_BDF.hpp
+++ b/ode/unit_test/Test_ODE_BDF.hpp
@@ -236,7 +236,7 @@ void test_BDF_Logistic() {
   using mv_type         = Kokkos::View<scalar_type**, execution_space>;
   using mat_type        = Kokkos::View<scalar_type**, execution_space>;
 
-  Kokkos::RangePolicy<execution_space> myPolicy(0, 1);
+  Kokkos::RangePolicy<execution_space> my_policy(0, 1);
   Logistic mySys(1, 1);
 
   constexpr int num_tests   = 7;
@@ -265,7 +265,7 @@ void test_BDF_Logistic() {
 
     BDFSolve_wrapper<Logistic, KokkosODE::Experimental::BDF_type::BDF1, vec_type, mv_type, mat_type, scalar_type>
         solve_wrapper(mySys, t_start, t_end, num_steps[idx], y0, y_new, rhs, update, scale, y_vecs, kstack, temp, jac);
-    Kokkos::parallel_for(myPolicy, solve_wrapper);
+    Kokkos::parallel_for(my_policy, solve_wrapper);
     Kokkos::fence();
 
     auto y_new_h = Kokkos::create_mirror_view(y_new);
@@ -290,7 +290,7 @@ void test_BDF_Logistic() {
 
     BDFSolve_wrapper<Logistic, KokkosODE::Experimental::BDF_type::BDF2, vec_type, mv_type, mat_type, scalar_type>
         solve_wrapper(mySys, t_start, t_end, num_steps[idx], y0, y_new, rhs, update, scale, y_vecs, kstack, temp, jac);
-    Kokkos::parallel_for(myPolicy, solve_wrapper);
+    Kokkos::parallel_for(my_policy, solve_wrapper);
     Kokkos::fence();
 
     auto y_new_h = Kokkos::create_mirror_view(y_new);
@@ -315,7 +315,7 @@ void test_BDF_Logistic() {
 
     BDFSolve_wrapper<Logistic, KokkosODE::Experimental::BDF_type::BDF3, vec_type, mv_type, mat_type, scalar_type>
         solve_wrapper(mySys, t_start, t_end, num_steps[idx], y0, y_new, rhs, update, scale, y_vecs, kstack, temp, jac);
-    Kokkos::parallel_for(myPolicy, solve_wrapper);
+    Kokkos::parallel_for(my_policy, solve_wrapper);
     Kokkos::fence();
 
     auto y_new_h = Kokkos::create_mirror_view(y_new);
@@ -340,7 +340,7 @@ void test_BDF_Logistic() {
 
     BDFSolve_wrapper<Logistic, KokkosODE::Experimental::BDF_type::BDF4, vec_type, mv_type, mat_type, scalar_type>
         solve_wrapper(mySys, t_start, t_end, num_steps[idx], y0, y_new, rhs, update, scale, y_vecs, kstack, temp, jac);
-    Kokkos::parallel_for(myPolicy, solve_wrapper);
+    Kokkos::parallel_for(my_policy, solve_wrapper);
     Kokkos::fence();
 
     auto y_new_h = Kokkos::create_mirror_view(y_new);
@@ -364,7 +364,7 @@ void test_BDF_Logistic() {
 
     BDFSolve_wrapper<Logistic, KokkosODE::Experimental::BDF_type::BDF5, vec_type, mv_type, mat_type, scalar_type>
         solve_wrapper(mySys, t_start, t_end, num_steps[idx], y0, y_new, rhs, update, scale, y_vecs, kstack, temp, jac);
-    Kokkos::parallel_for(myPolicy, solve_wrapper);
+    Kokkos::parallel_for(my_policy, solve_wrapper);
     Kokkos::fence();
 
     auto y_new_h = Kokkos::create_mirror_view(y_new);
@@ -404,10 +404,10 @@ void test_BDF_LotkaVolterra() {
   Kokkos::deep_copy(y0, 10.0);
   Kokkos::deep_copy(y_vecs, 10.0);
 
-  Kokkos::RangePolicy<execution_space> myPolicy(0, 1);
+  Kokkos::RangePolicy<execution_space> my_policy(0, 1);
   BDFSolve_wrapper<LotkaVolterra, KokkosODE::Experimental::BDF_type::BDF5, vec_type, mv_type, mat_type, scalar_type>
       solve_wrapper(mySys, t_start, t_end, 1000, y0, y_new, rhs, update, scale, y_vecs, kstack, temp, jac);
-  Kokkos::parallel_for(myPolicy, solve_wrapper);
+  Kokkos::parallel_for(my_policy, solve_wrapper);
 }
 
 template <class device_type, class scalar_type>
@@ -438,10 +438,10 @@ void test_BDF_StiffChemistry() {
   Kokkos::deep_copy(y0, y0_h);
   Kokkos::deep_copy(y_vecs, 0.0);
 
-  Kokkos::RangePolicy<execution_space> myPolicy(0, 1);
+  Kokkos::RangePolicy<execution_space> my_policy(0, 1);
   BDFSolve_wrapper<StiffChemistry, KokkosODE::Experimental::BDF_type::BDF5, vec_type, mv_type, mat_type, scalar_type>
       solve_wrapper(mySys, t_start, t_end, 110000, y0, y_new, rhs, update, scale, y_vecs, kstack, temp, jac);
-  Kokkos::parallel_for(myPolicy, solve_wrapper);
+  Kokkos::parallel_for(my_policy, solve_wrapper);
 }
 
 // Integrate the SparseLinearSystem, whose iteration matrix I - dt*J is
@@ -471,7 +471,7 @@ void test_BDF_SparseLinearSystem() {
   Kokkos::deep_copy(y0_h, 1.0);
   mySys.solution(t_end, y0_h, y_ref_h);
 
-  Kokkos::RangePolicy<execution_space> myPolicy(0, 1);
+  Kokkos::RangePolicy<execution_space> my_policy(0, 1);
 
   // Fixed order, fixed step BDF1 with dt = 0.1, large enough
   // for the static pivoting to fail.
@@ -489,7 +489,7 @@ void test_BDF_SparseLinearSystem() {
     BDFSolve_wrapper<SparseLinearSystem, KokkosODE::Experimental::BDF_type::BDF1, vec_type, mv_type, mat_type,
                      scalar_type>
         solve_wrapper(mySys, t_start, t_end, num_steps, y0, y_new, rhs, update, scale, y_vecs, kstack, temp, jac);
-    Kokkos::parallel_for(myPolicy, solve_wrapper);
+    Kokkos::parallel_for(my_policy, solve_wrapper);
     Kokkos::fence();
 
     Kokkos::deep_copy(y_new_h, y_new);
@@ -509,7 +509,7 @@ void test_BDF_SparseLinearSystem() {
 
     BDF_Solve_wrapper bdf_wrapper(mySys, t_start, t_end, scalar_type(0.0), (t_end - t_start) / 10, y0, y_new, temp,
                                   temp2);
-    Kokkos::parallel_for(myPolicy, bdf_wrapper);
+    Kokkos::parallel_for(my_policy, bdf_wrapper);
     Kokkos::fence();
 
     Kokkos::deep_copy(y_new_h, y_new);
@@ -615,13 +615,13 @@ void test_BDF_SparseLinearSystem() {
 //   Kokkos::deep_copy(y0, 10.0);
 //   Kokkos::deep_copy(y_vecs, 10.0);
 
-//   Kokkos::RangePolicy<execution_space> myPolicy(0, num_solves);
+//   Kokkos::RangePolicy<execution_space> my_policy(0, num_solves);
 //   BDFSolve_parallel<LotkaVolterra, KokkosODE::Experimental::BDF_type::BDF5,
 //                     vec_type, mv_type, mat_type, scalar_type>
 //       solve_wrapper(mySys, t_start, t_end, 1000, y0, y_new, rhs, update,
 //       scale, y_vecs,
 //                     kstack, temp, jac);
-//   Kokkos::parallel_for(myPolicy, solve_wrapper);
+//   Kokkos::parallel_for(my_policy, solve_wrapper);
 
 //   Kokkos::fence();
 // }


### PR DESCRIPTION
# Summary

The BDF solver in Kokkos Kernels has several issues that were leading it being extremely slow for stiff ODE systems with one dense row

1. It used static pivoting that was very fragile with stiff ODE systems. I've replaced this with partial pivoting that is more fault tolerant
2. Check `LIN_SOLVE_FAIL` before applying the output of the linear solver in the Newton iterate
3. Make the BDF driver halve dt on LIN_SOLVE_FAIL, same as MAX_ITER. Only reachable if the Jacobian is singular

## Adding to older versions of Kokkos Kernels

Is it possible to add this patch to older versions of Kokkos Kernels? I'm currently stuck on Kokkos 4.7 for reasons outside of my control, if it's possible to add this to 4.7.05 that would be very helpful

## Note

I do not have a background in ODE solvers, numerical linear algebra, or the internals of Kokkos/Kokkos Kernels. All the code in this patch was written by Claude. I've done my best to verify it and it does produce correct results in my code (AthenaK) but I would really appreciate someone with more expertise taking a look. Thanks