### PR TITLE
Address #2194: spgemm input/output sortedness

### DIFF
--- a/docs/source/API/sparse/handle_get_create_destroy.rst
+++ b/docs/source/API/sparse/handle_get_create_destroy.rst
@@ -75,14 +75,20 @@ create
 
 .. code:: c++
 
-  void create_spgemm_handle(KokkosSparse::SPGEMMAlgorithm spgemm_algo = KokkosSparse::SPGEMM_DEFAULT);
+  void create_spgemm_handle(KokkosSparse::SPGEMMAlgorithm spgemm_algo = KokkosSparse::SPGEMM_DEFAULT,
+                            bool input_sorted = false,
+                            bool result_sorted = true);
 
-Destroy any previous spgemm sub-handle and create a new owned one specifying which algorithm to use.
+Destroy any previous spgemm sub-handle and create a new owned one. 
 
 Parameters
 ^^^^^^^^^^
 
 :spgemm_algo: Specify the algorithm to be used to perform the spgemm operation.
+:input_sorted: Whether the input matrices (A and B) that will be multiplied with this handle are known to be sorted. When this is
+  `false`, KokkosKernels may internally switch to a slower SpGEMM algorithm that accepts unsorted inputs.
+:result_sorted: Whether the user requires that the output matrix C is sorted. Setting this to `false` may skip an explicit sort
+  and thus reduce the time spgemm takes. Default is `true` for backward compatibility.
 
 .. _handle_spgemm_destroy:
 

--- a/docs/source/API/sparse/spgemm_numeric.rst
+++ b/docs/source/API/sparse/spgemm_numeric.rst
@@ -50,7 +50,7 @@ Parameters
    For all parameters that are shared with ``spgemm_symbolic`` (dimensions, row maps, entries and matrices), the parameters to ``spgemm_numeric`` must match what was previously passed into ``spgemm_symbolic``
    with the same handle. For example, it is not valid to call ``spgemm_symbolic`` with one version of ``entriesA``, and then call ``spgemm_numeric`` with a different ``entriesA`` but the same handle.
 
-:handle: KokkosKernelsHandle with an active spgemm subhandle (i.e. `create_spgem_handle(...)` was previously called on it). Must be the same handle that was previously passed into ``spgemm_symbolic`` with the same input matrices.
+:handle: KokkosKernelsHandle with an active spgemm subhandle (i.e. `create_spgemm_handle(...)` was previously called on it). Must be the same handle that was previously passed into ``spgemm_symbolic`` with the same input matrices.
 
 :m, n, k: dimensions of the matrices. **m** is the number of rows in ``A`` and ``C``. **n** is the number of columns in ``A`` and the number of rows in ``B``. **k** is the number of columns in ``B`` and ``C``.
 

--- a/docs/source/API/sparse/spgemm_numeric.rst
+++ b/docs/source/API/sparse/spgemm_numeric.rst
@@ -20,7 +20,7 @@ Defined in header ``KokkosSparse_spgemm.hpp``
                       typename KernelHandle::const_nnz_lno_t block_dim = 1);
 
   template <class KernelHandle, class AMatrix, class BMatrix, class CMatrix>
-  void spgemm_numeric(KernelHandle& kh, const AMatrix& A, const bool Amode, const BMatrix& B, const bool Bmode,
+  void spgemm_numeric(KernelHandle& handle, const AMatrix& A, const bool Amode, const BMatrix& B, const bool Bmode,
                       CMatrix& C);
 
 Performs the numeric phase of the multiplication of two sparse matrices.
@@ -50,13 +50,13 @@ Parameters
    For all parameters that are shared with ``spgemm_symbolic`` (dimensions, row maps, entries and matrices), the parameters to ``spgemm_numeric`` must match what was previously passed into ``spgemm_symbolic``
    with the same handle. For example, it is not valid to call ``spgemm_symbolic`` with one version of ``entriesA``, and then call ``spgemm_numeric`` with a different ``entriesA`` but the same handle.
 
-:handle: spadd kernels handle obtained from an instance of ``KokkosKernels::KokkosKernelsHandle``. Must be the same handle that was previously passed into ``spgemm_symbolic`` with the same input matrices.
+:handle: KokkosKernelsHandle with an active spgemm subhandle (i.e. `create_spgem_handle(...)` was previously called on it). Must be the same handle that was previously passed into ``spgemm_symbolic`` with the same input matrices.
 
 :m, n, k: dimensions of the matrices. **m** is the number of rows in ``A`` and ``C``. **n** is the number of columns in ``A`` and the number of rows in ``B``. **k** is the number of columns in ``B`` and ``C``.
 
 :row_mapA, row_mapB: row maps of the input matrices ``A`` and ``B``.
 
-:entriesA, entriesB: column indices of the entries in each row of ``A`` and ``B``. In most cases, these should be in sorted and merged order (see note in :doc:`spgemm_symbolic <spgemm_symbolic>`).
+:entriesA, entriesB: column indices of the entries in each row of ``A`` and ``B``.
 
 :valuesA, valuesB: values of the entries in each row of ``A`` and ``B``.
 
@@ -70,7 +70,7 @@ Parameters
 
 :Amode, Bmode: transposition operation to apply to ``A`` and ``B`` respectively. **Must both be false**; the algorithm is not yet implemented for other cases.
 
-:A, B, C: three instances of :doc:`KokkosSparse::CrsMatrix <crs_matrix>`. ``A`` and ``B`` are inputs parameters only. The output is written into the values of ``C``. In most cases, ``A`` and ``B`` should be in sorted and merged order (see note in :doc:`spgemm_symbolic <spgemm_symbolic>`).
+:A, B, C: three instances of :doc:`KokkosSparse::CrsMatrix <crs_matrix>`. ``A`` and ``B`` are inputs parameters only. The output is written into the values of ``C``.
 
 Type Requirements
 -----------------

--- a/docs/source/API/sparse/spgemm_symbolic.rst
+++ b/docs/source/API/sparse/spgemm_symbolic.rst
@@ -18,7 +18,7 @@ Defined in header ``KokkosSparse_spgemm.hpp``
                        clno_row_view_t_ row_mapC, bool computeRowptrs = false);
 
   template <class KernelHandle, class AMatrix, class BMatrix, class CMatrix>
