### PR TITLE
fix(ode): use `max_step` provided to `BDFSolve`

### DIFF
--- a/ode/impl/KokkosODE_BDF_impl.hpp
+++ b/ode/impl/KokkosODE_BDF_impl.hpp
@@ -248,11 +248,11 @@ KOKKOS_FUNCTION void initial_step_size(const ode_type ode, const int order, cons
 }  // initial_step_size
 
 template <class ode_type, class vec_type, class res_type, class mat_type, class scalar_type>
-KOKKOS_FUNCTION void BDFStep(ode_type& ode, scalar_type& t, scalar_type& dt, scalar_type t_end, int& order,
-                             int& num_equal_steps, const int max_newton_iters, const scalar_type atol,
-                             const scalar_type rtol, const scalar_type min_factor, const vec_type& y_old,
-                             const vec_type& y_new, const res_type& rhs, const res_type& update, const mat_type& temp,
-                             const mat_type& temp2) {
+KOKKOS_FUNCTION void BDFStep(ode_type& ode, scalar_type& t, scalar_type& dt, scalar_type t_end,
+                             const scalar_type max_step, int& order, int& num_equal_steps, const int max_newton_iters,
+                             const scalar_type atol, const scalar_type rtol, const scalar_type min_factor,
+                             const vec_type& y_old, const vec_type& y_new, const res_type& rhs, const res_type& update,
+                             const mat_type& temp, const mat_type& temp2) {
   using newton_params = KokkosODE::Experimental::Newton_params;
 
   constexpr int max_order = 5;
@@ -306,7 +306,6 @@ KOKKOS_FUNCTION void BDFStep(ode_type& ode, scalar_type& t, scalar_type& dt, sca
       max_newton_iters, atol,
       Kokkos::max(10 * KokkosKernels::ArithTraits<scalar_type>::eps() / rtol, Kokkos::min(0.03, Kokkos::sqrt(rtol))));
 
-  scalar_type max_step = KokkosKernels::ArithTraits<scalar_type>::max();
   scalar_type min_step = KokkosKernels::ArithTraits<scalar_type>::min();
   scalar_type safety = 0.675, error_norm = 0.0;
   if (dt > max_step) {

--- a/ode/src/KokkosODE_BDF.hpp
+++ b/ode/src/KokkosODE_BDF.hpp
@@ -144,15 +144,13 @@ struct BDF {
 /// \param temp2 [in]: vectors for temporary storage
 template <class ode_type, class mat_type, class vec_type, class scalar_type>
 KOKKOS_FUNCTION void BDFSolve(const ode_type& ode, const scalar_type t_start, const scalar_type t_end,
-                              const scalar_type initial_step, const scalar_type max_step, const vec_type& y0,
+                              const scalar_type initial_step, scalar_type max_step, const vec_type& y0,
                               const vec_type& y_new, mat_type& temp, mat_type& temp2) {
   using KAT = KokkosKernels::ArithTraits<scalar_type>;
 
   // This needs to go away and be pulled out of temp instead...
   auto rhs    = Kokkos::subview(temp, Kokkos::ALL(), 0);
   auto update = Kokkos::subview(temp, Kokkos::ALL(), 1);
-  // vec_type rhs("rhs", ode.neqs), update("update", ode.neqs);
-  (void)max_step;
 
   int order = 1, num_equal_steps = 0;
   constexpr scalar_type min_factor = 0.2;
@@ -171,6 +169,11 @@ KOKKOS_FUNCTION void BDFSolve(const ode_type& ode, const scalar_type t_start, co
     KokkosODE::Impl::initial_step_size(ode, order, t_start, atol, rtol, y0, rhs, temp, dt);
   }
 
+  // Check if we need set the maximum step
+  if (max_step == KAT::zero()) {
+    max_step = t_end - t_start;
+  }
+
   // Initialize D(:, 0) = y0 and D(:, 1) = dt*rhs
   auto D = Kokkos::subview(temp, Kokkos::ALL(), Kokkos::pair<int, int>(2, 10));
   for (int eqIdx = 0; eqIdx < ode.neqs; ++eqIdx) {
@@ -182,13 +185,12 @@ KOKKOS_FUNCTION void BDFSolve(const ode_type& ode, const scalar_type t_start, co
   // Now we loop over the time interval [t_start, t_end]
   // and solve our ODE.
   while (t < t_end) {
-    KokkosODE::Impl::BDFStep(ode, t, dt, t_end, order, num_equal_steps, max_newton_iters, atol, rtol, min_factor, y0,
-                             y_new, rhs, update, temp, temp2);
+    KokkosODE::Impl::BDFStep(ode, t, dt, t_end, max_step, order, num_equal_steps, max_newton_iters, atol, rtol,
+                             min_factor, y0, y_new, rhs, update, temp, temp2);
 
     for (int eqIdx = 0; eqIdx < ode.neqs; ++eqIdx) {
       y0(eqIdx) = y_new(eqIdx);
     }
-    // printf("t=%f, dt=%f, y={%f, %f, %f}\n", t, dt, y0(0), y0(1), y0(2));
   }
 }  // BDFSolve
 


### PR DESCRIPTION
Previously `max_step` was just set to the maximum value for its type. Now it's set to `t_end - t_start` by default and the user can set it to something else if they wish.

Assisted-by: Claude:fable-5