### PR TITLE
Batched Serial Householder: use abs instead of real in norm calculation

### DIFF
--- a/batched/dense/impl/KokkosBatched_Householder_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_Householder_Serial_Internal.hpp
@@ -35,7 +35,7 @@ struct SerialLeftHouseholderInternal {
     mag_type norm_x2_square = zero;
     for (int i = 0; i < m_x2; ++i) {
       const auto x2_at_i = x2[i * x2s];
-      norm_x2_square += KAT::real(KAT::conj(x2_at_i) * x2_at_i);
+      norm_x2_square += KAT::abs(KAT::conj(x2_at_i) * x2_at_i);
     }
 
     /// if norm_x2 is zero, return with trivial values


### PR DESCRIPTION
This PR is motivated by a compilation error we see in a Trilinos build with Stokhos enabled, and with the option "Stokhos_ENABLE_Ensemble_Reduction" set to "ON".

```
INFO:root:#19 2788.6 /Trilinos-sources/packages/kokkos-kernels/batched/dense/impl/KokkosBatched_Householder_Serial_Internal.hpp:38:22: error: no match for 'operator+=' (operand types are 'mag_type' {aka 'double'} and 'KokkosKernels::ArithTraits<Sacado::MP::Vector<Stokhos::StaticFixedStorage<int, double, 16, Kokkos::Serial> > >::val_type' {aka 'Sacado::MP::Vector<Stokhos::StaticFixedStorage<int, double, 16, Kokkos::Serial> >'})
INFO:root:#19 2788.6    38 |       norm_x2_square += KAT::real(KAT::conj(x2_at_i) * x2_at_i);
```

The issue appears to be that with ensemble reduction, the `norm_x2_square` has magnitude type and is "reduced to a" scalar, whereas the conjugate and the real part are left as ensembles.

The proposed fix is to replace `KAT::real` with `KAT::abs` in this line. Indeed, with ensemble reduction, the `abs` function reduces to a scalar.

Tagging @cgcgcg as the last PR that had modified this line was:
- #3051

@etphipp 