-  void spgemm_symbolic(KernelHandle& kh, const AMatrix& A, const bool Amode,
+  void spgemm_symbolic(KernelHandle& handle, const AMatrix& A, const bool Amode,
                        const BMatrix& B, const bool Bmode, CMatrix& C);
 
 Performs the symbolic phase of the multiplication of two sparse matrices.
@@ -39,21 +39,18 @@ After ``spgemm_symbolic`` returns, the number of non-zeros in C is available thr
    While transpose flags are part of the interface, the algorithm is only implemented for non-transposed A and B.
 
 .. note::
-  Some underlying implementations require that both A and B are sorted and merged, meaning that the column indices within each row are sorted and unique.
-
-  Expert users may want to use SpGEMM but avoid the cost of explicitly sorting and merging the input matrices.
-  The implementations where this requirement doesn't apply are Kokkos Kernels, rocSPARSE (as long as there is no row with more than 8192 intermediate products), and MKL.
+   For both modes of the algorithm, the matrices A and B must both be sorted (have the entries in each row ordered by column) if ``handle->get_spgemm_handle()->get_input_sorted()``. This is `false` by default. See :ref:`create_spgemm_handle <handle_spgemm_create>` for how this is configured in the handle. Likewise, the output matrix C is only guaranteed to be sorted if ``handle->get_spgemm_handle()->get_result_sorted()``.
 
 Parameters
 ==========
 
-:handle: spadd kernels handle obtained from an instance of ``KokkosKernels::KokkosKernelsHandle``.
+:handle: KokkosKernelsHandle with an active spgemm subhandle (i.e. `create_spgem_handle(...)` was previously called on it).
 
 :m, n, k: dimensions of the matrices. **m** is the number of rows in ``A`` and ``C``. **n** is the number of columns in ``A`` and the number of rows in ``B``. **k** is the number of columns in ``B`` and ``C``.
 
 :row_mapA, row_mapB: row maps of the input matrices ``A`` and ``B``.
 
-:entriesA, entriesB: column indices of the entries in each row of ``A`` and ``B``. In most cases, these should be in sorted and merged order (see note above).
+:entriesA, entriesB: column indices of the entries in each row of ``A`` and ``B``.
 
 :transposeA, transposeB: transposition operator to be applied to ``row_mapA``, ``entriesA`` and ``row_mapB``, ``entriesB`` respectively. **Must both be false**; the algorithm is not yet implemented for other cases.
 
@@ -63,7 +60,7 @@ Parameters
 
 :Amode, Bmode: transposition operation to apply to ``A`` and ``B`` respectively. **Must both be false**; the algorithm is not yet implemented for other cases.
 
-:A, B, C: three instances of :doc:`KokkosSparse::CrsMatrix <crs_matrix>`. ``A`` and ``B`` are input parameters. ``C`` is an output parameter only. In most cases, ``A`` and ``B`` should be sorted and merged (see note above).
+:A, B, C: three instances of :doc:`KokkosSparse::CrsMatrix <crs_matrix>`. ``A`` and ``B`` are input parameters. ``C`` is an output parameter only.
 
 Type Requirements
 -----------------

--- a/docs/source/API/sparse/spgemm_symbolic.rst
+++ b/docs/source/API/sparse/spgemm_symbolic.rst
@@ -44,7 +44,7 @@ After ``spgemm_symbolic`` returns, the number of non-zeros in C is available thr
 Parameters
 ==========
 
-:handle: KokkosKernelsHandle with an active spgemm subhandle (i.e. `create_spgem_handle(...)` was previously called on it).
+:handle: KokkosKernelsHandle with an active spgemm subhandle (i.e. `create_spgemm_handle(...)` was previously called on it).
 
 :m, n, k: dimensions of the matrices. **m** is the number of rows in ``A`` and ``C``. **n** is the number of columns in ``A`` and the number of rows in ``B``. **k** is the number of columns in ``B`` and ``C``.
 

--- a/sparse/impl/KokkosSparse_spgemm_impl.hpp
+++ b/sparse/impl/KokkosSparse_spgemm_impl.hpp
@@ -479,7 +479,11 @@ class KokkosSPGEMM {
   static inline SPGEMMAlgorithm select_algorithm(HandleType *handle) {
     auto sh          = handle->get_spgemm_handle();
     auto handle_algo = sh->get_algorithm_type();
-    if (handle_algo == SPGEMM_DEFAULT) {
+    // If a non-native (TPL) algorithm is selected but we have reached the native
+    // implementation, then this is a runtime fallback (e.g. the inputs are
+    // unsorted but the TPL requires sorted inputs). In that case, use the
+    // default native algorithm for this execution space.
+    if (handle_algo == SPGEMM_DEFAULT || !KokkosSparse::Impl::is_spgemm_algorithm_native(handle_algo)) {
       return sh->get_default_native_algorithm();
     }
     return handle_algo;

--- a/sparse/impl/KokkosSparse_spgemm_noreuse_spec.hpp
+++ b/sparse/impl/KokkosSparse_spgemm_noreuse_spec.hpp
@@ -54,7 +54,7 @@ template <class CMatrix, class AMatrix, class BMatrix,
           bool eti_spec_avail = spgemm_noreuse_eti_spec_avail<CMatrix, AMatrix, BMatrix>::value>
 struct SPGEMM_NOREUSE {
   static CMatrix spgemm_noreuse(KokkosSparse::SPGEMMAlgorithm algo, const AMatrix& A, bool transA, const BMatrix& B,
-                                bool transB);
+                                bool transB, bool input_sorted, bool result_sorted);
 };
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) || KOKKOSKERNELS_IMPL_COMPILE_LIBRARY
@@ -63,7 +63,7 @@ struct SPGEMM_NOREUSE {
 template <class CMatrix, class AMatrix, class BMatrix>
 struct SPGEMM_NOREUSE<CMatrix, AMatrix, BMatrix, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   static CMatrix spgemm_noreuse(KokkosSparse::SPGEMMAlgorithm algo, const AMatrix& A, bool transA, const BMatrix& B,
-                                bool transB) {
+                                bool transB, bool input_sorted, bool result_sorted) {
     using device_t    = typename CMatrix::device_type;
     using scalar_t    = typename CMatrix::value_type;
     using ordinal_t   = typename CMatrix::ordinal_type;
@@ -74,7 +74,7 @@ struct SPGEMM_NOREUSE<CMatrix, AMatrix, BMatrix, false, KOKKOSKERNELS_IMPL_COMPI
     KokkosKernels::Experimental::KokkosKernelsHandle<size_type, ordinal_t, scalar_t, typename device_t::execution_space,
                                                      typename device_t::memory_space, typename device_t::memory_space>
         kh;
-    kh.create_spgemm_handle(algo);
+    kh.create_spgemm_handle(algo, input_sorted, result_sorted);
     // A is m*n, B is n*k, C is m*k
     ordinal_t m = A.numRows();
     ordinal_t n = B.numRows();

--- a/sparse/impl/KokkosSparse_spgemm_numeric_spec.hpp
+++ b/sparse/impl/KokkosSparse_spgemm_numeric_spec.hpp
@@ -122,9 +122,11 @@ struct SPGEMM_NUMERIC<KernelHandle, a_size_view_t_, a_lno_view_t, a_scalar_view_
         kspgemm.KokkosSPGEMM_numeric(row_mapC, entriesC, valuesC);
       } break;
     }
-    // Current implementation does not produce sorted matrix
-    // TODO: remove this call when impl sorts
-    KokkosSparse::sort_crs_matrix<typename KernelHandle::HandleExecSpace>(row_mapC, entriesC, valuesC);
+    // native impl does not produce a sorted matrix, so
+    // if the user requested sorted output, sort it now.
+    if (sh->get_result_sorted()) {
+      KokkosSparse::sort_crs_matrix<typename KernelHandle::HandleExecSpace>(row_mapC, entriesC, valuesC);
+    }
     sh->set_call_numeric();
     sh->set_computed_entries();
   }

--- a/sparse/src/KokkosKernels_Handle.hpp
+++ b/sparse/src/KokkosKernels_Handle.hpp
@@ -452,12 +452,21 @@ class KokkosKernelsHandle {
     }
   }
 
-  // SPGEM
   SPGEMMHandleType *get_spgemm_handle() { return this->spgemmHandle; }
