### PR TITLE
Fix argument mismatch for num_symmetric_edges

### DIFF
--- a/common/src/KokkosKernels_Utils.hpp
+++ b/common/src/KokkosKernels_Utils.hpp
@@ -717,7 +717,7 @@ void symmetrize_and_get_lower_diagonal_edge_list(typename in_lno_nnz_view_t::val
 
   out_lno_row_view_t pre_pps_("pre_pps", num_rows_to_symmetrize + 1);
 
-  typename out_lno_row_view_t::non_const_value_type num_symmetric_edges = 0;
+  idx num_symmetric_edges = 0;
   {
     hashmap_t umap(nnz);
     umap.clear();

--- a/common/src/KokkosKernels_Utils.hpp
+++ b/common/src/KokkosKernels_Utils.hpp
@@ -717,7 +717,7 @@ void symmetrize_and_get_lower_diagonal_edge_list(typename in_lno_nnz_view_t::val
 
   out_lno_row_view_t pre_pps_("pre_pps", num_rows_to_symmetrize + 1);
 
-  idx num_symmetric_edges = 0;
+  typename out_lno_row_view_t::non_const_value_type num_symmetric_edges = 0;
   {
     hashmap_t umap(nnz);
     umap.clear();
@@ -787,7 +787,7 @@ void symmetrize_graph_symbolic_hashmap(typename in_lno_row_view_t::value_type nu
 
   out_lno_row_view_t pre_pps_("pre_pps", num_rows_to_symmetrize + 1);
 
-  idx num_symmetric_edges = 0;
+  typename out_lno_row_view_t::non_const_value_type num_symmetric_edges = 0;
   {
     hashmap_t umap(nnz);
     umap.clear();


### PR DESCRIPTION
Resolve compilation errors detected in nightly Trilinos integration tests of form:
```
/root/Trilinos/kokkos-kernels/common/src/KokkosKernels_Utils.hpp(812): error: no instance of overloaded function "KokkosKernels::exclusive_parallel_prefix_sum" matches the argument list
            argument types are: (Kokkos::HostSpace::execution_space, Kokkos::View<int *, Kokkos::Serial::memory_space>, idx)
      KokkosKernels::exclusive_parallel_prefix_sum(MyExecSpace(), pre_pps_, num_symmetric_edges);
      ^
/root/Trilinos/kokkos-kernels/common/src/KokkosKernels_SimpleUtils.hpp(384): note #3322-D: number of parameters of function template "KokkosKernels::exclusive_parallel_prefix_sum(const view_t &, view_t::non_const_value_type &)" does not match the call
  void exclusive_parallel_prefix_sum(const view_t &arr, typename view_t::non_const_value_type &finalSum) {
       ^
/root/Trilinos/kokkos-kernels/common/src/KokkosKernels_SimpleUtils.hpp(368): note #3326-D: function template "KokkosKernels::exclusive_parallel_prefix_sum(const ExecSpace &, const view_t &, view_t::non_const_value_type &)" does not match because argument #3 does not match parameter
  void exclusive_parallel_prefix_sum(const ExecSpace &exec, const view_t &arr,
       ^
/root/Trilinos/kokkos-kernels/common/src/KokkosKernels_SimpleUtils.hpp(354): note #3322-D: number of parameters of function template "KokkosKernels::exclusive_parallel_prefix_sum(const view_t &)" does not match the call
  void exclusive_parallel_prefix_sum(const view_t &arr) {
       ^
/root/Trilinos/kokkos-kernels/common/src/KokkosKernels_SimpleUtils.hpp(342): note #3322-D: number of parameters of function template "KokkosKernels::exclusive_parallel_prefix_sum(const ExecSpace &, const view_t &)" does not match the call
  void exclusive_parallel_prefix_sum(const ExecSpace &exec, const view_t &arr) {
```