### PR TITLE
[5.2.2] Cherry-picks for 5.2.2: #3248 , #3251 , #3271 , #3286

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Export enabled TPLs in KokkosKernelsConfig.cmake [\#3248](https://github.com/kokkos/kokkos-kernels/pull/3248)
   - Fix typo KokkosKernels_TPL_ENABLE -> KokkosKernels_ENABLE_TPL [\#3251](https://github.com/kokkos/kokkos-kernels/pull/3251)
 - Indexing fixes for structured matrix generation in tests [\#3271](https://github.com/kokkos/kokkos-kernels/pull/3271)
+- Add missing <bit> header in KokkosBatched_HostLevel_Gemm_DblBuf_Impl.hpp [\#3286](https://github.com/kokkos/kokkos-kernels/pull/3286)
 
 ## [5.2.1](https://github.com/kokkos/kokkos-kernels/tree/5.2.1)
 [Full Changelog](https://github.com/kokkos/kokkos-kernels/compare/5.2.0...5.2.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## [5.2.2](https://github.com/kokkos/kokkos-kernels/tree/5.2.2)
+[Full Changelog](https://github.com/kokkos/kokkos-kernels/compare/5.2.1...5.2.2)
+
+### Bug fixes
+
+- Export enabled TPLs in KokkosKernelsConfig.cmake [\#3248](https://github.com/kokkos/kokkos-kernels/pull/3248)
+  - Fix typo KokkosKernels_TPL_ENABLE -> KokkosKernels_ENABLE_TPL [\#3251](https://github.com/kokkos/kokkos-kernels/pull/3251)
+- Indexing fixes for structured matrix generation in tests [\#3271](https://github.com/kokkos/kokkos-kernels/pull/3271)
+
 ## [5.2.1](https://github.com/kokkos/kokkos-kernels/tree/5.2.1)
 [Full Changelog](https://github.com/kokkos/kokkos-kernels/compare/5.2.0...5.2.1)
 

--- a/batched/dense/impl/KokkosBatched_HostLevel_Gemm_DblBuf_Impl.hpp
+++ b/batched/dense/impl/KokkosBatched_HostLevel_Gemm_DblBuf_Impl.hpp
@@ -6,6 +6,8 @@
 #include "KokkosBatched_Util.hpp"
 #include "KokkosKernels_Error.hpp"
 
+#include <bit>  // std::bit_floor
+
 namespace KokkosBatched {
 /********************* BEGIN functor-level routines *********************/
 /********************* END   functor-level routines *********************/

--- a/cmake/KokkosKernelsConfig.cmake.in
+++ b/cmake/KokkosKernelsConfig.cmake.in
@@ -7,6 +7,11 @@ include(CMakeFindDependencyMacro)
 
 @KOKKOSKERNELS_TPL_EXPORTS@
 
+set(KokkosKernels_TPLS @KOKKOSKERNELS_TPL_LIST@)
+foreach(TPL ${KokkosKernels_TPLS})
+  set(KokkosKernels_TPL_ENABLE_${TPL} ON)
+endforeach()
+
 if(NOT Kokkos_FOUND)
   find_dependency(Kokkos HINTS @Kokkos_DIR@)
 endif()

--- a/cmake/KokkosKernelsConfig.cmake.in
+++ b/cmake/KokkosKernelsConfig.cmake.in
@@ -9,7 +9,7 @@ include(CMakeFindDependencyMacro)
 
 set(KokkosKernels_TPLS @KOKKOSKERNELS_TPL_LIST@)
 foreach(TPL ${KokkosKernels_TPLS})
-  set(KokkosKernels_TPL_ENABLE_${TPL} ON)
+  set(KokkosKernels_ENABLE_TPL_${TPL} ON)
 endforeach()
 
 if(NOT Kokkos_FOUND)

--- a/test_common/KokkosKernels_Test_Structured_Matrix.hpp
+++ b/test_common/KokkosKernels_Test_Structured_Matrix.hpp
@@ -1516,7 +1516,7 @@ struct fill_3D_matrix_functor {
 
     // Fill column indices
     columns(rowOffset - 5) = rowIdx - ny * nx;
-    columns(rowOffset - 4) = rowIdx - 1;
+    columns(rowOffset - 4) = rowIdx - nx;
     columns(rowOffset - 3) = rowIdx;
     columns(rowOffset - 2) = rowIdx + 1;
     columns(rowOffset - 1) = rowIdx + nx;
@@ -2209,7 +2209,7 @@ struct fill_3D_matrix_functor {
     // Fill column indices
     columns(rowOffset - 18) = rowIdx - ny * nx - nx - 1;
     columns(rowOffset - 17) = rowIdx - ny * nx - nx;
-    columns(rowOffset - 16) = rowIdx - ny * nx - 1;
+    columns(rowOffset - 16) = rowIdx - ny * nx - nx + 1;
     columns(rowOffset - 15) = rowIdx - ny * nx - 1;
     columns(rowOffset - 14) = rowIdx - ny * nx;
     columns(rowOffset - 13) = rowIdx - ny * nx + 1;
@@ -2636,6 +2636,7 @@ struct fill_3D_matrix_functor {
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const yEdgeFETag&, const ordinal_type idx) const {
+    // Bottom-Left Edge
     // Compute row index
     ordinal_type j      = idx;
     ordinal_type rowIdx = (j + 1) * nx;
@@ -2687,6 +2688,7 @@ struct fill_3D_matrix_functor {
       values(rowOffset - 1)  = -1.0;
     }
 
+    // Bottom-Right Edge
     // Compute row index
     j              = idx;
     ordinal_type i = nx - 1;
@@ -2739,6 +2741,7 @@ struct fill_3D_matrix_functor {
       values(rowOffset - 1)  = 0.0;
     }
 
+    // Top-Left Edge
     // Compute row index
     ordinal_type k = nz - 2;
     j              = idx;
@@ -2750,16 +2753,16 @@ struct fill_3D_matrix_functor {
     rowmap(rowIdx + 1) = rowOffset;
 
     // Fill column indices
-    columns(rowOffset - 12) = rowIdx - nx * ny - 1;
-    columns(rowOffset - 11) = rowIdx - nx * ny;
-    columns(rowOffset - 10) = rowIdx - nx * ny + 1;
-    columns(rowOffset - 9)  = rowIdx - nx * ny + nx - 1;
+    columns(rowOffset - 12) = rowIdx - nx * ny - nx;
+    columns(rowOffset - 11) = rowIdx - nx * ny - nx + 1;
+    columns(rowOffset - 10) = rowIdx - nx * ny;
+    columns(rowOffset - 9)  = rowIdx - nx * ny + 1;
     columns(rowOffset - 8)  = rowIdx - nx * ny + nx;
     columns(rowOffset - 7)  = rowIdx - nx * ny + nx + 1;
-    columns(rowOffset - 6)  = rowIdx - 1;
-    columns(rowOffset - 5)  = rowIdx;
-    columns(rowOffset - 4)  = rowIdx + 1;
-    columns(rowOffset - 3)  = rowIdx + nx - 1;
+    columns(rowOffset - 6)  = rowIdx - nx;
+    columns(rowOffset - 5)  = rowIdx - nx + 1;
+    columns(rowOffset - 4)  = rowIdx;
+    columns(rowOffset - 3)  = rowIdx + 1;
     columns(rowOffset - 2)  = rowIdx + nx;
     columns(rowOffset - 1)  = rowIdx + nx + 1;
     if (topBC == 1 || leftBC == 1) {
@@ -2792,6 +2795,7 @@ struct fill_3D_matrix_functor {
       values(rowOffset - 1)  = -1.0;
     }
 
+    // Top-Right Edge
     // Compute row index
     k      = nz - 2;
     j      = idx;


### PR DESCRIPTION
- Export enabled TPLs in KokkosKernelsConfig.cmake [\#3248](https://github.com/kokkos/kokkos-kernels/pull/3248)
  - Fix typo KokkosKernels_TPL_ENABLE -> KokkosKernels_ENABLE_TPL [\#3251](https://github.com/kokkos/kokkos-kernels/pull/3251)
- Indexing fixes for structured matrix generation in tests [\#3271](https://github.com/kokkos/kokkos-kernels/pull/3271)
- Add missing <bit> header in KokkosBatched_HostLevel_Gemm_DblBuf_Impl.hpp [\#3286](https://github.com/kokkos/kokkos-kernels/pull/3286)
- CHANGELOG.md updated with 5.2.2 entries