### PR TITLE
fix(ode): residual & Jacobian being computed at wrong time

### DIFF
--- a/ode/impl/KokkosODE_BDF_impl.hpp
+++ b/ode/impl/KokkosODE_BDF_impl.hpp
@@ -71,8 +71,8 @@ struct BDF_system_wrapper {
 
   template <class vec_type>
   KOKKOS_FUNCTION void residual(const vec_type& y, const vec_type& f) const {
-    // f = f(t+dt, y)
-    mySys.evaluate_function(t, dt, y, f);
+    // The implicit BDF stage is evaluated at the end of the step,
+    mySys.evaluate_function(t + dt, dt, y, f);
 
     for (int eqIdx = 0; eqIdx < neqs; ++eqIdx) {
       f(eqIdx) = y(eqIdx) - table.coefficients[order] * dt * f(eqIdx);
@@ -84,7 +84,7 @@ struct BDF_system_wrapper {
 
   template <class vec_type, class mat_type>
   KOKKOS_FUNCTION void jacobian(const vec_type& y, const mat_type& jac) const {
-    mySys.evaluate_jacobian(t, dt, y, jac);
+    mySys.evaluate_jacobian(t + dt, dt, y, jac);
 
     for (int rowIdx = 0; rowIdx < neqs; ++rowIdx) {
       for (int colIdx = 0; colIdx < neqs; ++colIdx) {
@@ -112,8 +112,8 @@ struct BDF_system_wrapper2 {
 
   template <class YVectorType, class FVectorType>
   KOKKOS_FUNCTION void residual(const YVectorType& y, const FVectorType& f) const {
-    // f = f(t+dt, y)
-    mySys.evaluate_function(t, dt, y, f);
+    // The implicit stage is evaluated at the end of the step,
+    mySys.evaluate_function(t + dt, dt, y, f);
 
     // std::cout << "f = psi + d - c * f = " << psi(0) << " + " << d(0) << " - "
     // << c << " * " << f(0) << std::endl;
@@ -127,7 +127,7 @@ struct BDF_system_wrapper2 {
   template <class vec_type, class mat_type>
   KOKKOS_FUNCTION void jacobian(const vec_type& y, const mat_type& jac) const {
     if (compute_jac) {
-      mySys.evaluate_jacobian(t, dt, y, jac);
+      mySys.evaluate_jacobian(t + dt, dt, y, jac);
 
       // J = I - dt*(df/dy)
       for (int rowIdx = 0; rowIdx < neqs; ++rowIdx) {
@@ -354,7 +354,10 @@ KOKKOS_FUNCTION void BDFStep(ode_type& ode, scalar_type& t, scalar_type& dt, sca
     KokkosBlas::Experimental::serial_gemv('N', 1.0 / alpha[order], subD, subGamma, 0.0, psi);
 
     sys.compute_jac = true;
-    sys.c           = dt / alpha[order];
+    // dt may have been halved or clamped since the last attempt: refresh
+    // the wrapper so the residual and Jacobian see the current step.
+    sys.dt = dt;
+    sys.c  = dt / alpha[order];
     sys.jacobian(y_new, jac);
     sys.compute_jac = true;
     Kokkos::Experimental::local_deep_copy(y_new, y_predict);

--- a/ode/unit_test/Test_ODE_BDF.hpp
+++ b/ode/unit_test/Test_ODE_BDF.hpp
@@ -114,6 +114,34 @@ struct StiffChemistry {
   }
 };
 
+// Non-autonomous polynomial ODE
+// Since its right hand side depends explicitly
+// on time it detects implicit stages evaluated
+// at the wrong time: BDF2 reproduces the degree
+// two polynomial solution exactly only when f
+// is evaluated at t+dt.
+//
+// Equation: y'(t) = t + 1
+// Jacobian: df/dy = 0
+// Solution: y = 0.5*t^2 + t + y0
+struct TimeDependentPoly {
+  static constexpr int neqs = 1;
+
+  TimeDependentPoly() {}
+
+  template <class vec_type1, class vec_type2>
+  KOKKOS_FUNCTION void evaluate_function(const double t, const double /*dt*/, const vec_type1& /*y*/,
+                                         const vec_type2& f) const {
+    f(0) = t + 1.0;
+  }
+
+  template <class vec_type, class mat_type>
+  KOKKOS_FUNCTION void evaluate_jacobian(const double /*t*/, const double /*dt*/, const vec_type& /*y*/,
+                                         const mat_type& jac) const {
+    jac(0, 0) = 0.0;
+  }
+};
+
 template <class ode_type, KokkosODE::Experimental::BDF_type bdf_type, class vec_type, class mv_type, class mat_type,
           class scalar_type>
 struct BDFSolve_wrapper {
@@ -715,6 +743,72 @@ void test_BDF_adaptive_stiff() {
             << std::endl;
 }
 
+// Integrate a non-autonomous ODE, y' = t + 1, with both the fixed
+// order and the adaptive BDF solvers. The implicit stage of BDF is
+// taken at the end of the step so f and its Jacobian have to be
+// evaluated at t+dt: evaluating them at t instead leaves an O(dt)
+// error in the solution which both checks below detect.
+template <class device_type, class scalar_type>
+void test_BDF_time_dependence() {
+  using execution_space = typename device_type::execution_space;
+  using vec_type        = Kokkos::View<scalar_type*, execution_space>;
+  using mv_type         = Kokkos::View<scalar_type**, execution_space>;
+  using mat_type        = Kokkos::View<scalar_type**, execution_space>;
+
+  TimeDependentPoly mySys{};
+  Kokkos::RangePolicy<execution_space> myPolicy(0, 1);
+
+  const scalar_type t_start = 0.0, t_end = 1.0;
+  const scalar_type exact_val = 0.5 * t_end * t_end + t_end + 1.0;
+
+  // Fixed order: BDF2 integrates the degree two polynomial solution
+  // exactly so any error beyond round-off comes from evaluating the
+  // implicit stage at the wrong time.
+  {
+    constexpr int num_steps = 10;
+    vec_type y0("initial conditions", mySys.neqs), y_new("solution", mySys.neqs);
+    vec_type rhs("rhs", mySys.neqs), update("update", mySys.neqs);
+    vec_type scale("scaling factors", mySys.neqs);
+    mat_type jac("jacobian", mySys.neqs, mySys.neqs), temp("temp storage", mySys.neqs, mySys.neqs + 4);
+    mv_type kstack("Startup RK vectors", 6, mySys.neqs);
+    mv_type y_vecs("history vectors", mySys.neqs, 2);
+
+    Kokkos::deep_copy(scale, 1);
+    Kokkos::deep_copy(y0, 1.0);
+
+    BDFSolve_wrapper<TimeDependentPoly, KokkosODE::Experimental::BDF_type::BDF2, vec_type, mv_type, mat_type,
+                     scalar_type>
+        solve_wrapper(mySys, t_start, t_end, num_steps, y0, y_new, rhs, update, scale, y_vecs, kstack, temp, jac);
+    Kokkos::parallel_for(myPolicy, solve_wrapper);
+    Kokkos::fence();
+
+    auto y_new_h = Kokkos::create_mirror_view(y_new);
+    Kokkos::deep_copy(y_new_h, y_new);
+
+    EXPECT_NEAR_KK(y_new_h(0), exact_val, 1e-10);
+  }
+
+  // Adaptive: with f evaluated at t instead of t+dt the error at
+  // t_end is ~1e-1, two orders of magnitude above the tolerance
+  // used here (the solver targets atol=1e-6, rtol=1e-3).
+  {
+    vec_type y0("initial conditions", mySys.neqs), y_new("solution", mySys.neqs);
+    mat_type temp("buffer1", mySys.neqs, 23 + 2 * mySys.neqs + 4), temp2("buffer2", 6, 7);
+
+    Kokkos::deep_copy(y0, 1.0);
+
+    const scalar_type dt = (t_end - t_start) / 100;
+    BDF_Solve_wrapper bdf_wrapper(mySys, t_start, t_end, dt, (t_end - t_start) / 10, y0, y_new, temp, temp2);
+    Kokkos::parallel_for(myPolicy, bdf_wrapper);
+    Kokkos::fence();
+
+    auto y_new_h = Kokkos::create_mirror_view(y_new);
+    Kokkos::deep_copy(y_new_h, y_new);
+
+    EXPECT_NEAR_KK(y_new_h(0), exact_val, 1e-3);
+  }
+}  // test_BDF_time_dependence
+
 }  // namespace Test
 
 TEST_F(TestCategory, BDF_Logistic_serial) { ::Test::test_BDF_Logistic<TestDevice, double>(); }
@@ -729,3 +823,4 @@ TEST_F(TestCategory, BDF_Nordsieck) { ::Test::test_Nordsieck<TestDevice, double>
 //   ::Test::test_adaptive_BDF_v2<TestDevice, double>();
 // }
 TEST_F(TestCategory, BDF_StiffChemistry_adaptive) { ::Test::test_BDF_adaptive_stiff<TestDevice, double>(); }
+TEST_F(TestCategory, BDF_time_dependence) { ::Test::test_BDF_time_dependence<TestDevice, double>(); }


### PR DESCRIPTION
Previously they were being computed at `t` when it should be at `t+dt`. Additionally, `sys.c` and `sys.dt` weren't being updated inside the retry loop so that hat been fixed as well.

Added a test that tests for this bug

Assisted-by: Claude:fable-5