### PR TITLE
fix(ode): iteration matrix using `dt` instead of `c`

### DIFF
--- a/ode/impl/KokkosODE_BDF_impl.hpp
+++ b/ode/impl/KokkosODE_BDF_impl.hpp
@@ -129,10 +129,12 @@ struct BDF_system_wrapper2 {
     if (compute_jac) {
       mySys.evaluate_jacobian(t, dt, y, jac);
 
-      // J = I - dt*(df/dy)
+      // Jacobian of the corrector residual psi + (y - y_predict) - c*f:
+      //   J = I - c*(df/dy),  with c = dt/alpha[order].
+      // This must use the same c that scales f in residual()
       for (int rowIdx = 0; rowIdx < neqs; ++rowIdx) {
         for (int colIdx = 0; colIdx < neqs; ++colIdx) {
-          jac(rowIdx, colIdx) = -dt * jac(rowIdx, colIdx);
+          jac(rowIdx, colIdx) = -c * jac(rowIdx, colIdx);
         }
         jac(rowIdx, rowIdx) += 1.0;
       }

--- a/ode/unit_test/Test_ODE_BDF.hpp
+++ b/ode/unit_test/Test_ODE_BDF.hpp
@@ -711,8 +711,19 @@ void test_BDF_adaptive_stiff() {
 
   auto y_new_h = Kokkos::create_mirror_view(y_new);
   Kokkos::deep_copy(y_new_h, y_new);
-  std::cout << "Stiff Chemistry solution at t=500: {" << y_new_h(0) << ", " << y_new_h(1) << ", " << y_new_h(2) << "}"
+  std::cout << "Stiff Chemistry solution at t=350: {" << y_new_h(0) << ", " << y_new_h(1) << ", " << y_new_h(2) << "}"
             << std::endl;
+
+  // Reference solution at t=350 computed with SciPy's Radau integrator
+  // using rtol=1e-12 and atol=1e-14. BDFSolve integrates with rtol=1e-3
+  // so we check the solution with a relative tolerance of 5e-3.
+  // Scaling the Jacobian of the corrector residual with dt instead of
+  // c=dt/alpha[order] leads to relative errors around 9e-3 which this
+  // test would catch, see issue #5.
+  const scalar_type y_ref[3] = {4.6713854e-01, 3.4400401e-06, 5.3285802e-01};
+  EXPECT_NEAR_KK_REL(y_new_h(0), y_ref[0], 5.0e-3);
+  EXPECT_NEAR_KK_REL(y_new_h(1), y_ref[1], 5.0e-3);
+  EXPECT_NEAR_KK_REL(y_new_h(2), y_ref[2], 5.0e-3);
 }
 
 }  // namespace Test


### PR DESCRIPTION
This must use the same c that scales f in residual().

Added a regression test for this bug

Assisted-by: Claude:fable-5