### PR TITLE
  Implement right-transpose SerialApplyQ

### DIFF
--- a/batched/dense/impl/KokkosBatched_ApplyQ_Serial_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_ApplyQ_Serial_Impl.hpp
@@ -110,6 +110,38 @@ KOKKOS_INLINE_FUNCTION int SerialApplyQ<Side::Right, Trans::NoTranspose, Algo::A
                                                    B.stride(1), w.data());
 }
 
+template <>
+template <typename AViewType, typename tViewType, typename BViewType, typename wViewType>
+KOKKOS_INLINE_FUNCTION int SerialApplyQ<Side::Right, Trans::Transpose, Algo::ApplyQ::Unblocked>::invoke(
+    const AViewType &A, const tViewType &t, const BViewType &B, const wViewType &w) {
+  static_assert(Kokkos::is_view_v<AViewType>, "KokkosBatched::SerialApplyQ::invoke: AViewType must be a Kokkos::View");
+  static_assert(AViewType::rank() == 2, "KokkosBatched::SerialApplyQ::invoke: AViewType must have rank 2");
+
+  static_assert(Kokkos::is_view_v<tViewType>, "KokkosBatched::SerialApplyQ::invoke: tViewType must be a Kokkos::View");
+  static_assert(tViewType::rank() == 1, "KokkosBatched::SerialApplyQ::invoke: tViewType must have rank 1");
+
+  static_assert(Kokkos::is_view_v<BViewType>, "KokkosBatched::SerialApplyQ::invoke: BViewType must be a Kokkos::View");
+  static_assert(BViewType::rank() == 2, "KokkosBatched::SerialApplyQ::invoke: BViewType must have rank 2");
+
+  static_assert(Kokkos::is_view_v<wViewType>, "KokkosBatched::SerialApplyQ::invoke: wViewType must be a Kokkos::View");
+  static_assert(wViewType::rank() == 1, "KokkosBatched::SerialApplyQ::invoke: wViewType must have rank 1");
+
+#ifndef NDEBUG
+  if (!w.span_is_contiguous()) {
+    Kokkos::printf("KokkosBatched::SerialApplyQ::invoke: w must have a contiguous span.");
+    return 1;
+  }
+  if (A.extent_int(1) != t.extent_int(0)) {
+    Kokkos::printf("KokkosBatched::SerialApplyQ::invoke: A.extent(1) is different from t.extent(0).");
+    return 1;
+  }
+#endif
+
+  return SerialApplyQ_RightBackwardInternal::invoke(B.extent(0), B.extent(1), A.extent(1), A.data(), A.stride(0),
+                                                    A.stride(1), t.data(), t.stride(0), B.data(), B.stride(0),
+                                                    B.stride(1), w.data());
+}
+
 }  // namespace KokkosBatched
 
 #endif

--- a/batched/dense/impl/KokkosBatched_ApplyQ_Serial_Internal.hpp
+++ b/batched/dense/impl/KokkosBatched_ApplyQ_Serial_Internal.hpp
@@ -177,6 +177,60 @@ struct SerialApplyQ_RightForwardInternal {
   }
 };
 
+struct SerialApplyQ_RightBackwardInternal {
+  template <typename ValueType>
+  KOKKOS_INLINE_FUNCTION static int invoke(const int m, const int n, const int k,
+                                           /* */ ValueType *A, const int as0, const int as1,
+                                           /* */ ValueType *t, const int ts,
+                                           /* */ ValueType *B, const int bs0, const int bs1,
+                                           /* */ ValueType *w) {
+    using value_type = ValueType;
+    using KAT        = KokkosKernels::ArithTraits<value_type>;
+
+    /// Given a matrix A that includes a series of householder vectors,
+    /// it applies a unitary matrix Q to B from right with transpose
+    ///   B = B Q^H = B (H(k-1)^H H(k-2)^H ... H0^H)
+    /// where
+    ///   A is n x k (holding H0, H1 ... H(k-1)
+    ///   t is k x 1
+    ///   B is m x n
+
+    // partitions used for loop iteration
+    Partition2x2<value_type> A_part2x2(as0, as1);
+    Partition3x3<value_type> A_part3x3(as0, as1);
+
+    Partition2x1<value_type> t_part2x1(ts);
+    Partition3x1<value_type> t_part3x1(ts);
+
+    Partition1x2<value_type> B_part1x2(bs1);
+    Partition1x3<value_type> B_part1x3(bs1);
+
+    // initial partition of A where ABR has a zero dimension
+    A_part2x2.partWithABR(A, n, k, n - k, 0);
+    t_part2x1.partWithAB(t, k, 0);
+    B_part1x2.partWithAR(B, n, n - k);
+
+    for (int n_A0 = (k - 1); n_A0 >= 0; --n_A0) {
+      // part 2x2 into 3x3
+      A_part3x3.partWithATL(A_part2x2, 1, 1);
+      t_part3x1.partWithAT(t_part2x1, 1);
+      const value_type tau = KAT::conj(*t_part3x1.A1);
+
+      B_part1x3.partWithAL(B_part1x2, 1);
+      const int n_B2 = n - n_A0 - 1;
+      /// -----------------------------------------------------
+      // right apply transposed householder to partitioned B1 and B2
+      SerialApplyRightHouseholderInternal::invoke(m, n_B2, &tau, A_part3x3.A21, as0, B_part1x3.A1, bs0, B_part1x3.A2,
+                                                  bs0, bs1, w);
+      /// -----------------------------------------------------
+      A_part2x2.mergeToABR(A_part3x3);
+      t_part2x1.mergeToAB(t_part3x1);
+      B_part1x2.mergeToAR(B_part1x3);
+    }
+    return 0;
+  }
+};
+
 }  // end namespace KokkosBatched
 
 #endif

--- a/batched/dense/unit_test/Test_Batched_SerialQR.hpp
+++ b/batched/dense/unit_test/Test_Batched_SerialQR.hpp
@@ -122,6 +122,18 @@ struct qrFunctor {
       }
     }
 
+    // Applying Q and Q^H from the right should recover the identity matrix
+    for (int idx = 0; idx < w.extent_int(0); ++idx) {
+      w(idx) = 0.0;
+    }
+    KokkosBatched::SerialApplyQ<Side::Right, Trans::Transpose, Algo::ApplyQ::Unblocked>::invoke(A, tau, Q, w);
+    for (int rowIdx = 0; rowIdx < Q.extent_int(0); ++rowIdx) {
+      for (int colIdx = 0; colIdx < Q.extent_int(1); ++colIdx) {
+        const Scalar expected = rowIdx == colIdx ? SC_one : KAT::zero();
+        if (Kokkos::abs(Q(rowIdx, colIdx) - expected) > tol) ++error_lcl;
+      }
+    }
+
     // Apply Q' to B which holds a copy of the orginal A
     // Afterwards B should hold a copy of R and be zero below its diagonal
     for (int idx = 0; idx < w.extent_int(0); ++idx) {


### PR DESCRIPTION
Fixes #3087.

Adds the missing `SerialApplyQ<Side::Right, Trans::Transpose, Algo::ApplyQ::Unblocked>` specialization.

The implementation reuses the existing right-side Householder operation, traversing the reflectors in reverse order and conjugating `tau` for complex scalars.

The existing SerialQR tests now verify that applying `Q` followed by `Q^H` from the right recovers the original matrix. Existing coverage includes square and rectangular factorizations and the supported real and complex scalar types.

Testing:
- SerialQR batch tests pass for all four scalar types.
- Full `batched_dla_serial` test suite passes.