### PR TITLE
Add missing <bit> header in KokkosBatched_HostLevel_Gemm_DblBuf_Impl.hpp

### DIFF
--- a/batched/dense/impl/KokkosBatched_HostLevel_Gemm_DblBuf_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_HostLevel_Gemm_DblBuf_Impl.hpp
@@ -6,6 +6,8 @@
 #include "KokkosBatched_Util.hpp"
 #include "KokkosKernels_Error.hpp"
 
+#include <bit>  // std::bit_floor
+
 namespace KokkosBatched {
 /********************* BEGIN functor-level routines *********************/
 /********************* END   functor-level routines *********************/


### PR DESCRIPTION
Fixes compiling with clang++-23.
`std::bit_floor` was introduced in https://github.com/kokkos/kokkos-kernels/pull/2967.