-  void create_spgemm_handle(KokkosSparse::SPGEMMAlgorithm spgemm_algo = KokkosSparse::SPGEMM_DEFAULT) {
+
+  /// \brief Create an SpGEMM handle.
+  ///
+  /// \param spgemm_algo the algorithm to use.
+  /// \param input_sorted whether the entries within each row of the input
+  ///   matrices A and B are sorted. Defaults to false (assume unsorted).
+  /// \param result_sorted whether the entries within each row of the output
+  ///   matrix C are required to be sorted. Defaults to true (always produce
+  ///   sorted output).
+  void create_spgemm_handle(KokkosSparse::SPGEMMAlgorithm spgemm_algo = KokkosSparse::SPGEMM_DEFAULT,
+                            bool input_sorted = false, bool result_sorted = true) {
     this->destroy_spgemm_handle();
     this->is_owner_of_the_spgemm_handle = true;
-    this->spgemmHandle                  = new SPGEMMHandleType(spgemm_algo);
+    this->spgemmHandle                  = new SPGEMMHandleType(spgemm_algo, input_sorted, result_sorted);
   }
   void destroy_spgemm_handle() {
     if (is_owner_of_the_spgemm_handle && this->spgemmHandle != NULL) {

--- a/sparse/src/KokkosSparse_spgemm.hpp
+++ b/sparse/src/KokkosSparse_spgemm.hpp
@@ -153,12 +153,18 @@ void block_spgemm_numeric(KernelHandle& kh, const AMatrix& A, const bool Amode, 
 /// @param Amode Whether to transpose A (only Amode == false is currently supported)
 /// @param B Right input matrix.
 /// @param Bmode Whether to transpose B (only Bmode == false is currently supported)
-/// @param algo Algorithm option to use.
+/// @param input_sorted Whether A and B are both known to be sorted.
+///   If false and the selected algorithm requires sorted input,
+///   a native (KokkosKernels) implementation is used instead.
+///   Defaults to false (assume unsorted) for backwards compatibility.
+/// @param result_sorted When true, the output matrix C is always sorted,
+///   which may incur a runtime cost. When false, indicates that an unsorted output
+///   is acceptable. Defaults to true for backwards compatibility.
 /// @return CMatrix Product A*B.
 ///
 template <class CMatrix, class AMatrix, class BMatrix>
 CMatrix spgemm(KokkosSparse::SPGEMMAlgorithm algo, const AMatrix& A, const bool Amode, const BMatrix& B,
-               const bool Bmode) {
+               const bool Bmode, bool input_sorted = false, bool result_sorted = true) {
   // Canonicalize the matrix types:
   //  - Make A,B have const values and entries.
   //  - Make all views in A,B unmanaged, but otherwise default memory traits
@@ -175,6 +181,8 @@ CMatrix spgemm(KokkosSparse::SPGEMMAlgorithm algo, const AMatrix& A, const bool 
   using CMatrix_Internal =
       KokkosSparse::CrsMatrix<typename CMatrix::non_const_value_type, typename CMatrix::non_const_ordinal_type,
                               typename CMatrix::device_type, void, typename CMatrix::non_const_size_type>;
+  // Non-reuse always executes on C's exec space
+  using ExecSpace = typename CMatrix::execution_space;
   // Check now that A, B dimensions are compatible to multiply
   auto opACols = Amode ? A.numRows() : A.numCols();
   auto opBRows = Bmode ? B.numCols() : B.numRows();
@@ -202,14 +210,18 @@ CMatrix spgemm(KokkosSparse::SPGEMMAlgorithm algo, const AMatrix& A, const bool 
     typename CMatrix::values_type valuesC;
     return CMatrix("C", Crows, Ccols, 0, valuesC, row_mapC, entriesC);
   }
-  if (Impl::is_spgemm_algorithm_native(algo)) {
+  // Use the native path if the algorithm is natively implemented, or if the
+  // user has declared inputs are unsorted and the otherwise-selected TPL
+  // would require sorted inputs.
+  if (Impl::is_spgemm_algorithm_native(algo) ||
+      (!input_sorted && Impl::algorithm_may_require_sorted_input<ExecSpace>(algo))) {
     return CMatrix(
         KokkosSparse::Impl::SPGEMM_NOREUSE<CMatrix_Internal, AMatrix_Internal, BMatrix_Internal, false>::spgemm_noreuse(
-            algo, A_internal, Amode, B_internal, Bmode));
+            algo, A_internal, Amode, B_internal, Bmode, input_sorted, result_sorted));
   } else {
     return CMatrix(
         KokkosSparse::Impl::SPGEMM_NOREUSE<CMatrix_Internal, AMatrix_Internal, BMatrix_Internal>::spgemm_noreuse(
-            algo, A_internal, Amode, B_internal, Bmode));
+            algo, A_internal, Amode, B_internal, Bmode, input_sorted, result_sorted));
   }
 }
 
@@ -223,12 +235,20 @@ CMatrix spgemm(KokkosSparse::SPGEMMAlgorithm algo, const AMatrix& A, const bool 
 /// @param Amode Whether to transpose A (only Amode == false is currently supported)
 /// @param B Right input matrix.
 /// @param Bmode Whether to transpose B (only Bmode == false is currently supported)
-/// @param algo Algorithm option to use.
+/// @param input_sorted Whether A and B are both known to be sorted.
+///   If false and the selected algorithm requires sorted input,
+///   a native (KokkosKernels) implementation is used instead.
+///   Defaults to false (assume unsorted) for backwards compatibility.
+/// @param result_sorted When true, the output matrix C is always sorted,
+///   which may incur a runtime cost. When false, indicates that an unsorted output
+///   is acceptable. Defaults to true for backwards compatibility.
 /// @return CMatrix Product A*B.
 ///
 template <class CMatrix, class AMatrix, class BMatrix>
-CMatrix spgemm(const AMatrix& A, const bool Amode, const BMatrix& B, const bool Bmode) {
-  return spgemm<CMatrix, AMatrix, BMatrix>(KokkosSparse::SPGEMM_DEFAULT, A, Amode, B, Bmode);
+CMatrix spgemm(const AMatrix& A, const bool Amode, const BMatrix& B, const bool Bmode, bool input_sorted = false,
+               bool result_sorted = true) {
+  return spgemm<CMatrix, AMatrix, BMatrix>(KokkosSparse::SPGEMM_DEFAULT, A, Amode, B, Bmode, input_sorted,
+                                           result_sorted);
 }
 
 }  // namespace KokkosSparse

--- a/sparse/src/KokkosSparse_spgemm_handle.hpp
+++ b/sparse/src/KokkosSparse_spgemm_handle.hpp
@@ -518,8 +518,7 @@ class SPGEMMHandle {
    * \param alg the SpGEMM algorithm to use.
    * \param input_sorted_ whether inputs A and B are sorted.
    *   Defaults to false for backwards compatibility.
-   * \param result_sorted_ whether the output matrix C are required to
-   *   be sorted (ascending by column index).
+   * \param result_sorted_ whether the output matrix C is required to be sorted.
    *   Defaults to true to maintain backwards compatibility.
    */
   SPGEMMHandle(SPGEMMAlgorithm alg = SPGEMM_DEFAULT, bool input_sorted_ = false, bool result_sorted_ = true)

--- a/sparse/src/KokkosSparse_spgemm_handle.hpp
+++ b/sparse/src/KokkosSparse_spgemm_handle.hpp
@@ -90,6 +90,62 @@ inline bool is_spgemm_algorithm_native(SPGEMMAlgorithm a) {
   if (a == SPGEMM_DEFAULT || is_cusparse_spgemm_algorithm(a)) return false;
   return true;
 }
+
+/// \brief Return true if (given the ExecSpace and enabled TPLs),
+/// the spgemm algo may require the input matrices A and B to be sorted.
+///
+/// This is used at runtime to decide whether to fall back to native when
+/// the user has told us the input matrices are unsorted
+/// (native never requires sorted input).
+template <typename ExecSpace>
+bool algorithm_may_require_sorted_input(SPGEMMAlgorithm algo) {
+  if (is_spgemm_algorithm_native(algo)) {
+    // All native algos never require sorted input.
+    return false;
+  }
+#ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
+  if constexpr (std::is_same_v<ExecSpace, Kokkos::Cuda>) {
+    if (is_cusparse_spgemm_algorithm(algo)) {
+      // algo is a specific cusparse algo
+      switch (algo) {
+        // The SpGEMMreuse-based algorithms require sorted inputs.
+        case SPGEMM_CUSPARSE_DETERMINISTIC:
+        case SPGEMM_CUSPARSE_NONDETERMINISTIC: return true;
+        // The non-reuse SpGEMM algorithms (ALG1/ALG2/ALG3) do not require
+        // sorted inputs.
+        case SPGEMM_CUSPARSE_ALG1:
+        case SPGEMM_CUSPARSE_ALG2:
+        case SPGEMM_CUSPARSE_ALG3: return false;
+        default:;
+      }
+    } else if (algo == SPGEMM_DEFAULT) {
+      // Conservatively assume this spgemm will take the TPL path
+#if (CUSPARSE_VERSION < 12710)
+      // These cuSPARSE versions use the SpGEMMreuse path, which requires sorted
+      // inputs.
+      return true;
+#else
+      // Newer cuSPARSE versions use the non-reuse SpGEMM path, which does not
+      // require sorted inputs.
+      return false;
+#endif
+    }
+  }
+#endif
+#ifdef KOKKOSKERNELS_ENABLE_TPL_ROCSPARSE
+  if constexpr (std::is_same_v<ExecSpace, Kokkos::HIP>) {
+    // rocSPARSE csrgemm (reuse-style interface) requires sorted inputs in the general case
+    return true;
+  }
+#endif
+#ifdef KOKKOSKERNELS_ENABLE_TPL_MKL
+  // mkl_sparse_sp2m never requires sorted inputs.
+  return false;
+#endif
+  // Non-TPL path will call native, which never requires sorted inputs.
+  return false;
+}
+
 }  // namespace Impl
 
 enum SPGEMMAccumulator {
@@ -262,6 +318,11 @@ class SPGEMMHandle {
   SPGEMMAlgorithm algorithm_type;
   SPGEMMAccumulator accumulator_type;
   size_type result_nnz_size;
+
+  // Whether the user has promised input matrices A and B are sorted
+  bool input_sorted;
+  // Whether the user has requested output C is sorted
+  bool result_sorted;
 
   bool called_symbolic;
   bool computed_rowptrs;
@@ -453,11 +514,20 @@ class SPGEMMHandle {
 
   /**
    * \brief Default constructor.
+   *
+   * \param alg the SpGEMM algorithm to use.
+   * \param input_sorted_ whether inputs A and B are sorted.
+   *   Defaults to false for backwards compatibility.
+   * \param result_sorted_ whether the output matrix C are required to
+   *   be sorted (ascending by column index).
+   *   Defaults to true to maintain backwards compatibility.
    */
-  SPGEMMHandle(SPGEMMAlgorithm alg = SPGEMM_DEFAULT)
+  SPGEMMHandle(SPGEMMAlgorithm alg = SPGEMM_DEFAULT, bool input_sorted_ = false, bool result_sorted_ = true)
       : algorithm_type(alg),
         accumulator_type(SPGEMM_ACC_DEFAULT),
         result_nnz_size(0),
+        input_sorted(input_sorted_),
+        result_sorted(result_sorted_),
         called_symbolic(false),
         computed_rowptrs(false),
         computed_rowflops(false),
@@ -670,6 +740,14 @@ class SPGEMMHandle {
 
   // getters
   SPGEMMAlgorithm get_algorithm_type() const { return this->algorithm_type; }
+
+  /// \brief Return whether the user has indicated that the input matrices A and
+  /// B have sorted entries within each row.
+  bool get_input_sorted() const { return this->input_sorted; }
+
+  /// \brief Return whether the user requires the output matrix C to have sorted
+  /// entries within each row.
+  bool get_result_sorted() const { return this->result_sorted; }
 
   bool is_symbolic_called() { return this->called_symbolic; }
   bool are_rowptrs_computed() { return this->computed_rowptrs; }

--- a/sparse/src/KokkosSparse_spgemm_numeric.hpp
+++ b/sparse/src/KokkosSparse_spgemm_numeric.hpp
@@ -218,9 +218,9 @@ void spgemm_numeric(KernelHandle *handle, typename KernelHandle::const_nnz_lno_t
     return;
   }
 
-  if (Impl::is_spgemm_algorithm_native(algo)) {
-    // Never call a TPL if serial/debug is requested (this is needed for
-    // testing)
+  const bool useFallback =
+      !spgemmHandle->get_input_sorted() && Impl::algorithm_may_require_sorted_input<c_exec_t>(algo);
+  if (Impl::is_spgemm_algorithm_native(algo) || useFallback) {
     KokkosSparse::Impl::SPGEMM_NUMERIC<
         const_handle_type,  // KernelHandle,
         Internal_alno_row_view_t_, Internal_alno_nnz_view_t_, Internal_ascalar_nnz_view_t_, Internal_blno_row_view_t_,

--- a/sparse/src/KokkosSparse_spgemm_symbolic.hpp
+++ b/sparse/src/KokkosSparse_spgemm_symbolic.hpp
@@ -107,29 +107,6 @@ void spgemm_symbolic(KernelHandle *handle, typename KernelHandle::const_nnz_lno_
   Internal_blno_nnz_view_t_ const_b_l(entriesB.data(), entriesB.extent(0));
   Internal_clno_row_view_t_ c_r(row_mapC.data(), row_mapC.extent(0));
 
-  // Verify that graphs A and B are sorted.
-  // This test is designed to be as efficient as possible, but still skip
-  // it in a release build.
-  //
-  // Temporary fix for Trilinos issue #11655: Only perform this check if a TPL
-  // is to be called. The KokkosKernels (non-TPL) implementation does not
-  // actually require sorted indices yet. And Tpetra uses size_type = size_t, so
-  // it will (currently) not be calling a TPL path.
-#ifndef NDEBUG
-  if constexpr (KokkosSparse::Impl::spgemm_symbolic_tpl_spec_avail<
-                    const_handle_type, Internal_alno_row_view_t_, Internal_alno_nnz_view_t_, Internal_blno_row_view_t_,
-                    Internal_blno_nnz_view_t_, Internal_clno_row_view_t_>::value) {
-    if (!KokkosSparse::Impl::isCrsGraphSorted(const_a_r, const_a_l))
-      throw std::runtime_error(
-          "KokkosSparse::spgemm_symbolic: entries of A are not sorted within "
-          "rows. May use KokkosSparse::sort_crs_matrix to sort it.");
-    if (!KokkosSparse::Impl::isCrsGraphSorted(const_b_r, const_b_l))
-      throw std::runtime_error(
-          "KokkosSparse::spgemm_symbolic: entries of B are not sorted within "
-          "rows. May use KokkosSparse::sort_crs_matrix to sort it.");
-  }
-#endif
-
   auto spgemmHandle = tmp_handle.get_spgemm_handle();
 
   if (!spgemmHandle) {
@@ -148,7 +125,12 @@ void spgemm_symbolic(KernelHandle *handle, typename KernelHandle::const_nnz_lno_
 
   auto algo = spgemmHandle->get_algorithm_type();
 
-  if (Impl::is_spgemm_algorithm_native(algo)) {
+  // Decide at runtime whether to fallback to native. Required if the TPL for this algo/exec space
+  // requires sorted inputs, but the user has told us that the inputs are not sorted.
+  const bool useFallback =
+      !spgemmHandle->get_input_sorted() && Impl::algorithm_may_require_sorted_input<c_exec_t>(algo);
+
+  if (Impl::is_spgemm_algorithm_native(algo) || useFallback) {
     KokkosSparse::Impl::SPGEMM_SYMBOLIC<const_handle_type,  // KernelHandle,
                                         Internal_alno_row_view_t_, Internal_alno_nnz_view_t_, Internal_blno_row_view_t_,
                                         Internal_blno_nnz_view_t_, Internal_clno_row_view_t_,

--- a/sparse/tpls/KokkosSparse_spgemm_noreuse_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spgemm_noreuse_tpl_spec_decl.hpp
@@ -152,7 +152,7 @@ SPGEMM_NOREUSE_DECL_CUSPARSE_S(Kokkos::complex<double>)
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_MKL
 template <typename Matrix, typename MatrixConst>
-Matrix spgemm_noreuse_mkl(const MatrixConst &A, const MatrixConst &B) {
+Matrix spgemm_noreuse_mkl(const MatrixConst &A, const MatrixConst &B, bool result_sorted) {
   using size_type   = typename Matrix::non_const_size_type;
   using index_type  = typename Matrix::non_const_ordinal_type;
   using scalar_type = typename Matrix::non_const_value_type;
@@ -171,7 +171,9 @@ Matrix spgemm_noreuse_mkl(const MatrixConst &A, const MatrixConst &B) {
   generalDescr.mode = SPARSE_FILL_MODE_FULL;
   generalDescr.diag = SPARSE_DIAG_NON_UNIT;
   KOKKOSKERNELS_MKL_SAFE_CALL(mkl_sparse_spmm(SPARSE_OPERATION_NON_TRANSPOSE, Amkl, Bmkl, &C));
-  KOKKOSKERNELS_MKL_SAFE_CALL(mkl_sparse_order(C));
+  if (result_sorted) {
+    KOKKOSKERNELS_MKL_SAFE_CALL(mkl_sparse_order(C));
+  }
   MKLMatrix wrappedC(C);
   MKL_INT nrows = 0, ncols = 0;
   MKL_INT *rowmapRaw     = nullptr;
@@ -216,10 +218,10 @@ Matrix spgemm_noreuse_mkl(const MatrixConst &A, const MatrixConst &B) {
                                                 Kokkos::MemoryTraits<Kokkos::Unmanaged>, const MKL_INT>;              \
     static KokkosSparse::CrsMatrix<SCALAR, MKL_INT, Kokkos::Device<EXEC, Kokkos::HostSpace>, void, MKL_INT>           \
     spgemm_noreuse(KokkosSparse::SPGEMMAlgorithm, const ConstMatrix &A, bool, const ConstMatrix &B, bool, bool,       \
-                   bool) {                                                                                            \
+                   bool result_sorted) {                                                                              \
       std::string label = "KokkosSparse::spgemm_noreuse[TPL_MKL," + KokkosKernels::ArithTraits<SCALAR>::name() + "]"; \
       Kokkos::Profiling::pushRegion(label);                                                                           \
-      Matrix C = spgemm_noreuse_mkl<Matrix>(A, B);                                                                    \
+      Matrix C = spgemm_noreuse_mkl<Matrix>(A, B, result_sorted);                                                     \
       Kokkos::Profiling::popRegion();                                                                                 \
       return C;                                                                                                       \
     }                                                                                                                 \

--- a/sparse/tpls/KokkosSparse_spgemm_noreuse_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spgemm_noreuse_tpl_spec_decl.hpp
@@ -129,7 +129,7 @@ Matrix spgemm_noreuse_cusparse(KokkosSparse::SPGEMMAlgorithm algo, const MatrixC
     using ConstMatrix = KokkosSparse::CrsMatrix<const SCALAR, const int, Kokkos::Device<Kokkos::Cuda, MEMSPACE>,   \
                                                 Kokkos::MemoryTraits<Kokkos::Unmanaged>, const int>;               \
     static KokkosSparse::CrsMatrix<SCALAR, int, Kokkos::Device<Kokkos::Cuda, MEMSPACE>, void, int> spgemm_noreuse( \
-        KokkosSparse::SPGEMMAlgorithm algo, const ConstMatrix &A, bool, const ConstMatrix &B, bool) {              \
+        KokkosSparse::SPGEMMAlgorithm algo, const ConstMatrix &A, bool, const ConstMatrix &B, bool, bool, bool) {  \
       std::string label =                                                                                          \
           "KokkosSparse::spgemm_noreuse[TPL_CUSPARSE," + KokkosKernels::ArithTraits<SCALAR>::name() + "]";         \
       Kokkos::Profiling::pushRegion(label);                                                                        \
@@ -215,7 +215,8 @@ Matrix spgemm_noreuse_mkl(const MatrixConst &A, const MatrixConst &B) {
     using ConstMatrix = KokkosSparse::CrsMatrix<const SCALAR, const MKL_INT, Kokkos::Device<EXEC, Kokkos::HostSpace>, \
                                                 Kokkos::MemoryTraits<Kokkos::Unmanaged>, const MKL_INT>;              \
     static KokkosSparse::CrsMatrix<SCALAR, MKL_INT, Kokkos::Device<EXEC, Kokkos::HostSpace>, void, MKL_INT>           \
-    spgemm_noreuse(KokkosSparse::SPGEMMAlgorithm, const ConstMatrix &A, bool, const ConstMatrix &B, bool) {           \
+    spgemm_noreuse(KokkosSparse::SPGEMMAlgorithm, const ConstMatrix &A, bool, const ConstMatrix &B, bool, bool,       \
+                   bool) {                                                                                            \
       std::string label = "KokkosSparse::spgemm_noreuse[TPL_MKL," + KokkosKernels::ArithTraits<SCALAR>::name() + "]"; \
       Kokkos::Profiling::pushRegion(label);                                                                           \
       Matrix C = spgemm_noreuse_mkl<Matrix>(A, B);                                                                    \

--- a/sparse/tpls/KokkosSparse_spgemm_numeric_tpl_spec_decl.hpp
+++ b/sparse/tpls/KokkosSparse_spgemm_numeric_tpl_spec_decl.hpp
@@ -356,7 +356,11 @@ void spgemm_numeric_mkl(KernelHandle *handle, typename KernelHandle::nnz_lno_t m
   KOKKOSKERNELS_MKL_SAFE_CALL(mkl_sparse_sp2m(SPARSE_OPERATION_NON_TRANSPOSE, generalDescr, A,
                                               SPARSE_OPERATION_NON_TRANSPOSE, generalDescr, B,
                                               SPARSE_STAGE_FINALIZE_MULT, &mklSpgemmHandle->C));
-  KOKKOSKERNELS_MKL_SAFE_CALL(mkl_sparse_order(mklSpgemmHandle->C));
+  // mkl_sparse_sp2m does not produce sorted output, so sort C now if the user
+  // requires sorted output. If the user opted out of sorted output, skip to save the cost of sorting.
+  if (handle->get_result_sorted()) {
+    KOKKOSKERNELS_MKL_SAFE_CALL(mkl_sparse_order(mklSpgemmHandle->C));
+  }
   MKLMatrix wrappedC(mklSpgemmHandle->C);
   MKL_INT nrows = 0, ncols = 0;
   MKL_INT *rowptrRaw     = nullptr;

--- a/sparse/unit_test/Test_Sparse_Utils.hpp
+++ b/sparse/unit_test/Test_Sparse_Utils.hpp
@@ -23,6 +23,8 @@ vector_t create_random_y_vector_mv(crsMat_t crsMat, vector_t x_vector) {
   return y_vector;
 }
 
+// Test whether two CRS matrices are identical (shape, #nonzeros, entries, and values to within tolerance),
+// including the order of entries within each row.
 template <typename crsMat_t, typename device>
 bool is_same_matrix(crsMat_t output_mat_actual, crsMat_t output_mat_reference) {
   typedef typename crsMat_t::StaticCrsGraphType graph_t;

--- a/sparse/unit_test/Test_Sparse_spgemm.hpp
+++ b/sparse/unit_test/Test_Sparse_spgemm.hpp
@@ -491,6 +491,101 @@ void test_issue1738() {
 #endif
 }
 
+// Test spgemm with explicitly unsorted inputs. Run once while requesting sorted
+// output, and once without.
+template <typename scalar_t, typename lno_t, typename size_type, typename device>
+void test_spgemm_sortedness() {
+#if defined(KOKKOSKERNELS_ENABLE_TPL_ARMPL)
+  {
+    std::cerr << "TEST SKIPPED: See "
+                 "https://github.com/kokkos/kokkos-kernels/issues/1542 for details."
+              << std::endl;
+    return;
+  }
+#endif  // KOKKOSKERNELS_ENABLE_TPL_ARMPL
+
+  using namespace Test;
+  using crsMat_t       = CrsMatrix<scalar_t, lno_t, device, void, size_type>;
+  using graph_t        = typename crsMat_t::StaticCrsGraphType;
+  using lno_view_t     = typename graph_t::row_map_type::non_const_type;
+  using lno_nnz_view_t = typename graph_t::entries_type::non_const_type;
+  using scalar_view_t  = typename crsMat_t::values_type::non_const_type;
+  using KernelHandle =
+      KokkosKernels::Experimental::KokkosKernelsHandle<size_type, lno_t, scalar_t, typename device::execution_space,
+                                                       typename device::memory_space, typename device::memory_space>;
+  const lno_t m                 = 1000;
+  const lno_t k                 = 500;
+  const lno_t n                 = 1600;
+  size_type nnz                 = 20000;
+  const lno_t bandwidth         = 500;
+  const lno_t row_size_variance = 10;
+
+  // Generate random matrices. This relies on kk_generate_sparse_matrix not producing a sorted matrix.
+  crsMat_t A = KokkosSparse::Impl::kk_generate_sparse_matrix<crsMat_t>(m, k, nnz, row_size_variance, bandwidth);
+  crsMat_t B = KokkosSparse::Impl::kk_generate_sparse_matrix<crsMat_t>(k, n, nnz, row_size_variance, bandwidth);
+  randomize_matrix_values(A.values);
+  randomize_matrix_values(B.values);
+
+  // Compute reference C using the serial/debug algorithm.
+  crsMat_t C_reference;
+  run_spgemm<crsMat_t, device>(A, B, SPGEMM_DEBUG, C_reference, false);
+
+  std::vector<std::string> algorithm_names = {"SPGEMM_DEFAULT", "SPGEMM_KK"};
+  std::vector<SPGEMMAlgorithm> algorithms  = {SPGEMM_DEFAULT, SPGEMM_KK};
+  for (auto algo_name : algorithm_names) {
+    SPGEMMAlgorithm algo = KokkosSparse::StringToSPGEMMAlgorithm(algo_name);
+    for (bool resultSorted : {true, false}) {
+      for (bool reuse : {true, false}) {
+        crsMat_t C;
+        if (reuse) {
+          KernelHandle kh;
+          kh.create_spgemm_handle(algo, /* input_sorted */ false, /* result_sorted */ resultSorted);
+
+          const size_t num_rows_A = A.numRows();
+          const size_t num_rows_B = B.numRows();
+          const size_t num_cols_B = B.numCols();
+
+          lno_view_t row_mapC("row_mapC", num_rows_A + 1);
+          lno_nnz_view_t entriesC;
+          scalar_view_t valuesC;
+
+          KokkosSparse::spgemm_symbolic(&kh, num_rows_A, num_rows_B, num_cols_B, A.graph.row_map, A.graph.entries,
+                                        false, B.graph.row_map, B.graph.entries, false, row_mapC);
+          size_t c_nnz_size = kh.get_spgemm_handle()->get_c_nnz();
+          entriesC          = lno_nnz_view_t(Kokkos::view_alloc(Kokkos::WithoutInitializing, "entriesC"), c_nnz_size);
+          valuesC           = scalar_view_t(Kokkos::view_alloc(Kokkos::WithoutInitializing, "valuesC"), c_nnz_size);
+          KokkosSparse::spgemm_numeric(&kh, num_rows_A, num_rows_B, num_cols_B, A.graph.row_map, A.graph.entries,
+                                       A.values, false, B.graph.row_map, B.graph.entries, B.values, false, row_mapC,
+                                       entriesC, valuesC);
+          kh.destroy_spgemm_handle();
+          C = crsMat_t("C", num_rows_A, num_cols_B, c_nnz_size, valuesC, row_mapC, entriesC);
+        } else {
+          run_spgemm_noreuse(algo, A, B, C);
+        }
+
+        // If we requested sorted output, verify the output really is sorted.
+        if (resultSorted) {
+          bool sorted = KokkosSparse::Impl::isCrsGraphSorted(C.graph.row_map, C.graph.entries);
+          EXPECT_TRUE(sorted) << "spgemm (" << (reuse ? "reuse" : "non-reuse") << " interface)"
+                              << " produced unsorted output for algo " << algo_name
+                              << " even though sorted output was requested";
+        } else {
+          // Sort C for comparison
+          KokkosSparse::sort_crs_matrix(C);
+        }
+
+        // Build the result matrix and compare against the reference. is_same_matrix
+        // compares entries directly (it does not sort first), so explicitly sort
+        // C so that the comparison is valid regardless of resultSorted.
+        bool isCorrect = TestUtils::is_same_matrix<crsMat_t, device>(C, C_reference);
+        EXPECT_TRUE(isCorrect) << "spgemm with unsorted inputs produced incorrect result for algo " << algo_name
+                               << ", request sorted outputs = " << (resultSorted ? "true" : "false") << ", "
+                               << (reuse ? "reuse" : "non-reuse") << " interface";
+      }
+    }
+  }
+}
+
 #define KOKKOSKERNELS_EXECUTE_TEST(SCALAR, ORDINAL, OFFSET, DEVICE)                                                   \
   TEST_F(TestCategory, sparse##_##spgemm##_##SCALAR##_##ORDINAL##_##OFFSET##_##DEVICE) {                              \
     test_spgemm<SCALAR, ORDINAL, OFFSET, DEVICE>(10000, 8000, 6000, 8000 * 20, 500, 10, ::Test::spgemm_reuse_matrix); \
@@ -519,6 +614,7 @@ void test_issue1738() {
     test_spgemm_symbolic<SCALAR, ORDINAL, OFFSET, DEVICE>(false, false);                                              \
     test_issue402<SCALAR, ORDINAL, OFFSET, DEVICE>();                                                                 \
     test_issue1738<SCALAR, ORDINAL, OFFSET, DEVICE>();                                                                \
+    test_spgemm_sortedness<SCALAR, ORDINAL, OFFSET, DEVICE>();                                                        \
   }
 
 // test_spgemm<SCALAR,ORDINAL,OFFSET,DEVICE>(50000, 50000 * 30, 100, 10);

--- a/sparse/unit_test/Test_Sparse_spgemm.hpp
+++ b/sparse/unit_test/Test_Sparse_spgemm.hpp
@@ -56,12 +56,14 @@ void randomize_matrix_values(const Values &v) {
 }
 
 template <typename crsMat_t>
-void run_spgemm_noreuse(KokkosSparse::SPGEMMAlgorithm algo, crsMat_t A, crsMat_t B, crsMat_t &C) {
-  C = KokkosSparse::spgemm<crsMat_t>(algo, A, false, B, false);
+void run_spgemm_noreuse(KokkosSparse::SPGEMMAlgorithm algo, crsMat_t A, crsMat_t B, crsMat_t &C, bool input_sorted,
+                        bool result_sorted) {
+  C = KokkosSparse::spgemm<crsMat_t>(algo, A, false, B, false, input_sorted, result_sorted);
 }
 
 template <typename crsMat_t, typename device>
-int run_spgemm(crsMat_t &A, crsMat_t &B, KokkosSparse::SPGEMMAlgorithm spgemm_algorithm, crsMat_t &C, bool testReuse) {
+int run_spgemm(crsMat_t &A, crsMat_t &B, KokkosSparse::SPGEMMAlgorithm spgemm_algorithm, crsMat_t &C, bool testReuse,
+               bool input_sorted, bool result_sorted) {
   typedef typename crsMat_t::size_type size_type;
   typedef typename crsMat_t::ordinal_type lno_t;
   typedef typename crsMat_t::value_type scalar_t;
@@ -75,7 +77,7 @@ int run_spgemm(crsMat_t &A, crsMat_t &B, KokkosSparse::SPGEMMAlgorithm spgemm_al
   kh.set_team_work_size(16);
   kh.set_dynamic_scheduling(true);
 
-  kh.create_spgemm_handle(spgemm_algorithm);
+  kh.create_spgemm_handle(spgemm_algorithm, input_sorted, result_sorted);
   {
     auto sh = kh.get_spgemm_handle();
 
@@ -112,7 +114,7 @@ int run_spgemm(crsMat_t &A, crsMat_t &B, KokkosSparse::SPGEMMAlgorithm spgemm_al
 
 template <typename crsMat_t, typename device>
 int run_spgemm_old_interface(crsMat_t &A, crsMat_t &B, KokkosSparse::SPGEMMAlgorithm spgemm_algorithm, crsMat_t &result,
-                             bool testReuse) {
+                             bool testReuse, bool input_sorted, bool result_sorted) {
   typedef typename crsMat_t::StaticCrsGraphType graph_t;
   typedef typename graph_t::row_map_type::non_const_type lno_view_t;
   typedef typename graph_t::entries_type::non_const_type lno_nnz_view_t;
@@ -130,7 +132,7 @@ int run_spgemm_old_interface(crsMat_t &A, crsMat_t &B, KokkosSparse::SPGEMMAlgor
   kh.set_team_work_size(16);
   kh.set_dynamic_scheduling(true);
 
-  kh.create_spgemm_handle(spgemm_algorithm);
+  kh.create_spgemm_handle(spgemm_algorithm, input_sorted, result_sorted);
   {
     auto sh = kh.get_spgemm_handle();
 
@@ -197,14 +199,8 @@ void test_spgemm(lno_t m, lno_t k, lno_t n, size_type nnz, lno_t bandwidth, lno_
   }
 #endif  // KOKKOSKERNELS_ENABLE_TPL_ARMPL
   using namespace Test;
-  // device::execution_space::initialize();
-  // device::execution_space::print_configuration(std::cout);
 
   typedef CrsMatrix<scalar_t, lno_t, device, void, size_type> crsMat_t;
-  // typedef typename crsMat_t::StaticCrsGraphType graph_t;
-  // typedef typename graph_t::row_map_type::non_const_type lno_view_t;
-  // typedef typename graph_t::entries_type::non_const_type   lno_nnz_view_t;
-  // typedef typename crsMat_t::values_type::non_const_type scalar_view_t;
 
   // Generate random compressed sparse row matrix. Randomly generated (non-zero)
   // values are stored in a 1-D (1 rank) array.
@@ -220,7 +216,8 @@ void test_spgemm(lno_t m, lno_t k, lno_t n, size_type nnz, lno_t bandwidth, lno_
   // If this test won't reuse symbolic, we can compute the reference matrix once
   // here
   if (!testReuse) {
-    run_spgemm<crsMat_t, device>(A, B, SPGEMM_DEBUG, output_mat2, false);
+    run_spgemm<crsMat_t, device>(A, B, SPGEMM_DEBUG, output_mat2, /* testReuse */ false, /* input sorted */ true,
+                                 /* result sorted */ true);
   }
 
   std::vector<SPGEMMAlgorithm> algorithms;
@@ -280,12 +277,16 @@ void test_spgemm(lno_t m, lno_t k, lno_t n, size_type nnz, lno_t bandwidth, lno_
     try {
       switch (callMode) {
         case spgemm_reuse_view:
-          res = run_spgemm_old_interface<crsMat_t, device>(A, B, spgemm_algorithm, output_mat, testReuse);
+          res = run_spgemm_old_interface<crsMat_t, device>(A, B, spgemm_algorithm, output_mat, testReuse,
+                                                           /* input sorted */ true, /* result sorted */ true);
           break;
         case spgemm_reuse_matrix:
-          res = run_spgemm<crsMat_t, device>(A, B, spgemm_algorithm, output_mat, testReuse);
+          res = run_spgemm<crsMat_t, device>(A, B, spgemm_algorithm, output_mat, testReuse, /* input sorted */ true,
+                                             /* result sorted */ true);
           break;
-        case spgemm_noreuse: run_spgemm_noreuse(spgemm_algorithm, A, B, output_mat); break;
+        case spgemm_noreuse:
+          run_spgemm_noreuse(spgemm_algorithm, A, B, output_mat, /* input sorted */ true, /* result sorted */ true);
+          break;
       }
     } catch (const char *message) {
       EXPECT_TRUE(is_expected_to_fail) << algo << ": " << message;
@@ -302,7 +303,8 @@ void test_spgemm(lno_t m, lno_t k, lno_t n, size_type nnz, lno_t bandwidth, lno_
     // If this is testing reuse, the values of A and B changed so
     // the reference matrix must be recomputed
     if (testReuse) {
-      run_spgemm<crsMat_t, device>(A, B, SPGEMM_DEBUG, output_mat2, false);
+      run_spgemm<crsMat_t, device>(A, B, SPGEMM_DEBUG, output_mat2, /* reuse */ false, /* input sorted */ true,
+                                   /* result sorted */ true);
     }
 
     // double spgemm_time = timer1.seconds();
@@ -315,12 +317,8 @@ void test_spgemm(lno_t m, lno_t k, lno_t n, size_type nnz, lno_t bandwidth, lno_
                                 << ", testReuse=" << int(testReuse) << ", m=" << m << ", k=" << k << ", n=" << n
                                 << ", nnz=" << nnz << ", bandwidth=" << bandwidth
                                 << ", row_size_variance=" << row_size_variance;
-      // EXPECT_TRUE( equal) << algo;
     }
-    // std::cout << "algo:" << algo << " spgemm_time:" << spgemm_time << "
-    // output_check_time:" << timer1.seconds() << std::endl;
   }
-  // device::execution_space::finalize();
 }
 
 template <typename scalar_t, typename lno_t, typename size_type, typename device>
@@ -358,14 +356,17 @@ void test_spgemm_symbolic(bool callSymbolicFirst, bool testEmpty) {
     KokkosSparse::sort_crs_matrix(B);
   }
   // Call reference impl to get complete product
+  // Note: for both reference C and output C: we're only checking that
+  // the rowmap is correct, so don't care if result is sorted.
   crsMat_t C_reference;
-  Test::run_spgemm<crsMat_t, device>(A, B, SPGEMM_DEBUG, C_reference, false);
+  Test::run_spgemm<crsMat_t, device>(A, B, SPGEMM_DEBUG, C_reference, /* reuse */ false, /* input sorted */ true,
+                                     /* result sorted */ false);
   // Now call just symbolic, and specifically request that rowptrs be populated
   // Make sure this never depends on C_rowmap being initialized
   rowmap_t C_rowmap(Kokkos::view_alloc(Kokkos::WithoutInitializing, "rowmapC"), m + 1);
   Kokkos::deep_copy(C_rowmap, size_type(123));
   KernelHandle kh;
-  kh.create_spgemm_handle();
+  kh.create_spgemm_handle(KokkosSparse::SPGEMM_DEFAULT, /* input sorted */ true, /* output sorted */ false);
   if (callSymbolicFirst) {
     KokkosSparse::spgemm_symbolic(&kh, m, n, k, A.graph.row_map, A.graph.entries, false, B.graph.row_map,
                                   B.graph.entries, false, C_rowmap);
@@ -430,12 +431,14 @@ void test_issue402() {
   KokkosSparse::sort_crs_matrix(A);
   KokkosSparse::sort_crs_matrix(B);
   crsMat_t Cgold;
-  run_spgemm<crsMat_t, device>(A, B, SPGEMM_DEBUG, Cgold, false);
+  run_spgemm<crsMat_t, device>(A, B, SPGEMM_DEBUG, Cgold, /* reuse */ false, /* input sorted */ true,
+                               /* result sorted */ true);
   crsMat_t C;
   bool success = true;
   std::string errMsg;
   try {
-    int res = run_spgemm<crsMat_t, device>(A, B, SPGEMM_KK_MEMORY, C, false);
+    int res = run_spgemm<crsMat_t, device>(A, B, SPGEMM_KK_MEMORY, C, /* reuse */ false, /* input sorted */ true,
+                                           /* result sorted */ true);
     if (res) throw "run_spgemm returned error code";
   } catch (const char *message) {
     errMsg  = message;
@@ -520,7 +523,7 @@ void test_spgemm_sortedness() {
   const lno_t bandwidth         = 500;
   const lno_t row_size_variance = 10;
 
-  // Generate random matrices. This relies on kk_generate_sparse_matrix not producing a sorted matrix.
+  // Generate random matrices. This relies on kk_generate_sparse_matrix NOT producing a sorted matrix.
   crsMat_t A = KokkosSparse::Impl::kk_generate_sparse_matrix<crsMat_t>(m, k, nnz, row_size_variance, bandwidth);
   crsMat_t B = KokkosSparse::Impl::kk_generate_sparse_matrix<crsMat_t>(k, n, nnz, row_size_variance, bandwidth);
   randomize_matrix_values(A.values);
@@ -528,10 +531,10 @@ void test_spgemm_sortedness() {
 
   // Compute reference C using the serial/debug algorithm.
   crsMat_t C_reference;
-  run_spgemm<crsMat_t, device>(A, B, SPGEMM_DEBUG, C_reference, false);
+  run_spgemm<crsMat_t, device>(A, B, SPGEMM_DEBUG, C_reference, /* reuse */ false, /* input sorted */ false,
+                               /* result sorted */ true);
 
   std::vector<std::string> algorithm_names = {"SPGEMM_DEFAULT", "SPGEMM_KK"};
-  std::vector<SPGEMMAlgorithm> algorithms  = {SPGEMM_DEFAULT, SPGEMM_KK};
   for (auto algo_name : algorithm_names) {
     SPGEMMAlgorithm algo = KokkosSparse::StringToSPGEMMAlgorithm(algo_name);
     for (bool resultSorted : {true, false}) {
@@ -560,7 +563,7 @@ void test_spgemm_sortedness() {
           kh.destroy_spgemm_handle();
           C = crsMat_t("C", num_rows_A, num_cols_B, c_nnz_size, valuesC, row_mapC, entriesC);
         } else {
-          run_spgemm_noreuse(algo, A, B, C);
+          run_spgemm_noreuse(algo, A, B, C, /* input sorted */ false, /* result sorted */ resultSorted);
         }
 
         // If we requested sorted output, verify the output really is sorted.
@@ -570,7 +573,7 @@ void test_spgemm_sortedness() {
                               << " produced unsorted output for algo " << algo_name
                               << " even though sorted output was requested";
         } else {
-          // Sort C for comparison
+          // Sort C so we can directly compare it to sorted reference
           KokkosSparse::sort_crs_matrix(C);
         }
 


### PR DESCRIPTION
Addresses #2194 and fixes https://github.com/trilinos/Trilinos/issues/15105.

Adds `input_sorted` and `result_sorted` as options in spgemm handle, and as parameters in non-reuse spgemm interface.
- input_sorted means user promises A,B are sorted on input
  - default false for backward compatibility
- result_sorted means user needs output C to be sorted
  - default true for backward compatibility
- if a TPL is known to require sorted inputs and input_sorted=false, fall back to native automatically.

This also adds test cases for reuse and non-reuse spgemm where input_sorted is explicitly false, and where result_sorted is explicitly true. The changes to `create_spgemm_handle` and spgemm itself are documented on the wiki pages.