### PR TITLE
CI: update Kokkos version to test post 5.2.1 release

### DIFF
--- a/.github/workflows/at2.yml
+++ b/.github/workflows/at2.yml
@@ -19,31 +19,31 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  KOKKOS_VERSION: 5.2.0
+  KOKKOS_VERSION: 5.2.1
 
 jobs:
   h100_lychee:
     uses: ./.github/workflows/h100_lychee.yml
     with:
-      kokkos_version: 5.2.0
+      kokkos_version: 5.2.1
   v100_kumquat:
     uses: ./.github/workflows/v100_kumquat.yml
     with:
-      kokkos_version: 5.2.0
+      kokkos_version: 5.2.1
       kokkos_previous_version: 5.1.1
   host:
     uses: ./.github/workflows/host.yml
     with:
-      kokkos_version: 5.2.0
+      kokkos_version: 5.2.1
   mi210:
     uses: ./.github/workflows/mi210.yml
     with:
-      kokkos_version: 5.2.0
+      kokkos_version: 5.2.1
   pv:
     uses: ./.github/workflows/pv.yml
     with:
-      kokkos_version: 5.2.0
+      kokkos_version: 5.2.1
   gh200:
     uses: ./.github/workflows/gh200.yml
     with:
-      kokkos_version: 5.2.0
+      kokkos_version: 5.2.1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -56,7 +56,7 @@ jobs:
       with:
         repository: 'kokkos/kokkos'
         path: 'kokkos'
-        ref: '5.2.0'
+        ref: '5.2.1'
 
     - name: configure_kokkos
       run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -19,7 +19,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  kokkos_version: 5.2.0
+  kokkos_version: 5.2.1
 
 jobs:
   check-pr-labels:

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -19,7 +19,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  kokkos_version: 5.2.0
+  kokkos_version: 5.2.1
 
 jobs:
   check-pr-labels:


### PR DESCRIPTION
Updating our CI to keep it in sync with the latest Kokkos Core release.