### PR TITLE
Add header needed for sequential_fill

### DIFF
--- a/sparse/impl/KokkosSparse_sort_crs_impl.hpp
+++ b/sparse/impl/KokkosSparse_sort_crs_impl.hpp
@@ -5,6 +5,7 @@
 
 #include "Kokkos_Core.hpp"
 #include "Kokkos_Sort.hpp"
+#include "KokkosKernels_SimpleUtils.hpp" // for sequential_fill
 #include "KokkosKernels_Sorting.hpp"
 
 namespace KokkosSparse {

--- a/sparse/impl/KokkosSparse_sort_crs_impl.hpp
+++ b/sparse/impl/KokkosSparse_sort_crs_impl.hpp
@@ -5,7 +5,7 @@
 
 #include "Kokkos_Core.hpp"
 #include "Kokkos_Sort.hpp"
-#include "KokkosKernels_SimpleUtils.hpp" // for sequential_fill
+#include "KokkosKernels_SimpleUtils.hpp"  // for sequential_fill
 #include "KokkosKernels_Sorting.hpp"
 
 namespace KokkosSparse {


### PR DESCRIPTION
This resolved errors for me when updating Trilinos for compatibility following #3254

It seems prior to #3254 , the inclusion of #include "KokkosKernels_SimpleUtils.hpp" in KokkosKernels_Sorting.hpp pulled this in [see KokkosKernels_Sorting.hpp](https://github.com/kokkos/kokkos-kernels/pull/3254/changes#diff-b48a340a5217a37205043a396e24318f11ba63bbb470b0b6be7fbaf46c23a345). I'm not sure if some code path is untested so this didn't show up in CI?

Previous error output (using sym-linked kokkos-kernels@develop in Trilinos):
```
In file included from /home/ndellin/trilinos/Trilinos-1/Build/Blake-serial-llvm1507/build/packages/tpetra/core/src/Tpetra_CrsGraph_INT_LONG_LONG_SERIAL.cpp:35:
In file included from /home/ndellin/trilinos/Trilinos-1/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp:36:
In file included from /home/ndellin/trilinos/Trilinos-1/packages/tpetra/core/src/Tpetra_Import_Util2.hpp:27:
In file included from /home/ndellin/trilinos/Trilinos-1/kokkos-kernels/sparse/src/KokkosSparse_SortCrs.hpp:6:
/home/ndellin/trilinos/Trilinos-1/kokkos-kernels/sparse/impl/KokkosSparse_sort_crs_impl.hpp:405:24: error: no member named 'sequential_fill' in namespace 'KokkosKernels::Impl'
  KokkosKernels::Impl::sequential_fill(exec, permutation);
```